### PR TITLE
fix: Handle library access gracefully

### DIFF
--- a/Screenbox.Core/Common/ResourceHelper.cs
+++ b/Screenbox.Core/Common/ResourceHelper.cs
@@ -34,6 +34,11 @@ namespace Screenbox.Core
         public const string Disable = "Disable";
         public const string FailedToLoadSubtitleNotificationTitle = "FailedToLoadSubtitleNotificationTitle";
         public const string VolumeChangeStatusMessage = "VolumeChangeStatusMessage";
+        public const string AccessDeniedMusicLibraryTitle = "AccessDeniedMusicLibraryTitle";
+        public const string AccessDeniedVideosLibraryTitle = "AccessDeniedVideosLibraryTitle";
+        public const string AccessDeniedPicturesLibraryTitle = "AccessDeniedPicturesLibraryTitle";
+        public const string OpenPrivacySettingsButtonText = "OpenPrivacySettingsButtonText";
+        public const string AccessDeniedMessage = "AccessDeniedMessage";
 
         public static string GetString(string resourceName, params object[] parameters)
         {

--- a/Screenbox.Core/Messages/RaiseLibraryAccessDeniedNotificationMessage.cs
+++ b/Screenbox.Core/Messages/RaiseLibraryAccessDeniedNotificationMessage.cs
@@ -1,0 +1,14 @@
+﻿using Windows.Storage;
+
+namespace Screenbox.Core.Messages
+{
+    public sealed class RaiseLibraryAccessDeniedNotificationMessage
+    {
+        public KnownLibraryId Library { get; }
+
+        public RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId library)
+        {
+            Library = library;
+        }
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Messages\PlaylistRequestMessage.cs" />
     <Compile Include="Messages\PlayMediaMessage.cs" />
     <Compile Include="Messages\QueuePlaylistMessage.cs" />
+    <Compile Include="Messages\RaiseLibraryAccessDeniedNotificationMessage.cs" />
     <Compile Include="Messages\RaiseFrameSavedNotificationMessage.cs" />
     <Compile Include="Messages\RaiseResumePositionNotificationMessage.cs" />
     <Compile Include="Messages\RefreshFolderMessage.cs" />

--- a/Screenbox.Core/Services/ILibraryService.cs
+++ b/Screenbox.Core/Services/ILibraryService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Windows.Foundation;
+using Windows.Storage;
 using Screenbox.Core.Models;
 using MediaViewModel = Screenbox.Core.ViewModels.MediaViewModel;
 
@@ -13,6 +14,8 @@ namespace Screenbox.Core.Services
     {
         event TypedEventHandler<ILibraryService, object>? MusicLibraryContentChanged;
         event TypedEventHandler<ILibraryService, object>? VideosLibraryContentChanged;
+        StorageLibrary? MusicLibrary { get; }
+        StorageLibrary? VideosLibrary { get; }
         Task<MusicLibraryFetchResult> FetchMusicAsync(bool useCache = true);
         Task<IReadOnlyList<MediaViewModel>> FetchVideosAsync(bool useCache = true);
         MusicLibraryFetchResult GetMusicCache();

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -20,6 +20,9 @@ namespace Screenbox.Core.Services
         public event TypedEventHandler<ILibraryService, object>? MusicLibraryContentChanged; 
         public event TypedEventHandler<ILibraryService, object>? VideosLibraryContentChanged;
 
+        public StorageLibrary? MusicLibrary { get; private set; }
+        public StorageLibrary? VideosLibrary { get; private set; }
+
         private readonly IFilesService _filesService;
         private readonly MediaViewModelFactory _mediaFactory;
         private readonly AlbumViewModelFactory _albumFactory;
@@ -34,8 +37,6 @@ namespace Screenbox.Core.Services
         private List<AlbumViewModel> _albums;
         private List<ArtistViewModel> _artists;
         private List<MediaViewModel> _videos;
-        private StorageLibrary? _musicLibrary;
-        private StorageLibrary? _videosLibrary;
         private StorageFileQueryResult? _musicLibraryQueryResult;
         private StorageFileQueryResult? _videosLibraryQueryResult;
         private bool _invalidateMusicCache;
@@ -167,24 +168,24 @@ namespace Screenbox.Core.Services
 
         private async Task<StorageLibrary> InitializeMusicLibraryAsync()
         {
-            if (_musicLibrary == null)
+            if (MusicLibrary == null)
             {
-                _musicLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Music);
-                _musicLibrary.DefinitionChanged += OnMusicLibraryContentChanged;
+                MusicLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Music);
+                MusicLibrary.DefinitionChanged += OnMusicLibraryContentChanged;
             }
 
-            return _musicLibrary;
+            return MusicLibrary;
         }
 
         private async Task<StorageLibrary> InitializeVideosLibraryAsync()
         {
-            if (_videosLibrary == null)
+            if (VideosLibrary == null)
             {
-                _videosLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Videos);
-                _videosLibrary.DefinitionChanged += OnVideosLibraryContentChanged;
+                VideosLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Videos);
+                VideosLibrary.DefinitionChanged += OnVideosLibraryContentChanged;
             }
 
