### PR TITLE
feat: advanced mode for passing VLC commands

### DIFF
--- a/Screenbox.Core/Enums/ResourceName.cs
+++ b/Screenbox.Core/Enums/ResourceName.cs
@@ -30,6 +30,7 @@
         FailedToLoadSubtitleNotificationTitle,
         FailedToSaveFrameNotificationTitle,
         FailedToOpenFilesNotificationTitle,
+        FailedToInitializeNotificationTitle,
         FrameSavedNotificationTitle,
         ResumePositionNotificationTitle,
         FailedToLoadMediaNotificationTitle,

--- a/Screenbox.Core/Playback/PlaybackItem.cs
+++ b/Screenbox.Core/Playback/PlaybackItem.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using LibVLCSharp.Shared;
-using Screenbox.Core.Services;
 using System;
 
 namespace Screenbox.Core.Playback
@@ -26,10 +25,9 @@ namespace Screenbox.Core.Playback
 
         public TimeSpan? Duration => Media.Duration > 0 ? TimeSpan.FromMilliseconds(Media.Duration) : null;
 
-        public PlaybackItem(object source, IMediaService mediaService)
+        public PlaybackItem(object source, Media media)
         {
             OriginalSource = source;
-            Media media = mediaService.CreateMedia(source);
             Media = media;
             AudioTracks = new PlaybackAudioTrackList(media);
             VideoTracks = new PlaybackVideoTrackList(media);

--- a/Screenbox.Core/Services/IMediaService.cs
+++ b/Screenbox.Core/Services/IMediaService.cs
@@ -1,16 +1,16 @@
 ﻿#nullable enable
 
+using LibVLCSharp.Shared;
 using System;
 using Windows.Storage;
-using LibVLCSharp.Shared;
 
 namespace Screenbox.Core.Services;
 
 public interface IMediaService
 {
-    Media CreateMedia(object source);
-    Media CreateMedia(string source);
-    Media CreateMedia(IStorageFile source);
-    Media CreateMedia(Uri source);
+    Media CreateMedia(object source, params string[] options);
+    Media CreateMedia(string source, params string[] options);
+    Media CreateMedia(IStorageFile source, params string[] options);
+    Media CreateMedia(Uri source, params string[] options);
     void DisposeMedia(Media media);
 }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -12,6 +12,8 @@ namespace Screenbox.Core.Services
         int PersistentVolume { get; set; }
         bool ShowRecent { get; set; }
         int MaxVolume { get; set; }
+        string GlobalArguments { get; set; }
+        bool AdvancedMode { get; set; }
         MediaPlaybackAutoRepeatMode PersistentRepeatMode { get; set; }
     }
 }

--- a/Screenbox.Core/Services/MediaService.cs
+++ b/Screenbox.Core/Services/MediaService.cs
@@ -40,7 +40,7 @@ namespace Screenbox.Core.Services
 
             Guard.IsNotNull(_libVlcService.LibVlc, nameof(_libVlcService.LibVlc));
             LibVLC libVlc = _libVlcService.LibVlc;
-            return new Media(libVlc, str);
+            return new Media(libVlc, str, FromType.FromPath, options);
         }
 
         public Media CreateMedia(IStorageFile file, params string[] options)
@@ -48,7 +48,7 @@ namespace Screenbox.Core.Services
             Guard.IsNotNull(_libVlcService.LibVlc, nameof(_libVlcService.LibVlc));
             LibVLC libVlc = _libVlcService.LibVlc;
             string mrl = "winrt://" + StorageApplicationPermissions.FutureAccessList.Add(file, "media");
-            return new Media(libVlc, mrl, FromType.FromLocation);
+            return new Media(libVlc, mrl, FromType.FromLocation, options);
         }
 
         public Media CreateMedia(Uri uri, params string[] options)

--- a/Screenbox.Core/Services/MediaService.cs
+++ b/Screenbox.Core/Services/MediaService.cs
@@ -1,10 +1,10 @@
 ﻿#nullable enable
 
+using CommunityToolkit.Diagnostics;
+using LibVLCSharp.Shared;
 using System;
 using Windows.Storage;
 using Windows.Storage.AccessCache;
-using LibVLCSharp.Shared;
-using CommunityToolkit.Diagnostics;
 
 namespace Screenbox.Core.Services
 {
@@ -20,22 +20,22 @@ namespace Screenbox.Core.Services
             StorageApplicationPermissions.FutureAccessList.Clear();
         }
 
-        public Media CreateMedia(object source)
+        public Media CreateMedia(object source, params string[] options)
         {
             return source switch
             {
-                IStorageFile file => CreateMedia(file),
-                string str => CreateMedia(str),
-                Uri uri => CreateMedia(uri),
+                IStorageFile file => CreateMedia(file, options),
+                string str => CreateMedia(str, options),
+                Uri uri => CreateMedia(uri, options),
                 _ => throw new ArgumentOutOfRangeException(nameof(source))
             };
         }
 
-        public Media CreateMedia(string str)
+        public Media CreateMedia(string str, params string[] options)
         {
             if (Uri.TryCreate(str, UriKind.Absolute, out Uri uri))
             {
-                return CreateMedia(uri);
+                return CreateMedia(uri, options);
             }
 
             Guard.IsNotNull(_libVlcService.LibVlc, nameof(_libVlcService.LibVlc));
@@ -43,7 +43,7 @@ namespace Screenbox.Core.Services
             return new Media(libVlc, str);
         }
 
-        public Media CreateMedia(IStorageFile file)
+        public Media CreateMedia(IStorageFile file, params string[] options)
         {
             Guard.IsNotNull(_libVlcService.LibVlc, nameof(_libVlcService.LibVlc));
             LibVLC libVlc = _libVlcService.LibVlc;
@@ -51,11 +51,11 @@ namespace Screenbox.Core.Services
             return new Media(libVlc, mrl, FromType.FromLocation);
         }
 
-        public Media CreateMedia(Uri uri)
+        public Media CreateMedia(Uri uri, params string[] options)
         {
             Guard.IsNotNull(_libVlcService.LibVlc, nameof(_libVlcService.LibVlc));
             LibVLC libVlc = _libVlcService.LibVlc;
-            return new Media(libVlc, uri);
+            return new Media(libVlc, uri, options);
         }
 
         public void DisposeMedia(Media media)

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -2,6 +2,8 @@
 
 using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
+using System;
+using System.Linq;
 using Windows.Foundation.Collections;
 using Windows.Media;
 using Windows.Storage;
@@ -17,6 +19,8 @@ namespace Screenbox.Core.Services
         private const string PlayerSeekGestureKey = "Player/Gesture/Seek";
         private const string PlayerTapGestureKey = "Player/Gesture/Tap";
         private const string GeneralShowRecent = "General/ShowRecent";
+        private const string AdvancedModeKey = "Advanced/IsEnabled";
+        private const string GlobalArgumentsKey = "Values/GlobalArguments";
         private const string PersistentVolumeKey = "Values/Volume";
         private const string MaxVolumeKey = "Values/MaxVolume";
         private const string PersistentRepeatModeKey = "Values/RepeatMode";
@@ -69,6 +73,18 @@ namespace Screenbox.Core.Services
             set => SetValue(PersistentRepeatModeKey, (int)value);
         }
 
+        public string GlobalArguments
+        {
+            get => GetValue<string>(GlobalArgumentsKey) ?? string.Empty;
+            set => SetValue(GlobalArgumentsKey, SanitizeArguments(value));
+        }
+
+        public bool AdvancedMode
+        {
+            get => GetValue<bool>(AdvancedModeKey);
+            set => SetValue(AdvancedModeKey, value);
+        }
+
         public SettingsService()
         {
             SetDefault(PlayerAutoResizeKey, (int)PlayerAutoResizeOption.Always);
@@ -79,6 +95,8 @@ namespace Screenbox.Core.Services
             SetDefault(MaxVolumeKey, 100);
             SetDefault(GeneralShowRecent, true);
             SetDefault(PersistentRepeatModeKey, (int)MediaPlaybackAutoRepeatMode.None);
+            SetDefault(AdvancedModeKey, false);
+            SetDefault(GlobalArgumentsKey, string.Empty);
 
             // Device family specific overrides
             if (SystemInformationExtensions.IsXbox)
@@ -109,6 +127,13 @@ namespace Screenbox.Core.Services
         {
             if (_settingsStorage.ContainsKey(key) && _settingsStorage[key] is T) return;
             _settingsStorage[key] = value;
+        }
+
+        private static string SanitizeArguments(string raw)
+        {
+            string[] args = raw.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Where(s => s.StartsWith('-') && s != "--").ToArray();
+            return string.Join(' ', args);
         }
     }
 }

