### PR TITLE
fix: streamline library fetch operation

### DIFF
--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -219,12 +219,14 @@ namespace Screenbox.Core.Services
         private void OnVideosLibraryContentChanged(object sender, object args)
         {
             async void FetchAction() => await FetchVideosAsync();
+            // Delay fetch due to query result not yet updated at this time
             _videosRefreshTimer.Debounce(FetchAction, TimeSpan.FromMilliseconds(500));
         }
 
         private void OnMusicLibraryContentChanged(object sender, object args)
         {
             async void FetchAction() => await FetchMusicAsync();
+            // Delay fetch due to query result not yet updated at this time
             _musicRefreshTimer.Debounce(FetchAction, TimeSpan.FromMilliseconds(500));
         }
     }

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.Storage;
 using Windows.System;
 
 namespace Screenbox.Core.ViewModels
@@ -80,7 +81,11 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand(CanExecute = nameof(LibraryLoaded))]
         private async Task AddFolder()
         {
-            await _libraryService.MusicLibrary?.RequestAddFolderAsync();
+            StorageFolder? addedFolder = await _libraryService.MusicLibrary?.RequestAddFolderAsync();
+            if (addedFolder != null)
+            {
+                _timer.Debounce(() => IsLoading = _libraryService.IsLoadingMusic, TimeSpan.FromSeconds(1));
+            }
         }
     }
 }


### PR DESCRIPTION
Improve library query fetch stability without having to get count first
