### PR TITLE
feat: Improve Gamepad and keyboard experience

### DIFF
--- a/Screenbox.Core/Messages/MediaPlayerRequestMessage.cs
+++ b/Screenbox.Core/Messages/MediaPlayerRequestMessage.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+using CommunityToolkit.Mvvm.Messaging.Messages;
+using Screenbox.Core.Playback;
+
+namespace Screenbox.Core.Messages
+{
+    public sealed class MediaPlayerRequestMessage : RequestMessage<IMediaPlayer?>
+    {
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Messages\CloseNotificationMessage.cs" />
     <Compile Include="Messages\ErrorMessage.cs" />
     <Compile Include="Messages\MediaPlayerChangedMessage.cs" />
+    <Compile Include="Messages\MediaPlayerRequestMessage.cs" />
     <Compile Include="Messages\MessageHelpers.cs" />
     <Compile Include="Messages\NavigationViewDisplayModeRequestMessage.cs" />
     <Compile Include="Messages\OverrideControlsHideMessage.cs" />

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -38,6 +38,7 @@ namespace Screenbox.Core.ViewModels
             _resourceService = resourceService;
             SubtitleTracks = new ObservableCollection<string>();
             AudioTracks = new ObservableCollection<string>();
+            _mediaPlayer = Messenger.Send(new MediaPlayerRequestMessage()).Response;
 
             IsActive = true;
         }

--- a/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
@@ -21,7 +21,8 @@ using MediaPlayer = LibVLCSharp.Shared.MediaPlayer;
 namespace Screenbox.Core.ViewModels
 {
     public sealed partial class PlayerElementViewModel : ObservableRecipient,
-        IRecipient<ChangeZoomToFitMessage>
+        IRecipient<ChangeZoomToFitMessage>,
+        IRecipient<MediaPlayerRequestMessage>
     {
         public MediaPlayer? VlcPlayer { get; private set; }
 
@@ -59,6 +60,11 @@ namespace Screenbox.Core.ViewModels
         {
             _zoomToFit = message.Value;
             SetCropGeometry(_viewSize);
+        }
+
+        public void Receive(MediaPlayerRequestMessage message)
+        {
+            message.Reply(_mediaPlayer);
         }
 
         public void Initialize(string[] swapChainOptions)

--- a/Screenbox.Core/ViewModels/PlayerInteractionViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerInteractionViewModel.cs
@@ -105,6 +105,39 @@ namespace Screenbox.Core.ViewModels
             Messenger.Send(new UpdateVolumeStatusMessage(volume, false));
         }
 
+        public void ProcessGamepadKeyDown(object sender, KeyRoutedEventArgs args)
+        {
+            args.Handled = true;
+            int volumeChange = 0;
+            switch (args.Key)
+            {
+                case VirtualKey.GamepadRightThumbstickLeft:
+                    Seek(-5000);
+                    break;
+                case VirtualKey.GamepadRightThumbstickRight:
+                    Seek(5000);
+                    break;
+                case VirtualKey.GamepadRightThumbstickUp:
+                    volumeChange = 2;
+                    break;
+                case VirtualKey.GamepadRightThumbstickDown:
+                    volumeChange = -2;
+                    break;
+                case VirtualKey.GamepadX:
+                    TogglePlayPauseWithBadge(false);
+                    break;
+                default:
+                    args.Handled = false;
+                    return;
+            }
+
+            if (volumeChange != 0)
+            {
+                int volume = Messenger.Send(new ChangeVolumeRequestMessage(volumeChange, true));
+                Messenger.Send(new UpdateVolumeStatusMessage(volume, false));
+            }
+        }
+
         public void ProcessKeyboardAccelerators(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
             if (_mediaPlayer == null) return;

--- a/Screenbox/Controls/PlayerElement.xaml
+++ b/Screenbox/Controls/PlayerElement.xaml
@@ -17,6 +17,7 @@
         CornerRadius="{x:Bind CornerRadius, Mode=OneWay}">
         <Button
             x:Name="VideoViewButton"
+            Margin="{x:Bind ButtonMargin, Mode=OneWay}"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             AllowDrop="True"

--- a/Screenbox/Controls/PlayerElement.xaml
+++ b/Screenbox/Controls/PlayerElement.xaml
@@ -25,6 +25,7 @@
             DragOver="VideoViewButton_OnDragOver"
             Drop="{x:Bind InteractionViewModel.OnDrop}"
             IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
+            KeyDown="{x:Bind InteractionViewModel.ProcessGamepadKeyDown}"
             ManipulationCompleted="{x:Bind InteractionViewModel.VideoView_ManipulationCompleted}"
             ManipulationDelta="{x:Bind InteractionViewModel.VideoView_ManipulationDelta}"
             ManipulationMode="TranslateX,TranslateY"

--- a/Screenbox/Controls/PlayerElement.xaml.cs
+++ b/Screenbox/Controls/PlayerElement.xaml.cs
@@ -14,6 +14,18 @@ namespace Screenbox.Controls
 {
     public sealed partial class PlayerElement : UserControl
     {
+        public static readonly DependencyProperty ButtonMarginProperty = DependencyProperty.Register(
+            nameof(ButtonMargin),
+            typeof(Thickness),
+            typeof(PlayerElement),
+            new PropertyMetadata(default(Thickness)));
+
+        public Thickness ButtonMargin
+        {
+            get => (Thickness)GetValue(ButtonMarginProperty);
+            set => SetValue(ButtonMarginProperty, value);
+        }
+
         public event RoutedEventHandler? Click;
 
         internal PlayerElementViewModel ViewModel => (PlayerElementViewModel)DataContext;

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -101,9 +101,10 @@ namespace Screenbox.Controls
 
         private void GoToCurrentItem()
         {
-            if (ViewModel.Playlist.CurrentItem != null && PlaylistListView.FindChild<ListViewBase>() is { } listView)
+            if (ViewModel.Playlist.CurrentItem != null)
             {
-                listView.SmoothScrollIntoViewWithItemAsync(ViewModel.Playlist.CurrentItem, ScrollItemPlacement.Center);
+                PlaylistListView.SmoothScrollIntoViewWithItemAsync(ViewModel.Playlist.CurrentItem, ScrollItemPlacement.Center);
+                (PlaylistListView.ContainerFromItem(ViewModel.Playlist.CurrentItem) as Control)?.Focus(FocusState.Programmatic);
             }
         }
 

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -2,7 +2,7 @@
     x:Class="Screenbox.Pages.AlbumDetailsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Screenbox.Controls"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls1="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
@@ -13,7 +13,6 @@
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     Loaded="AlbumDetailsPage_OnLoaded"
     mc:Ignorable="d">
     <Page.Resources>
@@ -138,6 +137,9 @@
                             <FontIcon Glyph="&#xe768;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=Play}" />
                         </StackPanel>
+                        <interactivity:Interaction.Behaviors>
+                            <behaviors:AutoFocusBehavior />
+                        </interactivity:Interaction.Behaviors>
                     </Button>
 
                     <Button Command="{x:Bind ViewModel.ShuffleAndPlayCommand}">

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -2,14 +2,13 @@
     x:Class="Screenbox.Pages.AlbumsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Screenbox.Pages"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -32,6 +31,10 @@
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <SemanticZoom Margin="0,24,0,0">

--- a/Screenbox/Pages/AllVideosPage.xaml
+++ b/Screenbox/Pages/AllVideosPage.xaml
@@ -2,16 +2,15 @@
     x:Class="Screenbox.Pages.AllVideosPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -41,6 +40,10 @@
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <GridView

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.ArtistDetailsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
@@ -193,6 +194,9 @@
                             <FontIcon Glyph="&#xe768;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=Play}" />
                         </StackPanel>
+                        <interactivity:Interaction.Behaviors>
+                            <behaviors:AutoFocusBehavior />
+                        </interactivity:Interaction.Behaviors>
                     </Button>
 
                     <Button Command="{x:Bind ViewModel.ShuffleAndPlayCommand}">

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -2,14 +2,13 @@
     x:Class="Screenbox.Pages.ArtistsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Screenbox.Pages"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -32,6 +31,10 @@
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <SemanticZoom Margin="0,24,0,0">

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.FolderListViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
@@ -65,6 +66,10 @@
             </Grid>
         </DataTemplate>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <muxc:ProgressBar

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -3,18 +3,15 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
-    xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     xmlns:viewModels1="using:Screenbox.Core.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
@@ -67,10 +64,6 @@
         </DataTemplate>
     </Page.Resources>
 
-    <interactivity:Interaction.Behaviors>
-        <behaviors:AutoFocusBehavior />
-    </interactivity:Interaction.Behaviors>
-
     <Grid>
         <muxc:ProgressBar
             x:Name="LoadingProgressBar"
@@ -91,6 +84,7 @@
             ItemsSource="{x:Bind ViewModel.Items}"
             SelectionMode="None">
             <interactivity:Interaction.Behaviors>
+                <behaviors:AutoFocusBehavior />
                 <interactions:AlternatingListViewBehavior
                     AlternateBackground="{ThemeResource AccentListViewItemBackgroundBrush}"
                     AlternateBorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -98,10 +98,6 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <interactivity:Interaction.Behaviors>
-        <behaviors:AutoFocusBehavior />
-    </interactivity:Interaction.Behaviors>
-
     <Grid>
         <muxc:ProgressBar
             x:Name="LoadingProgressBar"
@@ -122,6 +118,7 @@
                 <Border Height="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
             </GridView.Footer>
             <interactivity:Interaction.Behaviors>
+                <behaviors:AutoFocusBehavior />
                 <interactions:ListViewContextTriggerBehavior ContextRequested="FolderView_OnItemContextRequested" Flyout="{x:Bind ItemFlyout}" />
                 <interactions:ThumbnailGridViewBehavior />
             </interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.FolderViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:core="using:Microsoft.Xaml.Interactions.Core"
@@ -96,6 +97,10 @@
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <muxc:ProgressBar

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.HomePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls1="using:Screenbox.Controls"
     xmlns:core="using:Screenbox.Core"
@@ -125,6 +126,14 @@
         </ResourceDictionary>
     </Page.Resources>
 
+    <interactivity:Interaction.Behaviors>
+        <behaviors:FocusBehavior>
+            <behaviors:FocusTarget Control="{x:Bind RecentFilesGridView}" />
+            <behaviors:FocusTarget Control="{x:Bind OpenButton}" />
+            <behaviors:FocusTarget Control="{x:Bind HeaderOpenButton}" />
+        </behaviors:FocusBehavior>
+    </interactivity:Interaction.Behaviors>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -200,6 +209,7 @@
                 TextWrapping="Wrap" />
 
             <controls:SplitButton
+                x:Name="OpenButton"
                 Grid.Row="2"
                 Grid.Column="1"
                 Margin="0,8,0,0"

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
 using Windows.ApplicationModel.Core;
+using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -88,6 +89,7 @@ namespace Screenbox.Pages
 
         private void MainPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Window.Current.Dispatcher.AcceleratorKeyActivated += CoreDispatcher_AcceleratorKeyActivated;
             SystemNavigationManager.GetForCurrentView().BackRequested += System_BackRequested;
             Window.Current.CoreWindow.PointerPressed += CoreWindow_PointerPressed;
             ViewModel.NavigationViewDisplayMode = (NavigationViewDisplayMode)NavView.DisplayMode;
@@ -151,6 +153,20 @@ namespace Screenbox.Pages
             if (!(pageType is null) && !Type.Equals(preNavPageType, pageType))
             {
                 ContentFrame.Navigate(pageType, null, new SuppressNavigationTransitionInfo());
+            }
+        }
+
+        private void CoreDispatcher_AcceleratorKeyActivated(CoreDispatcher sender, AcceleratorKeyEventArgs args)
+        {
+            if (args is
+                {
+                    EventType: CoreAcceleratorKeyEventType.SystemKeyDown,
+                    VirtualKey: VirtualKey.Left,
+                    KeyStatus.IsMenuKeyDown: true,
+                    Handled: false
+                })
+            {
+                args.Handled = TryGoBack();
             }
         }
 

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -2,13 +2,18 @@
     x:Class="Screenbox.Pages.MusicPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     mc:Ignorable="d">
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <Grid.RowDefinitions>

--- a/Screenbox/Pages/NetworkPage.xaml
+++ b/Screenbox/Pages/NetworkPage.xaml
@@ -9,7 +9,6 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
-    xmlns:viewmodels="using:Screenbox.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <converters:DefaultStringConverter x:Key="DefaultTitleTextConverter" Default="{strings:Resources Key=Network}" />

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -2,8 +2,10 @@
     x:Class="Screenbox.Pages.PlayQueuePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -12,7 +14,6 @@
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
     Loaded="PlayQueuePage_OnLoaded"
     mc:Ignorable="d">
-
     <Page.Resources>
         <MenuFlyout x:Key="AddToPlayQueueFlyout" Placement="BottomEdgeAlignedRight">
             <MenuFlyoutItem Icon="{ui:FontIcon Glyph=&#xe838;}" Text="{strings:Resources Key=AddFiles}" />
@@ -48,6 +49,9 @@
                         Margin="8,0,0,0"
                         Text="{x:Bind strings:Resources.AddFiles}" />
                 </StackPanel>
+                <interactivity:Interaction.Behaviors>
+                    <behaviors:AutoFocusBehavior />
+                </interactivity:Interaction.Behaviors>
             </muxc:SplitButton>
         </Grid>
 

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -255,7 +255,8 @@
             VerticalAlignment="Stretch"
             ButtonMargin="0,52,0,84"
             Click="{x:Bind ViewModel.OnPlayerClick}"
-            ContextFlyout="{x:Bind PlayerControls.PlayerContextMenu, Mode=OneWay}">
+            ContextFlyout="{x:Bind PlayerControls.PlayerContextMenu, Mode=OneWay}"
+            KeyDown="OnGamepadKeyDown">
             <interactivity:Interaction.Behaviors>
                 <core:EventTriggerBehavior EventName="GotFocus">
                     <core:ChangePropertyAction

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -253,6 +253,7 @@
             Grid.Column="0"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
+            ButtonMargin="0,52,0,84"
             Click="{x:Bind ViewModel.OnPlayerClick}"
             ContextFlyout="{x:Bind PlayerControls.PlayerContextMenu, Mode=OneWay}">
             <interactivity:Interaction.Behaviors>
@@ -555,6 +556,7 @@
                         <Setter Target="BackButton.Visibility" Value="Collapsed" />
                         <Setter Target="PlayQueueButton.Margin" Value="20,20,6,20" />
                         <Setter Target="PlayerControls.Padding" Value="20" />
+                        <Setter Target="VideoView.ButtonMargin" Value="0,70,0,104" />
                     </VisualState.Setters>
                     <Storyboard>
                         <RepositionThemeAnimation FromVerticalOffset="-120" TargetName="AlbumArtPanel" />
@@ -578,6 +580,7 @@
                         <Setter Target="AlbumArtPanel.VerticalAlignment" Value="Center" />
                         <Setter Target="AlbumArtPanel.Margin" Value="16,10" />
                         <Setter Target="PlayerControls.Padding" Value="0,4,0,0" />
+                        <Setter Target="VideoView.ButtonMargin" Value="0,0,0,40" />
                         <Setter Target="StatusMessageText.FontSize" Value="16" />
                         <Setter Target="StatusMessage.Margin" Value="8,4" />
                         <Setter Target="PlayerStateBadge.Width" Value="50" />

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -318,5 +318,21 @@ namespace Screenbox.Pages
             // Set in code due to XAML compiler not setting it in Release
             BackgroundAcrylicBrush.TintLuminosityOpacity = theme == ElementTheme.Light ? 0.5 : 0.4;
         }
+
+        private void OnGamepadKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key == VirtualKey.GamepadY && ViewModel.VideoViewFocused)
+            {
+                e.Handled = true;
+                AudioTrackSubtitlePicker control = new();
+                Flyout flyout = new()
+                {
+                    Content = control
+                };
+
+                flyout.Opening += (_, _) => control.ViewModel.OnAudioCaptionFlyoutOpening();
+                flyout.ShowAt(PlayerControls);
+            }
+        }
     }
 }

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -2,8 +2,10 @@
     x:Class="Screenbox.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -84,6 +86,10 @@
             </Grid>
         </DataTemplate>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <Grid.RowDefinitions>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -4,17 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:controls1="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-    xmlns:viewModels="using:Screenbox.ViewModels"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -64,10 +61,6 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <interactivity:Interaction.Behaviors>