--- a/Screenbox.Core/ViewModels/CommonViewModel.cs
+++ b/Screenbox.Core/ViewModels/CommonViewModel.cs
@@ -24,6 +24,8 @@ namespace Screenbox.Core.ViewModels
     {
         public Dictionary<Type, string> NavigationStates { get; }
 
+        public bool IsAdvancedModeEnabled => _settingsService.AdvancedMode;
+
         [ObservableProperty] private NavigationViewDisplayMode _navigationViewDisplayMode;
         [ObservableProperty] private Thickness _scrollBarMargin;
         [ObservableProperty] private Thickness _footerBottomPaddingMargin;
@@ -32,15 +34,20 @@ namespace Screenbox.Core.ViewModels
         private readonly INavigationService _navigationService;
         private readonly IFilesService _filesService;
         private readonly IResourceService _resourceService;
+        private readonly ISettingsService _settingsService;
         private readonly Func<IPropertiesDialog> _propertiesDialogFactory;
         private readonly Dictionary<string, double> _scrollingStates;
 
-        public CommonViewModel(INavigationService navigationService, IFilesService filesService, IResourceService resourceService,
+        public CommonViewModel(INavigationService navigationService,
+            IFilesService filesService,
+            IResourceService resourceService,
+            ISettingsService settingsService,
             Func<IPropertiesDialog> propertiesDialogFactory)
         {
             _navigationService = navigationService;
             _filesService = filesService;
             _resourceService = resourceService;
+            _settingsService = settingsService;
             _navigationViewDisplayMode = Messenger.Send<NavigationViewDisplayModeRequestMessage>();
             _propertiesDialogFactory = propertiesDialogFactory;
             NavigationStates = new Dictionary<Type, string>();

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -18,12 +18,9 @@ using Windows.Storage.AccessCache;
 namespace Screenbox.Core.ViewModels
 {
     public sealed partial class HomePageViewModel : ObservableRecipient,
-        IRecipient<PlaylistActiveItemChangedMessage>,
-        IRecipient<SettingsChangedMessage>
+        IRecipient<PlaylistActiveItemChangedMessage>
     {
         public ObservableCollection<MediaViewModelWithMruToken> Recent { get; }
-
-        [ObservableProperty] private bool _isAdvancedModeEnabled;
 
         public bool HasRecentMedia => StorageApplicationPermissions.MostRecentlyUsedList.Entries.Count > 0 && _settingsService.ShowRecent;
 
@@ -42,7 +39,6 @@ namespace Screenbox.Core.ViewModels
             _filesService = filesService;
             _settingsService = settingsService;
             _libraryService = libraryService;
-            IsAdvancedModeEnabled = settingsService.AdvancedMode;
             Recent = new ObservableCollection<MediaViewModelWithMruToken>();
 
             // Activate the view model's messenger
@@ -54,14 +50,6 @@ namespace Screenbox.Core.ViewModels
             if (message.Value is { Source: IStorageItem } && _settingsService.ShowRecent)
             {
                 await UpdateRecentMediaListAsync().ConfigureAwait(false);
-            }
-        }
-
-        public void Receive(SettingsChangedMessage message)
-        {
-            if (message.SettingsName == nameof(_settingsService.AdvancedMode))
-            {
-                IsAdvancedModeEnabled = _settingsService.AdvancedMode;
             }
         }
 

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -18,9 +18,12 @@ using Windows.Storage.AccessCache;
 namespace Screenbox.Core.ViewModels
 {
     public sealed partial class HomePageViewModel : ObservableRecipient,
-        IRecipient<PlaylistActiveItemChangedMessage>
+        IRecipient<PlaylistActiveItemChangedMessage>,
+        IRecipient<SettingsChangedMessage>
     {
         public ObservableCollection<MediaViewModelWithMruToken> Recent { get; }
+
+        [ObservableProperty] private bool _isAdvancedModeEnabled;
 
         public bool HasRecentMedia => StorageApplicationPermissions.MostRecentlyUsedList.Entries.Count > 0 && _settingsService.ShowRecent;
 
@@ -39,6 +42,7 @@ namespace Screenbox.Core.ViewModels
             _filesService = filesService;
             _settingsService = settingsService;
             _libraryService = libraryService;
+            IsAdvancedModeEnabled = settingsService.AdvancedMode;
             Recent = new ObservableCollection<MediaViewModelWithMruToken>();
 
             // Activate the view model's messenger
@@ -50,6 +54,14 @@ namespace Screenbox.Core.ViewModels
             if (message.Value is { Source: IStorageItem } && _settingsService.ShowRecent)
             {
                 await UpdateRecentMediaListAsync().ConfigureAwait(false);
+            }
+        }
+
+        public void Receive(SettingsChangedMessage message)
+        {
+            if (message.SettingsName == nameof(_settingsService.AdvancedMode))
+            {
+                IsAdvancedModeEnabled = _settingsService.AdvancedMode;
             }
         }
 

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -166,7 +166,7 @@ namespace Screenbox.Core.ViewModels
                 .Where(o => o.StartsWith(":") && o.Length > 1).ToArray();
 
             // Check if new options and existing options are the same
-            if (opts.Length == _options.Count && opts.Length > 0)
+            if (opts.Length == _options.Count)
             {
                 bool same = !opts.Where((o, i) => o != _options[i]).Any();
                 if (same) return;

--- a/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
+using LibVLCSharp.Shared;
 using Microsoft.Toolkit.Uwp.UI;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
@@ -98,7 +99,18 @@ namespace Screenbox.Core.ViewModels
                     ? _settingsService.GlobalArguments.Split(' ', StringSplitOptions.RemoveEmptyEntries)
                         .Concat(swapChainOptions).ToArray()
                     : swapChainOptions;
-                _libVlcService.Initialize(args);
+
+                try
+                {
+                    _libVlcService.Initialize(args);
+                }
+                catch (VLCException e)
+                {
+                    _libVlcService.Initialize(swapChainOptions);
+                    Messenger.Send(new ErrorMessage(
+                        _resourceService.GetString(ResourceName.FailedToInitializeNotificationTitle), e.Message));
+                }
+
                 _mediaPlayer = _libVlcService.MediaPlayer;
                 Guard.IsNotNull(_mediaPlayer, nameof(_mediaPlayer));
                 VlcPlayer = _mediaPlayer.VlcPlayer;

--- a/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
@@ -11,6 +11,7 @@ using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
@@ -93,7 +94,11 @@ namespace Screenbox.Core.ViewModels
         {
             Task.Run(() =>
             {
-                _libVlcService.Initialize(swapChainOptions);
+                string[] args = _settingsService.GlobalArguments.Length > 0
+                    ? _settingsService.GlobalArguments.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                        .Concat(swapChainOptions).ToArray()
+                    : swapChainOptions;
+                _libVlcService.Initialize(args);
                 _mediaPlayer = _libVlcService.MediaPlayer;
                 Guard.IsNotNull(_mediaPlayer, nameof(_mediaPlayer));
                 VlcPlayer = _mediaPlayer.VlcPlayer;

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -23,6 +23,9 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private bool _playerTapGesture;
         [ObservableProperty] private int _volumeBoost;
         [ObservableProperty] private bool _showRecent;
+        [ObservableProperty] private bool _advancedMode;
+        [ObservableProperty] private string _globalArguments;
+        [ObservableProperty] private bool _isRelaunchRequired;
 
         public ObservableCollection<StorageFolder> MusicLocations { get; }
 
@@ -31,6 +34,9 @@ namespace Screenbox.Core.ViewModels
         private readonly ISettingsService _settingsService;
         private readonly ILibraryService _libraryService;
         private readonly DispatcherQueue _dispatcherQueue;
+        private readonly DispatcherQueueTimer _argumentsChangedTimer;
+        private static string? _originalGlobalArguments;
+        private static bool? _originalAdvancedMode;
         private StorageLibrary? _videosLibrary;
         private StorageLibrary? _musicLibrary;
 
@@ -39,10 +45,29 @@ namespace Screenbox.Core.ViewModels
             _settingsService = settingsService;
             _libraryService = libraryService;
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+            _argumentsChangedTimer = _dispatcherQueue.CreateTimer();
             MusicLocations = new ObservableCollection<StorageFolder>();
             VideoLocations = new ObservableCollection<StorageFolder>();
 
-            LoadValues();
+            // Load values
+            _playerAutoResize = (int)_settingsService.PlayerAutoResize;
+            _playerVolumeGesture = _settingsService.PlayerVolumeGesture;
+            _playerSeekGesture = _settingsService.PlayerSeekGesture;
+            _playerTapGesture = _settingsService.PlayerTapGesture;
+            _showRecent = _settingsService.ShowRecent;
+            _advancedMode = _settingsService.AdvancedMode;
+            _globalArguments = _settingsService.GlobalArguments;
+            _originalAdvancedMode ??= _advancedMode;
+            _originalGlobalArguments ??= _globalArguments;
+            _isRelaunchRequired = CheckForRelaunch();
+            int maxVolume = _settingsService.MaxVolume;
+            _volumeBoost = maxVolume switch
+            {
+                >= 200 => 3,
+                >= 150 => 2,
+                >= 125 => 1,
+                _ => 0
+            };
 
             IsActive = true;
         }
@@ -50,31 +75,31 @@ namespace Screenbox.Core.ViewModels
         partial void OnPlayerAutoResizeChanged(int value)
         {
             _settingsService.PlayerAutoResize = (PlayerAutoResizeOption)value;
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.PlayerAutoResize)));
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerAutoResize)));
         }
 
         partial void OnPlayerVolumeGestureChanged(bool value)
         {
             _settingsService.PlayerVolumeGesture = value;
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.PlayerVolumeGesture)));
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerVolumeGesture)));
         }
 
         partial void OnPlayerSeekGestureChanged(bool value)
         {
             _settingsService.PlayerSeekGesture = value;
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.PlayerSeekGesture)));
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerSeekGesture)));
         }
 
         partial void OnPlayerTapGestureChanged(bool value)
         {
             _settingsService.PlayerTapGesture = value;
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.PlayerTapGesture)));
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerTapGesture)));
         }
 
         partial void OnShowRecentChanged(bool value)
         {
             _settingsService.ShowRecent = value;
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.ShowRecent)));
+            Messenger.Send(new SettingsChangedMessage(nameof(ShowRecent)));
         }
 
         partial void OnVolumeBoostChanged(int value)
