### PR TITLE
fix: controls visibility with gamepad

### DIFF
--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -310,6 +310,15 @@
             </interactivity:Interaction.Behaviors>
         </controls:PlayerElement>
 
+        <Button
+            x:Name="HiddenButton"
+            Grid.Row="0"
+            Grid.Column="0"
+            Click="{x:Bind ViewModel.RevealControls}"
+            Opacity="0"
+            Style="{x:Null}"
+            Visibility="Collapsed" />
+
         <controls1:ConstrainedBox
             x:Name="AlbumArtPanel"
             Grid.Row="1"
@@ -474,7 +483,7 @@
             IsMinimal="{x:Bind GetControlsIsMinimal(ViewModel.PlayerVisibility), Mode=OneWay}" />
 
         <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="ControlsVisibilityStates">
+            <VisualStateGroup x:Name="ControlsVisibilityStates" CurrentStateChanged="ControlsVisibilityStates_OnCurrentStateChanged">
                 <VisualStateGroup.Transitions>
                     <VisualTransition GeneratedDuration="0:0:0.167" From="ControlsHidden">
                         <VisualTransition.GeneratedEasingFunction>
@@ -494,6 +503,7 @@
                         <Setter Target="TitleBarArea.Opacity" Value="0" />
                         <Setter Target="PlayerControls.Opacity" Value="0" />
                         <Setter Target="PlayerControlsBackground.Opacity" Value="0" />
+                        <Setter Target="HiddenButton.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -84,9 +84,9 @@ namespace Screenbox.Pages
                 case VirtualKey.GamepadMenu:
                     VideoView.ContextFlyout.ShowAt(VideoView, new FlyoutShowOptions() { Placement = FlyoutPlacementMode.Auto });
                     break;
-                case VirtualKey.Escape when ViewModel.ControlsHidden:
-                case VirtualKey.GamepadB when ViewModel.ControlsHidden:
-                    ViewModel.ControlsHidden = false;
+                case VirtualKey.Escape when ViewModel is { ControlsHidden: false, ViewMode: WindowViewMode.Default }:
+                case VirtualKey.GamepadB when ViewModel is { ControlsHidden: false, ViewMode: WindowViewMode.Default }:
+                    ViewModel.TryHideControls();
                     break;
                 default:
                     return;
@@ -188,6 +188,11 @@ namespace Screenbox.Pages
             {
                 case nameof(PlayerPageViewModel.ControlsHidden):
                     VisualStateManager.GoToState(this, ViewModel.ControlsHidden ? "ControlsHidden" : "ControlsVisible", true);
+                    if (!ViewModel.ControlsHidden)
+                    {
+                        PlayerControls.FocusFirstButton();
+                    }
+
                     break;
                 case nameof(PlayerPageViewModel.ViewMode):
                     switch (ViewModel.ViewMode)
@@ -375,6 +380,14 @@ namespace Screenbox.Pages
             // Must be queued in Dispatcher or risk losing focus right after
             await Dispatcher.RunAsync(CoreDispatcherPriority.Low,
                 () => PlayerControls.FocusFirstButton(FocusState.Programmatic));
+        }
+
+        private void ControlsVisibilityStates_OnCurrentStateChanged(object sender, VisualStateChangedEventArgs e)
+        {
+            if (e.NewState.Name == nameof(ControlsHidden))
+            {
+                HiddenButton.Focus(FocusState.Programmatic);
+            }
         }
     }
 }


### PR DESCRIPTION
Hide controls using (B) and reveal with (A) like many other media players on Xbox.