-            return _videosLibrary;
+            return VideosLibrary;
         }
 
         private StorageFileQueryResult GetMusicLibraryQueryResult()

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -124,6 +124,7 @@ namespace Screenbox.Core.Services
             _songs = songs;
             _artists = _artistFactory.GetAllArtists();
             _albums = _albumFactory.GetAllAlbums();
+            MusicLibraryContentChanged?.Invoke(this, EventArgs.Empty);
             return new MusicLibraryFetchResult(songs.AsReadOnly(), _albums.AsReadOnly(), _artists.AsReadOnly(),
                 _albumFactory.UnknownAlbum, _artistFactory.UnknownArtist);
         }
@@ -140,6 +141,7 @@ namespace Screenbox.Core.Services
             List<MediaViewModel> videos = await FetchMediaFromStorage(queryResult);
             _invalidateVideosCache = false;
             _videos = videos;
+            VideosLibraryContentChanged?.Invoke(this, EventArgs.Empty);
             return videos.AsReadOnly();
         }
 

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Windows.System;
 using CommunityToolkit.Mvvm.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -34,9 +33,10 @@ namespace Screenbox.Core.ViewModels
             _refreshTimer.Stop();
         }
 
-        public async Task FetchAlbumsAsync()
+        public void FetchAlbums()
         {
-            MusicLibraryFetchResult musicLibrary = await _libraryService.FetchMusicAsync();
+            // No need to run fetch async. Music page should already called the method.
+            MusicLibraryFetchResult musicLibrary = _libraryService.GetMusicCache();
 
             GroupedAlbums.Clear();
             PopulateGroups();
@@ -59,7 +59,7 @@ namespace Screenbox.Core.ViewModels
 
         private void OnMusicLibraryContentChanged(ILibraryService sender, object args)
         {
-            _refreshTimer.Debounce(() => _ = FetchAlbumsAsync(), TimeSpan.FromSeconds(2));
+            _refreshTimer.Debounce(FetchAlbums, TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/Screenbox.Core/ViewModels/AllVideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AllVideosPageViewModel.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using Windows.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -23,11 +25,18 @@ namespace Screenbox.Core.ViewModels
 
         public async Task FetchVideosAsync()
         {
-            IReadOnlyList<MediaViewModel> videos = await _libraryService.FetchVideosAsync();
-            Videos.Clear();
-            foreach (MediaViewModel video in videos)
+            try
             {
-                Videos.Add(video);
+                IReadOnlyList<MediaViewModel> videos = await _libraryService.FetchVideosAsync();
+                Videos.Clear();
+                foreach (MediaViewModel video in videos)
+                {
+                    Videos.Add(video);
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Videos));
             }
         }
 

--- a/Screenbox.Core/ViewModels/ArtistsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistsPageViewModel.cs
@@ -34,9 +34,10 @@ namespace Screenbox.Core.ViewModels
             _refreshTimer.Stop();
         }
 
-        public async Task FetchArtistsAsync()
+        public void FetchArtists()
         {
-            MusicLibraryFetchResult musicLibrary = await _libraryService.FetchMusicAsync();
+            // No need to run fetch async. Music page should already called the method.
+            MusicLibraryFetchResult musicLibrary = _libraryService.GetMusicCache();
 
             GroupedArtists.Clear();
             PopulateGroups();
@@ -59,7 +60,7 @@ namespace Screenbox.Core.ViewModels
 
         private void OnMusicLibraryContentChanged(ILibraryService sender, object args)
         {
-            _refreshTimer.Debounce(() => _ = FetchArtistsAsync(), TimeSpan.FromSeconds(2));
+            _refreshTimer.Debounce(FetchArtists, TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -62,9 +62,16 @@ namespace Screenbox.Core.ViewModels
                 Recent.Clear();
             }
 
-            // Pre-fetch libraries
-            await _libraryService.FetchMusicAsync(true);
-            await _libraryService.FetchVideosAsync(true);
+            try
+            {
+                // Pre-fetch libraries
+                await _libraryService.FetchMusicAsync(true);
+                await _libraryService.FetchVideosAsync(true);
+            }
+            catch (Exception)
+            {
+                // pass
+            }
         }
 
         public void OpenUrl(Uri url)

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -65,8 +65,7 @@ namespace Screenbox.Core.ViewModels
             try
             {
                 // Pre-fetch libraries
-                await _libraryService.FetchMusicAsync(true);
-                await _libraryService.FetchVideosAsync(true);
+                await Task.WhenAll(_libraryService.FetchMusicAsync(true), _libraryService.FetchVideosAsync(true));
             }
             catch (Exception)
             {

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -27,11 +27,12 @@ namespace Screenbox.Core.ViewModels
 
         private bool HasSongs => _songs.Count > 0;
 
+        private bool LibraryLoaded => _libraryService.MusicLibrary != null;
+
         private readonly ILibraryService _libraryService;
         private readonly DispatcherQueue _dispatcherQueue;
         private readonly DispatcherQueueTimer _timer;
         private readonly List<MediaViewModel> _songs;
-        private StorageLibrary? _library;
 
         public MusicPageViewModel(ILibraryService libraryService)
         {
@@ -50,6 +51,7 @@ namespace Screenbox.Core.ViewModels
                 MusicLibraryFetchResult music = await _libraryService.FetchMusicAsync();
                 _songs.Clear();
                 _songs.AddRange(music.Songs);
+                AddFolderCommand.NotifyCanExecuteChanged();
             }
             catch (UnauthorizedAccessException)
             {
@@ -72,11 +74,10 @@ namespace Screenbox.Core.ViewModels
             Messenger.Send(new PlayMediaMessage(shuffledList[0], true));
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(LibraryLoaded))]
         private async Task AddFolder()
         {
-            _library ??= await StorageLibrary.GetLibraryAsync(KnownLibraryId.Music);
-            await _library?.RequestAddFolderAsync();
+            await _libraryService.MusicLibrary?.RequestAddFolderAsync();
         }
 
         public static string GetFirstLetterGroup(string name)

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -45,9 +45,16 @@ namespace Screenbox.Core.ViewModels
         {
             _timer.Debounce(() => IsLoading = true, TimeSpan.FromMilliseconds(200));
 
-            MusicLibraryFetchResult music = await _libraryService.FetchMusicAsync();
-            _songs.Clear();
-            _songs.AddRange(music.Songs);
+            try
+            {
+                MusicLibraryFetchResult music = await _libraryService.FetchMusicAsync();
+                _songs.Clear();
+                _songs.AddRange(music.Songs);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Music));
+            }
 
             ShuffleAndPlayCommand.NotifyCanExecuteChanged();
             _timer.Stop();

--- a/Screenbox.Core/ViewModels/NotificationViewModel.cs
+++ b/Screenbox.Core/ViewModels/NotificationViewModel.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -18,6 +19,7 @@ namespace Screenbox.Core.ViewModels
     public sealed partial class NotificationViewModel : ObservableRecipient,
         IRecipient<RaiseFrameSavedNotificationMessage>,
         IRecipient<RaiseResumePositionNotificationMessage>,
+        IRecipient<RaiseLibraryAccessDeniedNotificationMessage>,
         IRecipient<CloseNotificationMessage>,
         IRecipient<ErrorMessage>
     {
@@ -115,6 +117,53 @@ namespace Screenbox.Core.ViewModels
                 });
 
                 ActionButton = new Button