@@ -86,7 +111,21 @@ namespace Screenbox.Core.ViewModels
                 1 => 125,
                 _ => 100
             };
-            Messenger.Send(new SettingsChangedMessage(nameof(SettingsPageViewModel.VolumeBoost)));
+            Messenger.Send(new SettingsChangedMessage(nameof(VolumeBoost)));
+        }
+
+        partial void OnAdvancedModeChanged(bool value)
+        {
+            _settingsService.AdvancedMode = value;
+            Messenger.Send(new SettingsChangedMessage(nameof(AdvancedMode)));
+            IsRelaunchRequired = CheckForRelaunch();
+        }
+
+        partial void OnGlobalArgumentsChanged(string value)
+        {
+            // No need to broadcast SettingsChangedMessage for this option
+            _settingsService.GlobalArguments = value;
+            IsRelaunchRequired = CheckForRelaunch();
         }
 
         [RelayCommand]
@@ -137,23 +176,6 @@ namespace Screenbox.Core.ViewModels
         private void ClearRecentHistory()
         {
             StorageApplicationPermissions.MostRecentlyUsedList.Clear();
-        }
-
-        private void LoadValues()
-        {
-            PlayerAutoResize = (int)_settingsService.PlayerAutoResize;
-            PlayerVolumeGesture = _settingsService.PlayerVolumeGesture;
-            PlayerSeekGesture = _settingsService.PlayerSeekGesture;
-            PlayerTapGesture = _settingsService.PlayerTapGesture;
-            ShowRecent = _settingsService.ShowRecent;
-            int maxVolume = _settingsService.MaxVolume;
-            VolumeBoost = maxVolume switch
-            {
-                >= 200 => 3,
-                >= 150 => 2,
-                >= 125 => 1,
-                _ => 0
-            };
         }
 
         public async Task LoadLibraryLocations()
@@ -228,6 +250,30 @@ namespace Screenbox.Core.ViewModels
                     MusicLocations.Add(folder);
                 }
             }
+        }
+
+        private bool CheckForRelaunch()
+        {
+            // Check if global arguments have been changed
+            bool argsChanged = _originalGlobalArguments != _settingsService.GlobalArguments;
+
+            // Check if advanced mode has been changed
+            bool modeChanged = _originalAdvancedMode != AdvancedMode;
+
+            // Check if there are any global arguments set
+            bool hasArgs = _settingsService.GlobalArguments.Length > 0;
+
+            // Check if advanced mode is on, and if global arguments are set
+            bool whenOn = modeChanged && AdvancedMode && hasArgs;
+
+            // Check if advanced mode is off, and if global arguments are set or have been removed
+            bool whenOff = modeChanged && !AdvancedMode && (!hasArgs && argsChanged || hasArgs);
+
+            // Require relaunch when advanced mode is on and global arguments have been changed
+            bool whenOnAndChanged = AdvancedMode && argsChanged;
+
+            // Combine everything
+            return whenOn || whenOff || whenOnAndChanged;
         }
     }
 }

--- a/Screenbox/Commands/SetPlaybackOptionsCommand.cs
+++ b/Screenbox/Commands/SetPlaybackOptionsCommand.cs
@@ -41,6 +41,7 @@ internal class SetPlaybackOptionsCommand : IRelayCommand
     {
         MediaViewModel media => media,
         MediaViewModelWithMruToken mediaWithMru => mediaWithMru.Media,
+        StorageItemViewModel storageItemViewModel => storageItemViewModel.Media,
         _ => null
     };
 }

--- a/Screenbox/Commands/SetPlaybackOptionsCommand.cs
+++ b/Screenbox/Commands/SetPlaybackOptionsCommand.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+
+using CommunityToolkit.Mvvm.Input;
+using Screenbox.Controls;
+using Screenbox.Core;
+using Screenbox.Core.ViewModels;
+using System;
+using Windows.UI.Xaml.Controls;
+
+namespace Screenbox.Commands;
+internal class SetPlaybackOptionsCommand : IRelayCommand
+{
+    public event EventHandler? CanExecuteChanged;
+
+    public IRelayCommand? PlayCommand { get; set; }
+
+    public bool CanExecute(object parameter)
+    {
+        return true;
+    }
+
+    public async void Execute(object parameter)
+    {
+        if (TryGetMedia(parameter) is not { } media) return;
+        SetOptionsDialog dialog = new(string.Join(' ', media.Options));
+        ContentDialogResult result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.None) return;
+        media.SetOptions(dialog.Options);
+        if (result == ContentDialogResult.Secondary)
+        {
+            PlayCommand?.Execute(parameter);
+        }
+    }
+
+    public void NotifyCanExecuteChanged()
+    {
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static MediaViewModel? TryGetMedia(object parameter) => parameter switch
+    {
+        MediaViewModel media => media,
+        MediaViewModelWithMruToken mediaWithMru => mediaWithMru.Media,
+        _ => null
+    };
+}

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Controls.PlaylistView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:core="using:Microsoft.Xaml.Interactions.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
@@ -73,6 +74,16 @@
                 <MenuFlyoutItem Command="{StaticResource MoveUpCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutItem Command="{StaticResource MoveDownCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding}" />
+                <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
+                <MenuFlyoutItem
+                    CommandParameter="{Binding}"
+                    Icon="{ui:SymbolIcon Symbol=Setting}"
+                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
+                    <MenuFlyoutItem.Command>
+                        <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.Playlist.PlaySingleCommand}" />
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
             </MenuFlyout>
         </Grid.Resources>
         <Grid.RowDefinitions>

--- a/Screenbox/Controls/SetOptionsDialog.xaml
+++ b/Screenbox/Controls/SetOptionsDialog.xaml
@@ -2,30 +2,37 @@
     x:Class="Screenbox.Controls.SetOptionsDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Screenbox.Controls"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="Set playback options"
-    CloseButtonText="Close"
+    xmlns:strings="using:Screenbox.Strings"
+    Title="{strings:Resources Key=SetPlaybackOptions}"
+    CloseButtonText="{strings:Resources Key=Close}"
     DefaultButton="Primary"
-    PrimaryButtonText="Set"
-    SecondaryButtonText="Set and Play"
+    PrimaryButtonText="{strings:Resources Key=Set}"
+    SecondaryButtonText="{strings:Resources Key=SetAndPlay}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" Spacing="8">
-        <TextBlock TextWrapping="Wrap">
-            <Run Text="Set VLC options that apply to a stream." /><LineBreak /><Run Text="See" />
+    <StackPanel Orientation="Vertical" Spacing="12">
+        <TextBlock MaxWidth="420" TextWrapping="Wrap">
+            <Run Text="{strings:Resources Key=SetPlaybackOptionsHelpTextLine1}" /><LineBreak /><Run Text="{x:Bind VlcCommandLineHelpTextParts[0]}" />
             <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
-                <Run Text="VLC command-line help" />
+                <Run Text="{strings:Resources Key=VlcCommandLineHelpLink}" />
             </Hyperlink>
-            <Run Text="for the full list of available options." /><LineBreak /><Run Text="Some options may only be set globally." />
+            <Run Text="{x:Bind VlcCommandLineHelpTextParts[1]}" />
+            <Run Text="{strings:Resources Key=SetPlaybackOptionsHelpTextLine2}" />
         </TextBlock>
         <TextBox
             x:Name="OptionsTextBox"
             AcceptsReturn="False"
             IsSpellCheckEnabled="False"
             PlaceholderText=":option=value"
