### PR TITLE
fix: Micro plays/pauses when double tapping the video

### DIFF
--- a/Screenbox.Core/Messages/ShowPlayPauseBadgeMessage.cs
+++ b/Screenbox.Core/Messages/ShowPlayPauseBadgeMessage.cs
@@ -2,5 +2,11 @@
 {
     public sealed class ShowPlayPauseBadgeMessage
     {
+        public bool IsPlaying { get; }
+
+        public ShowPlayPauseBadgeMessage(bool isPlaying)
+        {
+            IsPlaying = isPlaying;
+        }
     }
 }

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -35,6 +35,7 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private string? _statusMessage;
         [ObservableProperty] private bool _videoViewFocused;
         [ObservableProperty] private bool _isPlaying;
+        [ObservableProperty] private bool _isPlayingBadge;
         [ObservableProperty] private bool _isOpening;
         [ObservableProperty] private bool _showPlayPauseBadge;
         [ObservableProperty] private WindowViewMode _viewMode;
@@ -136,6 +137,7 @@ namespace Screenbox.Core.ViewModels
 
         public void Receive(ShowPlayPauseBadgeMessage message)
         {
+            IsPlayingBadge = message.IsPlaying;
             BlinkPlayPauseBadge();
         }
 

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -394,7 +394,7 @@
                 FontFamily="{StaticResource ScreenboxCustomIconsFontFamily}"
                 FontSize="26"
                 Foreground="White"
-                Glyph="{x:Bind ViewModel.IsPlaying, Converter={StaticResource FilledPlayPauseGlyphConverter}, Mode=OneWay}" />
+                Glyph="{x:Bind ViewModel.IsPlayingBadge, Converter={StaticResource FilledPlayPauseGlyphConverter}, Mode=OneWay}" />
         </Border>
 
         <muxc:ProgressRing


### PR DESCRIPTION
Add debounce on the play pause toggle when tapping on the video surface to prevent micro plays/pauses.