### PR TITLE
feat: add Compact Overlay keystroke

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -478,6 +478,9 @@
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}">
                 <Button.KeyboardAccelerators>
+                    <KeyboardAccelerator
+                        Key="M"
+                        Modifiers="Control" />
                     <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsCompact, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
                 <FontIcon x:Name="CompactOverlayButtonIcon" Glyph="&#xEE49;" />

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -478,9 +478,7 @@
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}">
                 <Button.KeyboardAccelerators>
-                    <KeyboardAccelerator
-                        Key="M"
-                        Modifiers="Control" />
+                    <KeyboardAccelerator Key="M" Modifiers="Control" />
                     <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsCompact, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
                 <FontIcon x:Name="CompactOverlayButtonIcon" Glyph="&#xEE49;" />

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -301,7 +301,11 @@
                     Command="{x:Bind ViewModel.ToggleCompactLayoutCommand}"
                     Icon="{ui:FontIcon Glyph=&#xEE49;}"
                     Text="{x:Bind strings:Resources.CompactOverlayToggle(ViewModel.IsCompact), Mode=OneWay}"
-                    Visibility="Collapsed" />
+                    Visibility="Collapsed">
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="M" Modifiers="Control" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
                 <MenuFlyoutItem
                     x:Name="FullscreenMenuItem"
                     Command="{x:Bind ViewModel.ToggleFullscreenCommand}"


### PR DESCRIPTION
Added another keyboard shortcut to Compact Overlay, again mirroring the inbox app.

### To be confirmed
- [ ] Is Ctrl+M global or relative to locale