-            Text="{x:Bind Options, Mode=TwoWay}" />
+            Text="{x:Bind Options, Mode=TwoWay}">
+            <interactivity:Interaction.Behaviors>
+                <behaviors:AutoFocusBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBox>
     </StackPanel>
 </ContentDialog>

--- a/Screenbox/Controls/SetOptionsDialog.xaml
+++ b/Screenbox/Controls/SetOptionsDialog.xaml
@@ -1,0 +1,31 @@
+﻿<ContentDialog
+    x:Class="Screenbox.Controls.SetOptionsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Screenbox.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Set playback options"
+    CloseButtonText="Close"
+    DefaultButton="Primary"
+    PrimaryButtonText="Set"
+    SecondaryButtonText="Set and Play"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    mc:Ignorable="d">
+
+    <StackPanel Orientation="Vertical" Spacing="8">
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="VLC options that apply to a specific stream." /><LineBreak /><Run Text="See" />
+            <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
+                <Run Text="VLC command-line help" />
+            </Hyperlink>
+            <Run Text="for the full list of available options." /><LineBreak /><Run Text="Some options may only be set globally." />
+        </TextBlock>
+        <TextBox
+            x:Name="OptionsTextBox"
+            AcceptsReturn="False"
+            IsSpellCheckEnabled="False"
+            PlaceholderText=":option=value"
+            Text="{x:Bind Options, Mode=TwoWay}" />
+    </StackPanel>
+</ContentDialog>

--- a/Screenbox/Controls/SetOptionsDialog.xaml
+++ b/Screenbox/Controls/SetOptionsDialog.xaml
@@ -15,7 +15,7 @@
 
     <StackPanel Orientation="Vertical" Spacing="8">
         <TextBlock TextWrapping="Wrap">
-            <Run Text="VLC options that apply to a specific stream." /><LineBreak /><Run Text="See" />
+            <Run Text="Set VLC options that apply to a stream." /><LineBreak /><Run Text="See" />
             <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
                 <Run Text="VLC command-line help" />
             </Hyperlink>

--- a/Screenbox/Controls/SetOptionsDialog.xaml.cs
+++ b/Screenbox/Controls/SetOptionsDialog.xaml.cs
@@ -24,8 +24,10 @@ public sealed partial class SetOptionsDialog : ContentDialog
         this.InitializeComponent();
         Options = existingOptions;
         OptionsTextBox.Text = Options;
-        VlcCommandLineHelpTextParts = Strings.Resources.VlcCommandLineHelpText
+        VlcCommandLineHelpTextParts = new string[2];
+        string[] parts = Strings.Resources.VlcCommandLineHelpText
             .Split("{0}", StringSplitOptions.RemoveEmptyEntries)
             .Select(s => s.Trim()).ToArray();
+        Array.Copy(parts, VlcCommandLineHelpTextParts, VlcCommandLineHelpTextParts.Length);
     }
 }

--- a/Screenbox/Controls/SetOptionsDialog.xaml.cs
+++ b/Screenbox/Controls/SetOptionsDialog.xaml.cs
@@ -1,0 +1,24 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Screenbox.Controls;
+public sealed partial class SetOptionsDialog : ContentDialog
+{
+    public static readonly DependencyProperty OptionsProperty = DependencyProperty.Register(
+        nameof(Options), typeof(string), typeof(SetOptionsDialog), new PropertyMetadata(default(string)));
+
+    public string Options
+    {
+        get { return (string)GetValue(OptionsProperty); }
+        set { SetValue(OptionsProperty, value); }
+    }
+
+    public SetOptionsDialog(string existingOptions)
+    {
+        this.InitializeComponent();
+        Options = existingOptions;
+        OptionsTextBox.Text = Options;
+    }
+}

--- a/Screenbox/Controls/SetOptionsDialog.xaml.cs
+++ b/Screenbox/Controls/SetOptionsDialog.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Windows.UI.Xaml;
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -15,10 +17,15 @@ public sealed partial class SetOptionsDialog : ContentDialog
         set { SetValue(OptionsProperty, value); }
     }
 
+    private string[] VlcCommandLineHelpTextParts { get; }
+
     public SetOptionsDialog(string existingOptions)
     {
         this.InitializeComponent();
         Options = existingOptions;
         OptionsTextBox.Text = Options;
+        VlcCommandLineHelpTextParts = Strings.Resources.VlcCommandLineHelpText
+            .Split("{0}", StringSplitOptions.RemoveEmptyEntries)
+            .Select(s => s.Trim()).ToArray();
     }
 }

--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -123,6 +123,10 @@
     </header>
     <body>
       <group id="SCREENBOX/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
+        <trans-unit id="FailedToInitializeNotificationTitle" translate="yes" xml:space="preserve">
+          <source>Failed to initialize</source>
+          <target state="new"></target>
+        </trans-unit>
         <trans-unit id="FrameSavedNotificationTitle" translate="yes" xml:space="preserve">
           <source>Frame saved</source>
           <target state="translated">帧已保存</target>

--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -151,9 +151,34 @@
           <source>Playback speed</source>
           <target state="translated">播放速度</target>
         </trans-unit>
+        <trans-unit id="Set" translate="yes" xml:space="preserve">
+          <source>Set</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SetAndPlay" translate="yes" xml:space="preserve">
+          <source>Set and Play</source>
+          <target state="new"></target>
+        </trans-unit>
         <trans-unit id="SetPlaybackOptions" translate="yes" xml:space="preserve">
           <source>Set playback options</source>
           <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SetPlaybackOptionsHelpTextLine1" translate="yes" xml:space="preserve">
+          <source>Set VLC options that apply to a stream.</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SetPlaybackOptionsHelpTextLine2" translate="yes" xml:space="preserve">
+          <source>Some options may only be set globally.</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="VlcCommandLineHelpLink" translate="yes" xml:space="preserve">
+          <source>VLC command-line help</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="VlcCommandLineHelpText" translate="yes" xml:space="preserve">
+          <source>See {0} for the full list of available options.</source>
+          <target state="new"></target>
+          <note from="MultilingualBuild" priority="2">{0} = VLC command-line help</note>
         </trans-unit>
         <trans-unit id="VolumeChangeStatusMessage" translate="yes" xml:space="preserve">
           <source>Volume {0:F0}%</source>

--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -151,6 +151,10 @@
           <source>Playback speed</source>
           <target state="translated">播放速度</target>
         </trans-unit>
+        <trans-unit id="SetPlaybackOptions" translate="yes" xml:space="preserve">
+          <source>Set playback options</source>
+          <target state="new"></target>
+        </trans-unit>
         <trans-unit id="VolumeChangeStatusMessage" translate="yes" xml:space="preserve">
           <source>Volume {0:F0}%</source>
           <target state="translated">音量 {0:F0}%</target>

--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -139,6 +139,18 @@
           <source>Enter the URL for a file or stream</source>
           <target state="translated">输入文件或流的 URL</target>
         </trans-unit>
+        <trans-unit id="PendingChanges" translate="yes" xml:space="preserve">
+          <source>Pending changes</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="RelaunchForChangesMessage" translate="yes" xml:space="preserve">
+          <source>Relaunch the app for changes to take effect</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="RemoveFolder" translate="yes" xml:space="preserve">
+          <source>Remove folder</source>
+          <target state="new"></target>
+        </trans-unit>
         <trans-unit id="SaveCurrentFrame" translate="yes" xml:space="preserve">
           <source>Save current frame</source>
           <target state="translated">保存当前帧</target>
@@ -169,6 +181,26 @@
         </trans-unit>
         <trans-unit id="SetPlaybackOptionsHelpTextLine2" translate="yes" xml:space="preserve">
           <source>Some options may only be set globally.</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SettingsAdvancedModeDescription" translate="yes" xml:space="preserve">
+          <source>Advanced mode allows you to customize LibVLC's behavior using command line arguments.</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SettingsAdvancedModeHeader" translate="yes" xml:space="preserve">
+          <source>Advanced mode</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SettingsCategoryAdvanced" translate="yes" xml:space="preserve">
+          <source>Advanced</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SettingsGlobalArgumentsDescription" translate="yes" xml:space="preserve">
+          <source>Command line arguments that apply to all media playback.</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="SettingsGlobalArgumentsHeader" translate="yes" xml:space="preserve">
+          <source>Global arguments</source>
           <target state="new"></target>
         </trans-unit>
         <trans-unit id="VlcCommandLineHelpLink" translate="yes" xml:space="preserve">

--- a/Screenbox/Pages/AllVideosPage.xaml
+++ b/Screenbox/Pages/AllVideosPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -37,6 +38,16 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xe946;}"
                     Text="{strings:Resources Key=Properties}" />
