### PR TITLE
Convert Uri media source to StorageFile if possible

### DIFF
--- a/Screenbox/Factories/MediaViewModelFactory.cs
+++ b/Screenbox/Factories/MediaViewModelFactory.cs
@@ -35,6 +35,23 @@ namespace Screenbox.Factories
             return new MediaViewModel(_filesService, _mediaService, _albumFactory, _artistFactory, uri);
         }
 
+        public MediaViewModel GetSingleton(string localPath)
+        {
+            if (!_references.TryGetValue(localPath, out WeakReference<MediaViewModel> reference) ||
+                !reference.TryGetTarget(out MediaViewModel instance))
+            {
+                Uri uri = new(localPath);
+                instance = new MediaViewModel(_filesService, _mediaService, _albumFactory, _artistFactory, uri);
+                if (!string.IsNullOrEmpty(localPath))
+                {
+                    _references[localPath] = new WeakReference<MediaViewModel>(instance);
+                    CleanUpStaleReferences();
+                }
+            }
+
+            return instance;
+        }
+
         public MediaViewModel GetSingleton(StorageFile file)
         {
             string path = file.Path;

--- a/Screenbox/ViewModels/MediaViewModel.cs
+++ b/Screenbox/ViewModels/MediaViewModel.cs
@@ -20,9 +20,7 @@ namespace Screenbox.ViewModels
     {
         public string Location { get; }
 
-        public object Source { get; }
-
-        public string Glyph { get; }
+        public object Source { get; private set; }
 
         public StorageItemThumbnail? ThumbnailSource { get; set; }
 
@@ -53,6 +51,7 @@ namespace Screenbox.ViewModels
         [ObservableProperty] private MediaPlaybackType _mediaType;
         [ObservableProperty] private string? _caption;
         [ObservableProperty] private uint _year;
+        [ObservableProperty] private string _glyph;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ShouldDisplayTrackNumber))]
@@ -78,9 +77,9 @@ namespace Screenbox.ViewModels
             _artists = source._artists;
             _album = source._album;
             _caption = source._caption;
+            _glyph = source._glyph;
             Location = source.Location;
             Source = source.Source;
-            Glyph = source.Glyph;
         }
 
         public MediaViewModel(IFilesService filesService, IMediaService mediaService,
@@ -96,8 +95,8 @@ namespace Screenbox.ViewModels
             _loadThumbnailTask = Task.CompletedTask;
             _mediaType = GetMediaTypeForFile(file);
             _artists = Array.Empty<ArtistViewModel>();
+            _glyph = StorageItemGlyphConverter.Convert(file);
             Location = file.Path;
-            Glyph = StorageItemGlyphConverter.Convert(file);
         }
 
         public MediaViewModel(IFilesService filesService, IMediaService mediaService,
@@ -113,8 +112,8 @@ namespace Screenbox.ViewModels
             _loadTask = Task.CompletedTask;
             _loadThumbnailTask = Task.CompletedTask;
             _artists = Array.Empty<ArtistViewModel>();
-            Location = uri.ToString();
-            Glyph = "\ue774"; // Globe icon
+            _glyph = "\ue774"; // Globe icon
+            Location = uri.OriginalString;
         }
 
         public MediaViewModel Clone()
@@ -156,6 +155,12 @@ namespace Screenbox.ViewModels
 
         private async Task LoadDetailsInternalAsync()
         {
+            if (BasicProperties != null) return;
+            if (Source is Uri)
+            {
+                await TryConvertSourceToFileAsync();
+            }
+
             if (Source is not StorageFile { IsAvailable: true } file) return;
             string[] additionalPropertyKeys =
             {
@@ -227,13 +232,37 @@ namespace Screenbox.ViewModels
 
         private async Task LoadThumbnailInternalAsync()
         {
-            if (Thumbnail == null && Source is StorageFile file)
+            if (Thumbnail == null)
             {
+                if (Source is Uri)
+                {
+                    await TryConvertSourceToFileAsync();
+                }
+
+                if (Source is not StorageFile { IsAvailable: true } file) return;
                 StorageItemThumbnail? source = ThumbnailSource = await _filesService.GetThumbnailAsync(file);
                 if (source == null) return;
                 BitmapImage image = new();
                 await image.SetSourceAsync(ThumbnailSource);
                 Thumbnail = image;
+            }
+        }
+
+        private async Task TryConvertSourceToFileAsync()
+        {
+            if (Source is Uri { IsLoopback: true } uri)
+            {
+                try
+                {
+                    StorageFile file = await StorageFile.GetFileFromPathAsync(uri.OriginalString);
+                    Source = file;
+                    Glyph = StorageItemGlyphConverter.Convert(file);
+                    MediaType = GetMediaTypeForFile(file);
+                }
+                catch (Exception)
+                {
+                    // pass
+                }
             }
         }
 


### PR DESCRIPTION
Convert MediaViewModel's Uri source to a StorageFile when trying to get media details.