-        <behaviors:AutoFocusBehavior />
-    </interactivity:Interaction.Behaviors>
-
     <Grid>
         <SemanticZoom Margin="0,24,0,0">
             <SemanticZoom.ZoomedInView>
@@ -93,6 +86,7 @@
                         </XamlUICommand>
                     </ListView.Resources>
                     <interactivity:Interaction.Behaviors>
+                        <behaviors:AutoFocusBehavior />
                         <interactions:AlternatingListViewBehavior
                             AlternateBackground="{ThemeResource AccentListViewItemBackgroundBrush}"
                             AlternateBorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.SongsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls1="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -62,6 +63,10 @@
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <SemanticZoom Margin="0,24,0,0">

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -2,7 +2,9 @@
     x:Class="Screenbox.Pages.VideosPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:storage="using:Windows.Storage"
@@ -16,6 +18,10 @@
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
+
+    <interactivity:Interaction.Behaviors>
+        <behaviors:AutoFocusBehavior />
+    </interactivity:Interaction.Behaviors>
 
     <Grid>
         <Grid.RowDefinitions>


### PR DESCRIPTION
- Adaptively resize the interactable area in the player page to allow XY navigation.
- Better focus-changing behaviour when navigating with a keyboard
- Handle Window-level back navigation (Alt+Left)
- Bind some gamepad keys to common operations.
  - Right thumbstick up/down for volume change
  - Right thumbstick left/right for seeking
  - X for play/pause toggle
  - Y for audio and caption picker