+                <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
+                <MenuFlyoutItem
+                    CommandParameter="{Binding}"
+                    Icon="{ui:SymbolIcon Symbol=Setting}"
+                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
+                    <MenuFlyoutItem.Command>
+                        <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
@@ -33,6 +34,16 @@
                 CommandParameter="{Binding Media}"
                 Icon="{ui:FontIcon Glyph=&#xe946;}"
                 Text="{strings:Resources Key=Properties}" />
+            <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
+            <MenuFlyoutItem
+                CommandParameter="{Binding}"
+                Icon="{ui:SymbolIcon Symbol=Setting}"
+                Text="{strings:Resources Key=SetPlaybackOptions}"
+                Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
+                <MenuFlyoutItem.Command>
+                    <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
+                </MenuFlyoutItem.Command>
+            </MenuFlyoutItem>
         </MenuFlyout>
 
         <DataTemplate x:Key="StorageItemListViewItemTemplate" x:DataType="viewModels1:StorageItemViewModel">

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:core="using:Microsoft.Xaml.Interactions.Core"
@@ -46,6 +47,16 @@
                     CommandParameter="{Binding Media}"
                     Icon="{ui:FontIcon Glyph=&#xe946;}"
                     Text="{strings:Resources Key=Properties}" />
+                <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
+                <MenuFlyoutItem
+                    CommandParameter="{Binding}"
+                    Icon="{ui:SymbolIcon Symbol=Setting}"
+                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
+                    <MenuFlyoutItem.Command>
+                        <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
             </MenuFlyout>
 
             <DataTemplate x:Key="StorageItemGridViewTemplate" x:DataType="viewModels:StorageItemViewModel">

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -58,6 +58,11 @@
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource RemoveCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding Media}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem
+                    Click="SetOptionsMenuItem_OnClick"
+                    Icon="{ui:SymbolIcon Symbol=Setting}"
+                    Text="Set playback options" />
             </MenuFlyout>
 
             <MenuFlyout x:Key="OpenFlyout" Placement="BottomEdgeAlignedRight">
@@ -259,7 +264,7 @@
                     <Border Height="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
                 </GridView.Footer>
                 <interactivity:Interaction.Behaviors>
-                    <interactions:ListViewContextTriggerBehavior Flyout="{x:Bind ItemFlyout}" />
+                    <interactions:ListViewContextTriggerBehavior ContextRequested="ListViewContextTriggerBehavior_OnContextRequested" Flyout="{x:Bind ItemFlyout}" />
                     <interactions:BringIntoViewWithOffsetBehavior FromBottom="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
                 </interactivity:Interaction.Behaviors>
             </GridView>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -57,12 +57,12 @@
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource RemoveCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding Media}" />
-                <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}" />
+                <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
                     Text="{strings:Resources Key=SetPlaybackOptions}"
-                    Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}">
+                    Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
                     </MenuFlyoutItem.Command>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -3,13 +3,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
-    xmlns:controls1="using:Screenbox.Controls"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:core="using:Screenbox.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Screenbox.Core.Helpers"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
@@ -60,10 +59,14 @@
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding Media}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
-                    Click="SetOptionsMenuItem_OnClick"
+                    CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
                     Text="Set playback options"
-                    Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}" />
+                    Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}">
+                    <MenuFlyoutItem.Command>
+                        <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
             </MenuFlyout>
 
             <MenuFlyout x:Key="OpenFlyout" Placement="BottomEdgeAlignedRight">

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -58,11 +58,12 @@
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource RemoveCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding Media}" />
-                <MenuFlyoutSeparator />
+                <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     Click="SetOptionsMenuItem_OnClick"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="Set playback options" />
+                    Text="Set playback options"
+                    Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}" />
             </MenuFlyout>
 
             <MenuFlyout x:Key="OpenFlyout" Placement="BottomEdgeAlignedRight">
@@ -264,7 +265,7 @@
                     <Border Height="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
                 </GridView.Footer>
                 <interactivity:Interaction.Behaviors>
-                    <interactions:ListViewContextTriggerBehavior ContextRequested="ListViewContextTriggerBehavior_OnContextRequested" Flyout="{x:Bind ItemFlyout}" />
+                    <interactions:ListViewContextTriggerBehavior Flyout="{x:Bind ItemFlyout}" />
                     <interactions:BringIntoViewWithOffsetBehavior FromBottom="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
                 </interactivity:Interaction.Behaviors>
             </GridView>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -61,7 +61,7 @@
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="Set playback options"
+                    Text="{strings:Resources Key=SetPlaybackOptions}"
                     Visibility="{x:Bind ViewModel.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />

--- a/Screenbox/Pages/HomePage.xaml.cs
+++ b/Screenbox/Pages/HomePage.xaml.cs
@@ -1,12 +1,15 @@
 ﻿#nullable enable
 
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Screenbox.Controls;
+using Screenbox.Controls.Interactions;
+using Screenbox.Core;
+using Screenbox.Core.ViewModels;
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Screenbox.Controls;
-using Screenbox.Core.ViewModels;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -20,6 +23,8 @@ namespace Screenbox.Pages
         internal HomePageViewModel ViewModel => (HomePageViewModel)DataContext;
 
         internal CommonViewModel Common { get; }
+
+        private SelectorItem? _contextRequestedItem;
 
         public HomePage()
         {
@@ -41,6 +46,25 @@ namespace Screenbox.Pages
             {
                 ViewModel.OpenUrl(uri);
             }
+        }
+
+        private async void SetOptionsMenuItem_OnClick(object sender, RoutedEventArgs e)
+        {
+            if (_contextRequestedItem == null) return;
+            MediaViewModelWithMruToken? item = (MediaViewModelWithMruToken)RecentFilesGridView.ItemFromContainer(_contextRequestedItem);
+            SetOptionsDialog dialog = new(string.Join(' ', item.Media.Options));
+            ContentDialogResult result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.None) return;
+            item.Media.SetOptions(dialog.Options);
+            if (result == ContentDialogResult.Secondary)
+            {
+                ViewModel.PlayCommand.Execute(item);
+            }
+        }
+
+        private void ListViewContextTriggerBehavior_OnContextRequested(ListViewContextTriggerBehavior sender, ListViewContextRequestedEventArgs args)
+        {
+            _contextRequestedItem = args.Item;
         }
     }
 }

--- a/Screenbox/Pages/HomePage.xaml.cs
+++ b/Screenbox/Pages/HomePage.xaml.cs
@@ -2,7 +2,6 @@
 
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Controls;
-using Screenbox.Core;
 using Screenbox.Core.ViewModels;
 using System;
 using Windows.UI.Xaml;
@@ -41,19 +40,6 @@ namespace Screenbox.Pages
             if (uri != null)
             {
                 ViewModel.OpenUrl(uri);
-            }
-        }
-
-        private async void SetOptionsMenuItem_OnClick(object sender, RoutedEventArgs e)
-        {
-            if (sender is not FrameworkElement { DataContext: MediaViewModelWithMruToken item }) return;
-            SetOptionsDialog dialog = new(string.Join(' ', item.Media.Options));
-            ContentDialogResult result = await dialog.ShowAsync();
-            if (result == ContentDialogResult.None) return;
-            item.Media.SetOptions(dialog.Options);
-            if (result == ContentDialogResult.Secondary)
-            {
-                ViewModel.PlayCommand.Execute(item);
             }
         }
     }

--- a/Screenbox/Pages/HomePage.xaml.cs
+++ b/Screenbox/Pages/HomePage.xaml.cs
@@ -2,13 +2,11 @@
 
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Controls;
-using Screenbox.Controls.Interactions;
 using Screenbox.Core;
 using Screenbox.Core.ViewModels;
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -23,8 +21,6 @@ namespace Screenbox.Pages
         internal HomePageViewModel ViewModel => (HomePageViewModel)DataContext;
 
         internal CommonViewModel Common { get; }
-
-        private SelectorItem? _contextRequestedItem;
 
         public HomePage()
         {
@@ -50,8 +46,7 @@ namespace Screenbox.Pages
 
         private async void SetOptionsMenuItem_OnClick(object sender, RoutedEventArgs e)
         {
-            if (_contextRequestedItem == null) return;
-            MediaViewModelWithMruToken? item = (MediaViewModelWithMruToken)RecentFilesGridView.ItemFromContainer(_contextRequestedItem);
+            if (sender is not FrameworkElement { DataContext: MediaViewModelWithMruToken item }) return;
             SetOptionsDialog dialog = new(string.Join(' ', item.Media.Options));
             ContentDialogResult result = await dialog.ShowAsync();
             if (result == ContentDialogResult.None) return;
@@ -60,11 +55,6 @@ namespace Screenbox.Pages
             {
                 ViewModel.PlayCommand.Execute(item);
             }
-        }
-
-        private void ListViewContextTriggerBehavior_OnContextRequested(ListViewContextTriggerBehavior sender, ListViewContextRequestedEventArgs args)
-        {
-            _contextRequestedItem = args.Item;
         }
     }
 }

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -219,6 +219,24 @@
                 <TextBlock
                     Margin="0,24,0,4"
                     FontWeight="SemiBold"
