### PR TITLE
fix: override seekbar keyboard interaction

### DIFF
--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Uwp.UI;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Playback;
@@ -20,6 +21,7 @@ namespace Screenbox.Core.ViewModels
         IRecipient<TimeChangeOverrideMessage>,
         IRecipient<ChangeTimeRequestMessage>,
         IRecipient<PlayerControlsVisibilityChangedMessage>,
+        IRecipient<PlayerVisibilityChangedMessage>,
         IRecipient<MediaPlayerChangedMessage>
     {
         [ObservableProperty] private double _length;
@@ -35,6 +37,8 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private double _previewTime;
 
         [ObservableProperty] private bool _shouldShowPreview;
+
+        [ObservableProperty] private bool _shouldHandleKeyDown;
 
         private IMediaPlayer? _mediaPlayer;
 
@@ -54,9 +58,15 @@ namespace Screenbox.Core.ViewModels
             _originalPositionTimer = _dispatcherQueue.CreateTimer();
             _originalPositionTimer.IsRepeating = false;
             _shouldShowPreview = true;
+            _shouldHandleKeyDown = true;
 
             // Activate the view model's messenger
             IsActive = true;
+        }
+
+        public void Receive(PlayerVisibilityChangedMessage message)
+        {
+            ShouldHandleKeyDown = message.Value != PlayerVisibilityState.Visible;
         }
 
         public void Receive(PlayerControlsVisibilityChangedMessage message)

--- a/Screenbox/Controls/CustomSlider.cs
+++ b/Screenbox/Controls/CustomSlider.cs
@@ -1,0 +1,22 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Screenbox.Controls;
+internal class CustomSlider : Slider
+{
+    public static readonly DependencyProperty IsKeyDownEnabledProperty = DependencyProperty.Register(
+        nameof(IsKeyDownEnabled), typeof(bool), typeof(CustomSlider), new PropertyMetadata(true));
+
+    public bool IsKeyDownEnabled
+    {
+        get => (bool)GetValue(IsKeyDownEnabledProperty);
+        set => SetValue(IsKeyDownEnabledProperty, value);
+    }
+
+    protected override void OnKeyDown(KeyRoutedEventArgs e)
+    {
+        if (!IsKeyDownEnabled && !IsFocusEngaged) return;
+        base.OnKeyDown(e);
+    }
+}

--- a/Screenbox/Controls/SeekBar.xaml
+++ b/Screenbox/Controls/SeekBar.xaml
@@ -37,13 +37,14 @@
             Foreground="Orange"
             IsIndeterminate="True"
             Visibility="{x:Bind ViewModel.BufferingVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
-        <Slider
+        <local:CustomSlider
             x:Name="SeekBarSlider"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             Background="{x:Bind Background, Mode=OneWay}"
             Foreground="{x:Bind Foreground, Mode=OneWay}"
             IsEnabled="{x:Bind ViewModel.IsSeekable, Mode=OneWay, FallbackValue=False}"
+            IsKeyDownEnabled="{x:Bind ViewModel.ShouldHandleKeyDown, Mode=OneWay}"
             LargeChange="10000"
             Loaded="SeekBarSlider_OnLoaded"
             Maximum="{x:Bind ViewModel.Length, Mode=OneWay, FallbackValue=0}"
@@ -51,6 +52,7 @@
             PointerExited="SeekBarSlider_OnPointerExited"
             SizeChanged="SeekBarSlider_OnSizeChanged"
             SmallChange="1000"
+            Style="{StaticResource DefaultSliderStyle}"
             ThumbToolTipValueConverter="{StaticResource HumanizedDurationConverter}"
             ValueChanged="{x:Bind ViewModel.OnSeekBarValueChanged}"
             Visibility="{x:Bind ProgressOnly, Mode=OneWay, Converter={StaticResource InverseBoolToVisibilityConverter}}"

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -160,6 +160,7 @@
       <DependentUpon>ChapterProgressBar.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\CustomNavigationView.cs" />
+    <Compile Include="Controls\CustomSlider.cs" />
     <Compile Include="Controls\Extensions\ListViewExtensions.cs" />
     <Compile Include="Controls\Interactions\AdaptiveLayoutBreakpointsBehavior.cs" />
     <Compile Include="Controls\Interactions\BringIntoViewWithOffsetBehavior.cs" />


### PR DESCRIPTION
Use custom `Slider` to disable keyboard handling when player is expanded.