### PR TITLE
fix: Simplify active display request tracker

### DIFF
--- a/Screenbox.Core/Helpers/DisplayRequestTracker.cs
+++ b/Screenbox.Core/Helpers/DisplayRequestTracker.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Windows.System.Display;
+
+namespace Screenbox.Core.Helpers
+{
+    internal class DisplayRequestTracker
+    {
+        public bool IsActive => _requestCount > 0;
+
+        private readonly DisplayRequest _displayRequest;
+        private int _requestCount;
+
+        public DisplayRequestTracker()
+        {
+            _displayRequest = new DisplayRequest();
+        }
+
+        public void RequestActive()
+        {
+            lock (_displayRequest)
+            {
+                try
+                {
+                    _displayRequest.RequestActive();
+                    _requestCount++;
+                }
+                catch (Exception)
+                {
+                    // pass
+                }
+            }
+        }
+
+        public void RequestRelease()
+        {
+            lock (_displayRequest)
+            {
+                if (_requestCount <= 0) return;
+                try
+                {
+                    _displayRequest.RequestRelease();
+                    _requestCount--;
+                }
+                catch (Exception)
+                {
+                    // pass
+                }
+            }
+        }
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Models\Renderer.cs" />
     <Compile Include="Models\SearchResult.cs" />
     <Compile Include="Playback\AudioTrack.cs" />
+    <Compile Include="Helpers\DisplayRequestTracker.cs" />
     <Compile Include="Playback\IMediaPlayer.cs" />
     <Compile Include="Playback\PlaybackAudioTrackList.cs" />
     <Compile Include="Playback\PlaybackChapterList.cs" />
@@ -277,6 +278,7 @@
   <ItemGroup>
     <None Include="packages.lock.json" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #52 

The display request tracker will now be active no matter what the type of media.