+                    Text="Advanced" />
+                <labs:SettingsCard Description="Advanced mode allows you to customize libVLC's behavior using command line arguments." Header="Advanced mode">
+                    <ToggleSwitch />
+                </labs:SettingsCard>
+                <labs:SettingsCard
+                    Description="Command line arguments that apply to all media playback. You can set file specific arguments in the file context menu."
+                    Header="Default arguments"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xe756;}">
+                    <TextBox
+                        Width="180"
+                        AcceptsReturn="False"
+                        MaxLength="1024"
+                        PlaceholderText="--sout-all --sout #display" />
+                </labs:SettingsCard>
+
+                <TextBlock
+                    Margin="0,24,0,4"
+                    FontWeight="SemiBold"
                     Text="{strings:Resources Key=SettingsCategoryAbout}" />
                 <labs:SettingsCard
                     Margin="0,0,0,24"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -36,7 +36,7 @@
             <XamlUICommand
                 x:Key="RemoveMusicFolderCommand"
                 Command="{x:Bind ViewModel.RemoveMusicFolderCommand}"
-                Description="Remove folder"
+                Description="{strings:Resources Key=RemoveFolder}"
                 IconSource="{ui:FontIconSource FontSize=16,
                                                Glyph=&#xe894;}"
                 Label="{strings:Resources Key=Remove}" />
@@ -44,7 +44,7 @@
             <XamlUICommand
                 x:Key="RemoveVideosFolderCommand"
                 Command="{x:Bind ViewModel.RemoveVideosFolderCommand}"
-                Description="Remove folder"
+                Description="{strings:Resources Key=RemoveFolder}"
                 IconSource="{ui:FontIconSource FontSize=16,
                                                Glyph=&#xe894;}"
                 Label="{strings:Resources Key=Remove}" />
@@ -104,17 +104,13 @@
                 Style="{StaticResource PageHeaderTextBlockStyle}"
                 Text="{x:Bind strings:Resources.Settings}" />
             <muxc:InfoBar
-                x:Name="UnappliedChangesInfoBar"
+                x:Name="PendingChangesInfoBar"
+                Title="{strings:Resources Key=PendingChanges}"
                 Grid.Column="1"
-                MaxWidth="400"
                 IsClosable="False"
                 IsOpen="{x:Bind ViewModel.IsRelaunchRequired, Mode=OneWay}"
-                Message="Relaunch the app for changes to take effect"
-                Severity="Warning">
-                <!-- <muxc:InfoBar.ActionButton> -->
-                <!--     <Button Content="Relaunch" /> -->
-                <!-- </muxc:InfoBar.ActionButton> -->
-            </muxc:InfoBar>
+                Message="{strings:Resources Key=RelaunchForChangesMessage}"
+                Severity="Warning" />
         </Grid>
 
         <ScrollViewer
@@ -243,23 +239,22 @@
                 <TextBlock
                     Margin="0,24,0,4"
                     FontWeight="SemiBold"
-                    Text="Advanced" />
+                    Text="{strings:Resources Key=SettingsCategoryAdvanced}" />
                 <labs:SettingsExpander
-                    Description="Advanced mode allows you to customize libVLC's behavior using command line arguments."
-                    Header="Advanced mode"
+                    Description="{strings:Resources Key=SettingsAdvancedModeDescription}"
+                    Header="{strings:Resources Key=SettingsAdvancedModeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe756;}"
                     IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                     <ToggleSwitch x:Name="AdvancedModeToggleSwitch" IsOn="{x:Bind ViewModel.AdvancedMode, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
-                        <labs:SettingsCard Header="Global options" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
+                        <labs:SettingsCard Header="{strings:Resources Key=SettingsGlobalArgumentsHeader}" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                             <labs:SettingsCard.Description>
                                 <TextBlock>
-                                    <Run Text="Command line arguments that apply to all media playback." />
-                                    <Run Text="See" />
+                                    <Run Text="{strings:Resources Key=SettingsGlobalArgumentsDescription}" /><LineBreak /><Run Text="{x:Bind VlcCommandLineHelpTextParts[0]}" />
                                     <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
-                                        <Run Text="VLC command-line help" />
+                                        <Run Text="{strings:Resources Key=VlcCommandLineHelpLink}" />
                                     </Hyperlink>
-                                    <Run Text="for the full list of available options." />
+                                    <Run Text="{x:Bind VlcCommandLineHelpTextParts[1]}" />
                                 </TextBlock>
                             </labs:SettingsCard.Description>
                             <TextBox
@@ -320,7 +315,7 @@
                     <VisualState.Setters>
                         <Setter Target="HeaderGrid.Margin" Value="{StaticResource ContentPageHeaderMarginMinimal}" />
                         <Setter Target="ContentRoot.Padding" Value="{StaticResource ContentPageRightMarginMinimal}" />
-                        <Setter Target="UnappliedChangesInfoBar.MaxWidth" Value="360" />
+                        <Setter Target="PendingChangesInfoBar.MaxWidth" Value="360" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -19,58 +19,64 @@
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
     mc:Ignorable="d">
     <Page.Resources>
-        <x:Double x:Key="ToggleSwitchPreContentMargin">4</x:Double>
-        <x:Double x:Key="ToggleSwitchPostContentMargin">4</x:Double>
-        <x:Double x:Key="SettingsCardWrapThreshold">400</x:Double>
-        <converters:ResourceNameToResourceStringConverter x:Key="ResourceNameToResourceStringConverter" />
-        <muxc:StackLayout
-            x:Name="VerticalStackLayout"
-            Orientation="Vertical"
-            Spacing="12" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///CommunityToolkit.Labs.WinUI.SettingsControls/SettingsExpander/SettingsExpander.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-        <XamlUICommand
-            x:Key="RemoveMusicFolderCommand"
-            Command="{x:Bind ViewModel.RemoveMusicFolderCommand}"
-            Description="Remove folder"
-            IconSource="{ui:FontIconSource FontSize=16,
-                                           Glyph=&#xe894;}"
-            Label="{strings:Resources Key=Remove}" />
+            <x:Double x:Key="ToggleSwitchPreContentMargin">4</x:Double>
+            <x:Double x:Key="ToggleSwitchPostContentMargin">4</x:Double>
+            <x:Double x:Key="SettingsCardWrapThreshold">400</x:Double>
+            <converters:ResourceNameToResourceStringConverter x:Key="ResourceNameToResourceStringConverter" />
+            <muxc:StackLayout
+                x:Name="VerticalStackLayout"
+                Orientation="Vertical"
+                Spacing="12" />
 
-        <XamlUICommand
-            x:Key="RemoveVideosFolderCommand"
-            Command="{x:Bind ViewModel.RemoveVideosFolderCommand}"
-            Description="Remove folder"
-            IconSource="{ui:FontIconSource FontSize=16,
-                                           Glyph=&#xe894;}"
-            Label="{strings:Resources Key=Remove}" />
+            <XamlUICommand
+                x:Key="RemoveMusicFolderCommand"
+                Command="{x:Bind ViewModel.RemoveMusicFolderCommand}"
+                Description="Remove folder"
+                IconSource="{ui:FontIconSource FontSize=16,
+                                               Glyph=&#xe894;}"
+                Label="{strings:Resources Key=Remove}" />
 
-        <DataTemplate x:Key="VideosLibraryLocationTemplate" x:DataType="storage:StorageFolder">
-            <labs:SettingsCard Description="{x:Bind Path}" Header="{x:Bind DisplayName}">
-                <Button
-                    Height="32"
-                    VerticalAlignment="Center"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Command="{StaticResource RemoveVideosFolderCommand}"
-                    CommandParameter="{x:Bind}">
-                    <FontIcon FontSize="16" Glyph="&#xe894;" />
-                </Button>
-            </labs:SettingsCard>
-        </DataTemplate>
+            <XamlUICommand
+                x:Key="RemoveVideosFolderCommand"
+                Command="{x:Bind ViewModel.RemoveVideosFolderCommand}"
+                Description="Remove folder"
+                IconSource="{ui:FontIconSource FontSize=16,
+                                               Glyph=&#xe894;}"
+                Label="{strings:Resources Key=Remove}" />
 