+                {
+                    Content = ButtonContent,
+                    Command = ActionCommand
+                };
+
+                IsOpen = true;
+                _timer.Debounce(() => IsOpen = false, TimeSpan.FromSeconds(15));
+            });
+        }
+
+        public void Receive(RaiseLibraryAccessDeniedNotificationMessage message)
+        {
+            string title;
+            Uri link;
+            switch (message.Library)
+            {
+                case KnownLibraryId.Music:
+                    title = "Can't access music library";
+                    link = new Uri("ms-settings:privacy-musiclibrary");
+                    break;
+                case KnownLibraryId.Pictures:
+                    title = "Can't access pictures library";
+                    link = new Uri("ms-settings:privacy-pictures");
+                    break;
+                case KnownLibraryId.Videos:
+                    title = "Can't access videos library";
+                    link = new Uri("ms-settings:privacy-videos");
+                    break;
+                case KnownLibraryId.Documents:
+                default:
+                    return;
+            }
+
+            _dispatcherQueue.TryEnqueue(() =>
+            {
+                Reset();
+                Title = title;
+                Severity = NotificationLevel.Error;
+                ButtonContent = "Open privacy settings";
+                Message = "Access denied. Please verify your privacy settings to ensure Screenbox has sufficient permissions.";
+                ActionCommand = new RelayCommand(() =>
+                {
+                    IsOpen = false;
+                    Launcher.LaunchUriAsync(link);
+                });
+
+                ActionButton = new HyperlinkButton
                 {
                     Content = ButtonContent,
                     Command = ActionCommand

--- a/Screenbox.Core/ViewModels/NotificationViewModel.cs
+++ b/Screenbox.Core/ViewModels/NotificationViewModel.cs
@@ -134,15 +134,15 @@ namespace Screenbox.Core.ViewModels
             switch (message.Library)
             {
                 case KnownLibraryId.Music:
-                    title = "Can't access music library";
+                    title = ResourceHelper.GetString(ResourceHelper.AccessDeniedMusicLibraryTitle);
                     link = new Uri("ms-settings:privacy-musiclibrary");
                     break;
                 case KnownLibraryId.Pictures:
-                    title = "Can't access pictures library";
+                    title = ResourceHelper.GetString(ResourceHelper.AccessDeniedPicturesLibraryTitle);
                     link = new Uri("ms-settings:privacy-pictures");
                     break;
                 case KnownLibraryId.Videos:
-                    title = "Can't access videos library";
+                    title = ResourceHelper.GetString(ResourceHelper.AccessDeniedVideosLibraryTitle);
                     link = new Uri("ms-settings:privacy-videos");
                     break;
                 case KnownLibraryId.Documents:
@@ -155,8 +155,8 @@ namespace Screenbox.Core.ViewModels
                 Reset();
                 Title = title;
                 Severity = NotificationLevel.Error;
-                ButtonContent = "Open privacy settings";
-                Message = "Access denied. Please verify your privacy settings to ensure Screenbox has sufficient permissions.";
+                ButtonContent = ResourceHelper.GetString(ResourceHelper.OpenPrivacySettingsButtonText);
+                Message = ResourceHelper.GetString(ResourceHelper.AccessDeniedMessage);
                 ActionCommand = new RelayCommand(() =>
                 {
                     IsOpen = false;

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Windows.System;
 using CommunityToolkit.Mvvm.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -40,9 +39,10 @@ namespace Screenbox.Core.ViewModels
             _refreshTimer.Stop();
         }
 
-        public async Task FetchSongsAsync()
+        public void FetchSongs()
         {
-            MusicLibraryFetchResult musicLibrary = await _libraryService.FetchMusicAsync();
+            // No need to run fetch async. Music page should already called the method.
+            MusicLibraryFetchResult musicLibrary = _libraryService.GetMusicCache();
             _songs = musicLibrary.Songs.OrderBy(m => m.Name, StringComparer.CurrentCulture).ToList();
 
             // Populate song groups with fetched result
@@ -64,7 +64,7 @@ namespace Screenbox.Core.ViewModels
 
         private void OnMusicLibraryContentChanged(ILibraryService sender, object args)
         {
-            _refreshTimer.Debounce(() => _ = FetchSongsAsync(), TimeSpan.FromSeconds(2));
+            _refreshTimer.Debounce(FetchSongs, TimeSpan.FromSeconds(2));
         }
 
         [RelayCommand]

--- a/Screenbox.Core/ViewModels/VideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/VideosPageViewModel.cs
@@ -9,6 +9,8 @@ using Windows.Storage;
 using Windows.UI.Xaml.Navigation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Screenbox.Core.Messages;
 using Screenbox.Core.Services;
 
 namespace Screenbox.Core.ViewModels
@@ -31,7 +33,15 @@ namespace Screenbox.Core.ViewModels
 
         public async Task FetchVideosAsync()
         {
-            await _libraryService.FetchVideosAsync();
+            try
+            {
+                await _libraryService.FetchVideosAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Videos));
+            }
+
             AddFolderCommand.NotifyCanExecuteChanged();
         }
 

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -23,10 +23,10 @@ namespace Screenbox.Pages
             Common = App.Services.GetRequiredService<CommonViewModel>();
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            await ViewModel.FetchAlbumsAsync();
+            ViewModel.FetchAlbums();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/ArtistsPage.xaml.cs
+++ b/Screenbox/Pages/ArtistsPage.xaml.cs
@@ -23,10 +23,10 @@ namespace Screenbox.Pages
             Common = App.Services.GetRequiredService<CommonViewModel>();
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            await ViewModel.FetchArtistsAsync();
+            ViewModel.FetchArtists();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Navigation;
 using Microsoft.Extensions.DependencyInjection;
 using Screenbox.Core.ViewModels;
 
@@ -23,6 +24,12 @@ namespace Screenbox.Pages
             this.InitializeComponent();
             DataContext = App.Services.GetRequiredService<SettingsPageViewModel>();
             Common = App.Services.GetRequiredService<CommonViewModel>();
+        }
+
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            await ViewModel.LoadLibraryLocations();
         }
 
         private void ContentRoot_OnSizeChanged(object sender, SizeChangedEventArgs e)

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -23,10 +23,10 @@ namespace Screenbox.Pages
             Common = App.Services.GetRequiredService<CommonViewModel>();
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            await ViewModel.FetchSongsAsync();
+            ViewModel.FetchSongs();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/VideosPage.xaml.cs
+++ b/Screenbox/Pages/VideosPage.xaml.cs
@@ -47,7 +47,7 @@ namespace Screenbox.Pages
             };
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
             if (Common.NavigationStates.TryGetValue(typeof(VideosPage), out string navigationState))
@@ -59,6 +59,8 @@ namespace Screenbox.Pages
             {
                 LibraryNavView.SelectedItem = LibraryNavView.MenuItems[0];
             }
+
+            await ViewModel.FetchVideosAsync();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -1463,6 +1463,71 @@ namespace Screenbox.Strings{
             return string.Format(_resourceLoader.GetString("SearchResultVideoHeader"), query);
         }
         #endregion
+
+        #region AccessDeniedMessage
+        /// <summary>
+        ///   Looks up a localized string similar to: Access denied. Please verify your privacy settings to ensure Screenbox has sufficient permissions.
+        /// </summary>
+        public static string AccessDeniedMessage
+        {
+            get
+            {
+                return _resourceLoader.GetString("AccessDeniedMessage");
+            }
+        }
+        #endregion
+
+        #region AccessDeniedMusicLibraryTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Can't access music library
+        /// </summary>
+        public static string AccessDeniedMusicLibraryTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("AccessDeniedMusicLibraryTitle");
+            }
+        }
+        #endregion
+
+        #region AccessDeniedPicturesLibraryTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Can't access pictures library
+        /// </summary>
+        public static string AccessDeniedPicturesLibraryTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("AccessDeniedPicturesLibraryTitle");
+            }
+        }
+        #endregion
+
+        #region AccessDeniedVideosLibraryTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Can't access videos library
+        /// </summary>
+        public static string AccessDeniedVideosLibraryTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("AccessDeniedVideosLibraryTitle");
+            }
+        }
+        #endregion
+
+        #region OpenPrivacySettingsButtonText
+        /// <summary>
+        ///   Looks up a localized string similar to: Open privacy settings
+        /// </summary>
+        public static string OpenPrivacySettingsButtonText
+        {
+            get
+            {
+                return _resourceLoader.GetString("OpenPrivacySettingsButtonText");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -1584,6 +1649,11 @@ namespace Screenbox.Strings{
             SearchResultAlbumHeader,
             SearchResultSongHeader,
             SearchResultVideoHeader,
+            AccessDeniedMessage,
+            AccessDeniedMusicLibraryTitle,
+            AccessDeniedPicturesLibraryTitle,
+            AccessDeniedVideosLibraryTitle,
+            OpenPrivacySettingsButtonText,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -510,4 +510,19 @@
     <value>No album</value>
     <comment>#Format[Plural Int]</comment>
   </data>
+  <data name="AccessDeniedMessage" xml:space="preserve">
+    <value>Access denied. Please verify your privacy settings to ensure Screenbox has sufficient permissions.</value>
+  </data>
+  <data name="AccessDeniedMusicLibraryTitle" xml:space="preserve">
+    <value>Can't access music library</value>
+  </data>
+  <data name="AccessDeniedPicturesLibraryTitle" xml:space="preserve">
+    <value>Can't access pictures library</value>
+  </data>
+  <data name="AccessDeniedVideosLibraryTitle" xml:space="preserve">
+    <value>Can't access videos library</value>
+  </data>
+  <data name="OpenPrivacySettingsButtonText" xml:space="preserve">
+    <value>Open privacy settings</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #41 

View models were interacting with `StorageLibrary` directly without exception handling. This PR route all `StorageLibrary` access through `ILibraryService` with proper exception handling.