-        <DataTemplate x:Key="MusicLibraryLocationTemplate" x:DataType="storage:StorageFolder">
-            <labs:SettingsCard Description="{x:Bind Path}" Header="{x:Bind DisplayName}">
-                <Button
-                    Height="32"
-                    VerticalAlignment="Center"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    Command="{StaticResource RemoveMusicFolderCommand}"
-                    CommandParameter="{x:Bind}">
-                    <FontIcon FontSize="16" Glyph="&#xe894;" />
-                </Button>
-            </labs:SettingsCard>
-        </DataTemplate>
+            <DataTemplate x:Key="VideosLibraryLocationTemplate" x:DataType="storage:StorageFolder">
+                <labs:SettingsCard Description="{x:Bind Path}" Header="{x:Bind DisplayName}">
+                    <Button
+                        Height="32"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Command="{StaticResource RemoveVideosFolderCommand}"
+                        CommandParameter="{x:Bind}">
+                        <FontIcon FontSize="16" Glyph="&#xe894;" />
+                    </Button>
+                </labs:SettingsCard>
+            </DataTemplate>
+
+            <DataTemplate x:Key="MusicLibraryLocationTemplate" x:DataType="storage:StorageFolder">
+                <labs:SettingsCard Description="{x:Bind Path}" Header="{x:Bind DisplayName}">
+                    <Button
+                        Height="32"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Command="{StaticResource RemoveMusicFolderCommand}"
+                        CommandParameter="{x:Bind}">
+                        <FontIcon FontSize="16" Glyph="&#xe894;" />
+                    </Button>
+                </labs:SettingsCard>
+            </DataTemplate>
+        </ResourceDictionary>
     </Page.Resources>
 
     <interactivity:Interaction.Behaviors>
@@ -220,19 +226,46 @@
                     Margin="0,24,0,4"
                     FontWeight="SemiBold"
                     Text="Advanced" />
-                <labs:SettingsCard Description="Advanced mode allows you to customize libVLC's behavior using command line arguments." Header="Advanced mode">
-                    <ToggleSwitch />
-                </labs:SettingsCard>
-                <labs:SettingsCard
-                    Description="Command line arguments that apply to all media playback. You can set file specific arguments in the file context menu."
-                    Header="Default arguments"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xe756;}">
-                    <TextBox
-                        Width="180"
-                        AcceptsReturn="False"
-                        MaxLength="1024"
-                        PlaceholderText="--sout-all --sout #display" />
-                </labs:SettingsCard>
+                <labs:SettingsExpander
+                    Description="Advanced mode allows you to customize libVLC's behavior using command line arguments."
+                    Header="Advanced mode"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xe756;}"
+                    IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
+                    <labs:SettingsExpander.ItemsHeader>
+                        <muxc:InfoBar
+                            Title="Unapplied changes"
+                            BorderThickness="0"
+                            CornerRadius="0"
+                            IsClosable="False"
+                            IsOpen="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}"
+                            Message="Relaunch the app for changes to take effect"
+                            Severity="Warning">
+                            <!-- <muxc:InfoBar.ActionButton> -->
+                            <!--     <Button Content="Relaunch" /> -->
+                            <!-- </muxc:InfoBar.ActionButton> -->
+                        </muxc:InfoBar>
+                    </labs:SettingsExpander.ItemsHeader>
+                    <ToggleSwitch x:Name="AdvancedModeToggleSwitch" />
+                    <labs:SettingsExpander.Items>
+                        <labs:SettingsCard Header="Global options" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
+                            <labs:SettingsCard.Description>
+                                <TextBlock>
+                                    <Run Text="Command line arguments that apply to all media playback." />
+                                    <Run Text="See" />
+                                    <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
+                                        <Run Text="VLC command-line help" />
+                                    </Hyperlink>
+                                    <Run Text="for the full list of available options." />
+                                </TextBlock>
+                            </labs:SettingsCard.Description>
+                            <TextBox
+                                Width="180"
+                                AcceptsReturn="False"
+                                MaxLength="1024"
+                                PlaceholderText="--option=value" />
+                        </labs:SettingsCard>
+                    </labs:SettingsExpander.Items>
+                </labs:SettingsExpander>
 
                 <TextBlock
                     Margin="0,24,0,4"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -92,11 +92,29 @@
             x:Name="HeaderGrid"
             Grid.Row="0"
             Margin="{StaticResource ContentPageHeaderMargin}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
             <TextBlock
                 x:Name="HeaderText"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
                 MaxLines="2"
                 Style="{StaticResource PageHeaderTextBlockStyle}"
                 Text="{x:Bind strings:Resources.Settings}" />
+            <muxc:InfoBar
+                x:Name="UnappliedChangesInfoBar"
+                Grid.Column="1"
+                MaxWidth="400"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsRelaunchRequired, Mode=OneWay}"
+                Message="Relaunch the app for changes to take effect"
+                Severity="Warning">
+                <!-- <muxc:InfoBar.ActionButton> -->
+                <!--     <Button Content="Relaunch" /> -->
+                <!-- </muxc:InfoBar.ActionButton> -->
+            </muxc:InfoBar>
         </Grid>
 
         <ScrollViewer
@@ -231,21 +249,7 @@
                     Header="Advanced mode"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe756;}"
                     IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
-                    <labs:SettingsExpander.ItemsHeader>
-                        <muxc:InfoBar
-                            Title="Unapplied changes"
-                            BorderThickness="0"
-                            CornerRadius="0"
-                            IsClosable="False"
-                            IsOpen="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}"
-                            Message="Relaunch the app for changes to take effect"
-                            Severity="Warning">
-                            <!-- <muxc:InfoBar.ActionButton> -->
-                            <!--     <Button Content="Relaunch" /> -->
-                            <!-- </muxc:InfoBar.ActionButton> -->
-                        </muxc:InfoBar>
-                    </labs:SettingsExpander.ItemsHeader>
-                    <ToggleSwitch x:Name="AdvancedModeToggleSwitch" />
+                    <ToggleSwitch x:Name="AdvancedModeToggleSwitch" IsOn="{x:Bind ViewModel.AdvancedMode, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
                         <labs:SettingsCard Header="Global options" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                             <labs:SettingsCard.Description>
@@ -262,7 +266,8 @@
                                 Width="180"
                                 AcceptsReturn="False"
                                 MaxLength="1024"
-                                PlaceholderText="--option=value" />
+                                PlaceholderText="--option=value"
+                                Text="{x:Bind ViewModel.GlobalArguments, Mode=TwoWay}" />
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>
@@ -315,6 +320,7 @@
                     <VisualState.Setters>
                         <Setter Target="HeaderGrid.Margin" Value="{StaticResource ContentPageHeaderMarginMinimal}" />
                         <Setter Target="ContentRoot.Padding" Value="{StaticResource ContentPageRightMarginMinimal}" />
+                        <Setter Target="UnappliedChangesInfoBar.MaxWidth" Value="360" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Screenbox.Core.ViewModels;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Screenbox.Core.ViewModels;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -19,11 +20,19 @@ namespace Screenbox.Pages
         internal SettingsPageViewModel ViewModel => (SettingsPageViewModel)DataContext;
 
         internal CommonViewModel Common { get; }
+
+        private string[] VlcCommandLineHelpTextParts { get; }
+
         public SettingsPage()
         {
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<SettingsPageViewModel>();
             Common = Ioc.Default.GetRequiredService<CommonViewModel>();
+            VlcCommandLineHelpTextParts = new string[2];
+            string[] parts = Strings.Resources.VlcCommandLineHelpText
+                .Split("{0}", StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim()).ToArray();
+            Array.Copy(parts, VlcCommandLineHelpTextParts, VlcCommandLineHelpTextParts.Length);
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Behaviors"
+    xmlns:commands="using:Screenbox.Commands"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
@@ -57,6 +58,16 @@
                 <MenuFlyoutItem Command="{StaticResource PlayNextCommand}" CommandParameter="{Binding}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Command="{StaticResource PropertiesCommand}" CommandParameter="{Binding}" />
+                <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
+                <MenuFlyoutItem
+                    CommandParameter="{Binding}"
+                    Icon="{ui:SymbolIcon Symbol=Setting}"
+                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
+                    <MenuFlyoutItem.Command>
+                        <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -189,6 +189,9 @@
     <Compile Include="Controls\SeekBar.xaml.cs">
       <DependentUpon>SeekBar.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\SetOptionsDialog.xaml.cs">
+      <DependentUpon>SetOptionsDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\TimeDisplay.xaml.cs">
       <DependentUpon>TimeDisplay.xaml</DependentUpon>
     </Compile>
@@ -809,6 +812,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\PropertiesDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\SetOptionsDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -149,6 +149,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Commands\SetPlaybackOptionsCommand.cs" />
     <Compile Include="Controls\AcceleratorService.cs" />
     <Compile Include="Controls\AudioTrackSubtitlePicker.xaml.cs">
       <DependentUpon>AudioTrackSubtitlePicker.xaml</DependentUpon>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2299,6 +2299,19 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region FailedToInitializeNotificationTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Failed to initialize
+        /// </summary>
+        public static string FailedToInitializeNotificationTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("FailedToInitializeNotificationTitle");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2485,6 +2498,7 @@ namespace Screenbox.Strings{
             RemoveFolder,
             PendingChanges,
             RelaunchForChangesMessage,
+            FailedToInitializeNotificationTitle,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2104,6 +2104,19 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region SetPlaybackOptions
+        /// <summary>
+        ///   Looks up a localized string similar to: Set playback options
+        /// </summary>
+        public static string SetPlaybackOptions
+        {
+            get
+            {
+                return _resourceLoader.GetString("SetPlaybackOptions");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2275,6 +2288,7 @@ namespace Screenbox.Strings{
             FailedToOpenFilesNotificationTitle,
             OpenUrlPlaceholder,
             OpenConnectedDevicesSettingsButtonText,
+            SetPlaybackOptions,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2195,6 +2195,110 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region SettingsCategoryAdvanced
+        /// <summary>
+        ///   Looks up a localized string similar to: Advanced
+        /// </summary>
+        public static string SettingsCategoryAdvanced
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsCategoryAdvanced");
+            }
+        }
+        #endregion
+
+        #region SettingsAdvancedModeHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: Advanced mode
+        /// </summary>
+        public static string SettingsAdvancedModeHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsAdvancedModeHeader");
+            }
+        }
+        #endregion
+
+        #region SettingsAdvancedModeDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: Advanced mode allows you to customize LibVLC's behavior using command line arguments.
+        /// </summary>
+        public static string SettingsAdvancedModeDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsAdvancedModeDescription");
+            }
+        }
+        #endregion
+
+        #region SettingsGlobalArgumentsHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: Global arguments
+        /// </summary>
+        public static string SettingsGlobalArgumentsHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsGlobalArgumentsHeader");
+            }
+        }
+        #endregion
+
+        #region SettingsGlobalArgumentsDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: Command line arguments that apply to all media playback.
+        /// </summary>
+        public static string SettingsGlobalArgumentsDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsGlobalArgumentsDescription");
+            }
+        }
+        #endregion
+
+        #region RemoveFolder
+        /// <summary>
+        ///   Looks up a localized string similar to: Remove folder
+        /// </summary>
+        public static string RemoveFolder
+        {
+            get
+            {
+                return _resourceLoader.GetString("RemoveFolder");
+            }
+        }
+        #endregion
+
+        #region PendingChanges
+        /// <summary>
+        ///   Looks up a localized string similar to: Pending changes
+        /// </summary>
+        public static string PendingChanges
+        {
+            get
+            {
+                return _resourceLoader.GetString("PendingChanges");
+            }
+        }
+        #endregion
+
+        #region RelaunchForChangesMessage
+        /// <summary>
+        ///   Looks up a localized string similar to: Relaunch the app for changes to take effect
+        /// </summary>
+        public static string RelaunchForChangesMessage
+        {
+            get
+            {
+                return _resourceLoader.GetString("RelaunchForChangesMessage");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2373,6 +2477,14 @@ namespace Screenbox.Strings{
             SetPlaybackOptionsHelpTextLine2,
             VlcCommandLineHelpLink,
             VlcCommandLineHelpText,
+            SettingsCategoryAdvanced,
+            SettingsAdvancedModeHeader,
+            SettingsAdvancedModeDescription,
+            SettingsGlobalArgumentsHeader,
+            SettingsGlobalArgumentsDescription,
+            RemoveFolder,
+            PendingChanges,
+            RelaunchForChangesMessage,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2117,6 +2117,84 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region Set
+        /// <summary>
+        ///   Looks up a localized string similar to: Set
+        /// </summary>
+        public static string Set
+        {
+            get
+            {
+                return _resourceLoader.GetString("Set");
+            }
+        }
+        #endregion
+
+        #region SetAndPlay
+        /// <summary>
+        ///   Looks up a localized string similar to: Set and Play
+        /// </summary>
+        public static string SetAndPlay
+        {
+            get
+            {
+                return _resourceLoader.GetString("SetAndPlay");
+            }
+        }
+        #endregion
+
+        #region SetPlaybackOptionsHelpTextLine1
+        /// <summary>
+        ///   Looks up a localized string similar to: Set VLC options that apply to a stream.
+        /// </summary>
+        public static string SetPlaybackOptionsHelpTextLine1
+        {
+            get
+            {
+                return _resourceLoader.GetString("SetPlaybackOptionsHelpTextLine1");
+            }
+        }
+        #endregion
+
+        #region SetPlaybackOptionsHelpTextLine2
+        /// <summary>
+        ///   Looks up a localized string similar to: Some options may only be set globally.
+        /// </summary>
+        public static string SetPlaybackOptionsHelpTextLine2
+        {
+            get
+            {
+                return _resourceLoader.GetString("SetPlaybackOptionsHelpTextLine2");
+            }
+        }
+        #endregion
+
+        #region VlcCommandLineHelpLink
+        /// <summary>
+        ///   Looks up a localized string similar to: VLC command-line help
+        /// </summary>
+        public static string VlcCommandLineHelpLink
+        {
+            get
+            {
+                return _resourceLoader.GetString("VlcCommandLineHelpLink");
+            }
+        }
+        #endregion
+
+        #region VlcCommandLineHelpText
+        /// <summary>
+        ///   Looks up a localized string similar to: See {0} for the full list of available options.
+        /// </summary>
+        public static string VlcCommandLineHelpText
+        {
+            get
+            {
+                return _resourceLoader.GetString("VlcCommandLineHelpText");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2289,6 +2367,12 @@ namespace Screenbox.Strings{
             OpenUrlPlaceholder,
             OpenConnectedDevicesSettingsButtonText,
             SetPlaybackOptions,
+            Set,
+            SetAndPlay,
+            SetPlaybackOptionsHelpTextLine1,
+            SetPlaybackOptionsHelpTextLine2,
+            VlcCommandLineHelpLink,
+            VlcCommandLineHelpText,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1,5 +1,110 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -580,5 +685,29 @@
   <data name="VlcCommandLineHelpText" xml:space="preserve">
     <value>See {0} for the full list of available options.</value>
     <comment>{0} = VLC command-line help</comment>
+  </data>
+  <data name="SettingsCategoryAdvanced" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="SettingsAdvancedModeHeader" xml:space="preserve">
+    <value>Advanced mode</value>
+  </data>
+  <data name="SettingsAdvancedModeDescription" xml:space="preserve">
+    <value>Advanced mode allows you to customize LibVLC's behavior using command line arguments.</value>
+  </data>
+  <data name="SettingsGlobalArgumentsHeader" xml:space="preserve">
+    <value>Global arguments</value>
+  </data>
+  <data name="SettingsGlobalArgumentsDescription" xml:space="preserve">
+    <value>Command line arguments that apply to all media playback.</value>
+  </data>
+  <data name="RemoveFolder" xml:space="preserve">
+    <value>Remove folder</value>
+  </data>
+  <data name="PendingChanges" xml:space="preserve">
+    <value>Pending changes</value>
+  </data>
+  <data name="RelaunchForChangesMessage" xml:space="preserve">
+    <value>Relaunch the app for changes to take effect</value>
   </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -710,4 +710,7 @@
   <data name="RelaunchForChangesMessage" xml:space="preserve">
     <value>Relaunch the app for changes to take effect</value>
   </data>
+  <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
+    <value>Failed to initialize</value>
+  </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -559,4 +559,7 @@
   <data name="OpenConnectedDevicesSettingsButtonText" xml:space="preserve">
     <value>Open Connected Devices settings</value>
   </data>
+  <data name="SetPlaybackOptions" xml:space="preserve">
+    <value>Set playback options</value>
+  </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -562,4 +562,23 @@
   <data name="SetPlaybackOptions" xml:space="preserve">
     <value>Set playback options</value>
   </data>
+  <data name="Set" xml:space="preserve">
+    <value>Set</value>
+  </data>
+  <data name="SetAndPlay" xml:space="preserve">
+    <value>Set and Play</value>
+  </data>
+  <data name="SetPlaybackOptionsHelpTextLine1" xml:space="preserve">
+    <value>Set VLC options that apply to a stream.</value>
+  </data>
+  <data name="SetPlaybackOptionsHelpTextLine2" xml:space="preserve">
+    <value>Some options may only be set globally.</value>
+  </data>
+  <data name="VlcCommandLineHelpLink" xml:space="preserve">
+    <value>VLC command-line help</value>
+  </data>
+  <data name="VlcCommandLineHelpText" xml:space="preserve">
+    <value>See {0} for the full list of available options.</value>
+    <comment>{0} = VLC command-line help</comment>
+  </data>
 </root>


### PR DESCRIPTION
Closes #42

Add the ability to set VLC CLI options per media file or globally.

Setting playback options for media:
![image](https://github.com/huynhsontung/Screenbox/assets/31434093/3bf49a93-91fb-4269-aa24-87a53b50e056)
![image](https://github.com/huynhsontung/Screenbox/assets/31434093/312db268-6edc-49a1-813e-7decee65844f)

Setting global arguments in Settings:
![image](https://github.com/huynhsontung/Screenbox/assets/31434093/d6a9a664-dc2a-4e3a-bc36-414ab020e516)
