### PR TITLE
feat: richer navigation context

### DIFF
--- a/Screenbox.Core/Common/NavigationMetadata.cs
+++ b/Screenbox.Core/Common/NavigationMetadata.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+
+using System;
+
+namespace Screenbox.Core;
+
+public class NavigationMetadata
+{
+    public Type RootPageType { get; }
+
+    public object? Parameter { get; }
+
+    public NavigationMetadata(Type rootPageType, object? parameter)
+    {
+        RootPageType = rootPageType;
+        Parameter = parameter;
+    }
+}

--- a/Screenbox.Core/Common/NavigationMetadata.cs
+++ b/Screenbox.Core/Common/NavigationMetadata.cs
@@ -4,15 +4,15 @@ using System;
 
 namespace Screenbox.Core;
 
-public class NavigationMetadata
+internal class NavigationMetadata
 {
-    public Type RootPageType { get; }
+    public Type RootViewModelType { get; }
 
     public object? Parameter { get; }
 
-    public NavigationMetadata(Type rootPageType, object? parameter)
+    public NavigationMetadata(Type rootViewModelType, object? parameter)
     {
-        RootPageType = rootPageType;
+        RootViewModelType = rootViewModelType;
         Parameter = parameter;
     }
 }

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Common\IDialog.cs" />
     <Compile Include="Common\IPropertiesDialog.cs" />
     <Compile Include="Common\IVlcLoginDialog.cs" />
+    <Compile Include="Common\NavigationMetadata.cs" />
     <Compile Include="Enums\ResourceName.cs" />
     <Compile Include="Enums\ManipulationLock.cs" />
     <Compile Include="Enums\NotificationLevel.cs" />

--- a/Screenbox.Core/Services/INavigationService.cs
+++ b/Screenbox.Core/Services/INavigationService.cs
@@ -9,5 +9,6 @@ namespace Screenbox.Core.Services
         void Navigate(Type vmType, object? parameter = null);
         void NavigateChild(Type parentVmType, Type targetVmType, object? parameter = null);
         void NavigateExisting(Type vmType, object? parameter = null);
+        bool TryGetPageType(Type vmType, out Type pageType);
     }
 }

--- a/Screenbox.Core/Services/NavigationService.cs
+++ b/Screenbox.Core/Services/NavigationService.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Screenbox.Core;
 
 namespace Screenbox.Core.Services
 {
@@ -12,7 +11,7 @@ namespace Screenbox.Core.Services
     {
         private readonly Dictionary<Type, Type> _vmPageMapping;
 
-        public NavigationService(params KeyValuePair<Type,Type>[] mapping)
+        public NavigationService(params KeyValuePair<Type, Type>[] mapping)
         {
             _vmPageMapping = new Dictionary<Type, Type>(mapping);
         }
@@ -40,7 +39,7 @@ namespace Screenbox.Core.Services
                 if (page.ContentSourcePageType == parentPageType && page.FrameContent is IContentFrame childPage)
                 {
                     childPage.NavigateContent(targetPageType, parameter);
-                    break;
+                    return;
                 }
 
                 page = page.FrameContent as IContentFrame;

--- a/Screenbox.Core/Services/NavigationService.cs
+++ b/Screenbox.Core/Services/NavigationService.cs
@@ -16,6 +16,11 @@ namespace Screenbox.Core.Services
             _vmPageMapping = new Dictionary<Type, Type>(mapping);
         }
 
+        public bool TryGetPageType(Type vmType, out Type pageType)
+        {
+            return _vmPageMapping.TryGetValue(vmType, out pageType);
+        }
+
         public void Navigate(Type vmType, object? parameter = null)
         {
             if (!_vmPageMapping.TryGetValue(vmType, out Type pageType)) return;

--- a/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
@@ -1,15 +1,15 @@
 ﻿#nullable enable
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using Windows.Storage.FileProperties;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Uwp.UI;
 using Screenbox.Core.Messages;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.Storage.FileProperties;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -48,6 +48,16 @@ namespace Screenbox.Core.ViewModels
             SortedItems = new AdvancedCollectionView();
             SortedItems.SortDescriptions.Add(new SortDescription(nameof(MediaViewModel.MusicProperties),
                 SortDirection.Ascending, new TrackNumberComparer()));
+        }
+
+        public void OnNavigatedTo(object? parameter)
+        {
+            Source = parameter switch
+            {
+                NavigationMetadata { Parameter: AlbumViewModel source } => source,
+                AlbumViewModel source => source,
+                _ => throw new ArgumentException("Navigation parameter is not an album")
+            };
         }
 
         async partial void OnSourceChanged(AlbumViewModel value)

--- a/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
@@ -1,13 +1,13 @@
 ﻿#nullable enable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -34,6 +34,16 @@ namespace Screenbox.Core.ViewModels
         {
             _source = new ArtistViewModel();
             _albums = new List<IGrouping<AlbumViewModel?, MediaViewModel>>();
+        }
+
+        public void OnNavigatedTo(object? parameter)
+        {
+            Source = parameter switch
+            {
+                NavigationMetadata { Parameter: ArtistViewModel source } => source,
+                ArtistViewModel source => source,
+                _ => throw new ArgumentException("Navigation parameter is not an artist")
+            };
         }
 
         async partial void OnSourceChanged(ArtistViewModel value)

--- a/Screenbox.Core/ViewModels/CommonViewModel.cs
+++ b/Screenbox.Core/ViewModels/CommonViewModel.cs
@@ -73,14 +73,16 @@ namespace Screenbox.Core.ViewModels
         private void OpenAlbum(AlbumViewModel? album)
         {
             if (album == null) return;
-            _navigationService.Navigate(typeof(AlbumDetailsPageViewModel), album);
+            _navigationService.Navigate(typeof(AlbumDetailsPageViewModel),
+                new NavigationMetadata(typeof(MusicPageViewModel), album));
         }
 
         [RelayCommand]
         private void OpenArtist(ArtistViewModel? artist)
         {
             if (artist == null) return;
-            _navigationService.Navigate(typeof(ArtistDetailsPageViewModel), artist);
+            _navigationService.Navigate(typeof(ArtistDetailsPageViewModel),
+                new NavigationMetadata(typeof(MusicPageViewModel), artist));
         }
 
         [RelayCommand(CanExecute = nameof(HasMedia))]

--- a/Screenbox.Core/ViewModels/FolderListViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderListViewPageViewModel.cs
@@ -21,7 +21,7 @@ namespace Screenbox.Core.ViewModels
         protected override void Navigate(object? parameter = null)
         {
             _navigationService.NavigateExisting(typeof(FolderListViewPageViewModel),
-                new NavigationMetadata(NavData?.RootPageType ?? typeof(FolderListViewPageViewModel), parameter));
+                new NavigationMetadata(NavData?.RootViewModelType ?? typeof(FolderListViewPageViewModel), parameter));
         }
     }
 }

--- a/Screenbox.Core/ViewModels/FolderListViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderListViewPageViewModel.cs
@@ -20,7 +20,8 @@ namespace Screenbox.Core.ViewModels
 
         protected override void Navigate(object? parameter = null)
         {
-            _navigationService.NavigateExisting(typeof(FolderListViewPageViewModel), parameter);
+            _navigationService.NavigateExisting(typeof(FolderListViewPageViewModel),
+                new NavigationMetadata(NavData?.RootPageType ?? typeof(FolderListViewPageViewModel), parameter));
         }
     }
 }

--- a/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
@@ -77,15 +77,17 @@ namespace Screenbox.Core.ViewModels
                     Breadcrumbs = breadcrumbs;
                     await FetchFolderContentAsync(breadcrumbs.Last());
                     break;
-                case StorageFolder folder:
-                    Breadcrumbs = new[] { folder };
-                    await FetchFolderContentAsync(folder);
-                    break;
                 case StorageLibrary library:
                     await FetchFolderContentAsync(library);
                     break;
                 case StorageFileQueryResult queryResult:
                     await FetchQueryItemAsync(queryResult);
+                    break;
+                case "VideosLibrary":   // Special case for VideosPage
+                    // VideosPage needs to serialize navigation state so it cannot set nav data
+                    Breadcrumbs = new[] { KnownFolders.VideosLibrary };
+                    NavData = new NavigationMetadata(typeof(VideosPageViewModel), Breadcrumbs);
+                    await FetchFolderContentAsync(Breadcrumbs[0]);
                     break;
             }
         }

--- a/Screenbox.Core/ViewModels/FolderViewWithHeaderPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewWithHeaderPageViewModel.cs
@@ -15,7 +15,7 @@ namespace Screenbox.Core.ViewModels
         public IReadOnlyList<StorageFolder> Breadcrumbs { get; private set; }
 
         private readonly INavigationService _navigationService;
-        private NavigationMetadata? _source;
+        private NavigationMetadata? _navData;
 
         public FolderViewWithHeaderPageViewModel(INavigationService navigationService)
         {
@@ -27,7 +27,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (parameter is NavigationMetadata { Parameter: IReadOnlyList<StorageFolder> breadcrumbs } source)
             {
-                _source = source;
+                _navData = source;
                 Breadcrumbs = breadcrumbs;
             }
         }
@@ -35,8 +35,23 @@ namespace Screenbox.Core.ViewModels
         public void OnBreadcrumbBarItemClicked(int index)
         {
             IReadOnlyList<StorageFolder> crumbs = Breadcrumbs.Take(index + 1).ToArray();
-            _navigationService.Navigate(typeof(FolderViewWithHeaderPageViewModel),
-                new NavigationMetadata(_source?.RootPageType ?? typeof(FolderViewWithHeaderPageViewModel), crumbs));
+            if (_navData != null)
+            {
+                if (index == 0)
+                {
+                    _navigationService.Navigate(_navData.RootViewModelType);
+                }
+                else
+                {
+                    _navigationService.Navigate(typeof(FolderViewWithHeaderPageViewModel),
+                        new NavigationMetadata(_navData.RootViewModelType, crumbs));
+                }
+            }
+            else
+            {
+                _navigationService.Navigate(typeof(FolderViewWithHeaderPageViewModel),
+                    new NavigationMetadata(typeof(FolderViewWithHeaderPageViewModel), crumbs));
+            }
         }
     }
 }

--- a/Screenbox.Core/ViewModels/FolderViewWithHeaderPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewWithHeaderPageViewModel.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 
+using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Screenbox.Core.Services;
 using Windows.Storage;
 
 namespace Screenbox.Core.ViewModels
@@ -15,6 +15,7 @@ namespace Screenbox.Core.ViewModels
         public IReadOnlyList<StorageFolder> Breadcrumbs { get; private set; }
 
         private readonly INavigationService _navigationService;
+        private NavigationMetadata? _source;
 
         public FolderViewWithHeaderPageViewModel(INavigationService navigationService)
         {
@@ -24,8 +25,9 @@ namespace Screenbox.Core.ViewModels
 
         public void OnNavigatedTo(object? parameter)
         {
-            if (parameter is IReadOnlyList<StorageFolder> breadcrumbs)
+            if (parameter is NavigationMetadata { Parameter: IReadOnlyList<StorageFolder> breadcrumbs } source)
             {
+                _source = source;
                 Breadcrumbs = breadcrumbs;
             }
         }
@@ -33,7 +35,8 @@ namespace Screenbox.Core.ViewModels
         public void OnBreadcrumbBarItemClicked(int index)
         {
             IReadOnlyList<StorageFolder> crumbs = Breadcrumbs.Take(index + 1).ToArray();
-            _navigationService.Navigate(typeof(FolderViewWithHeaderPageViewModel), crumbs);
+            _navigationService.Navigate(typeof(FolderViewWithHeaderPageViewModel),
+                new NavigationMetadata(_source?.RootPageType ?? typeof(FolderViewWithHeaderPageViewModel), crumbs));
         }
     }
 }

--- a/Screenbox.Core/ViewModels/MainPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿#nullable enable
+
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
@@ -56,6 +58,13 @@ namespace Screenbox.Core.ViewModels
         public void Receive(NavigationViewDisplayModeRequestMessage message)
         {
             message.Reply(NavigationViewDisplayMode);
+        }
+
+        public bool TryGetPageTypeFromParameter(object? parameter, out Type pageType)
+        {
+            pageType = typeof(object);
+            return parameter is NavigationMetadata metadata &&
+                   _navigationService.TryGetPageType(metadata.RootViewModelType, out pageType);
         }
 
         public void ProcessGamepadKeyDown(KeyRoutedEventArgs args)

--- a/Screenbox.Core/ViewModels/VideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/VideosPageViewModel.cs
@@ -6,7 +6,6 @@ using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.System;
@@ -18,22 +17,23 @@ namespace Screenbox.Core.ViewModels
     {
         public ObservableCollection<StorageFolder> Breadcrumbs { get; }
 
+        public object NavigationParameter { get; }
+
         [ObservableProperty] private bool _hasVideos;
 
         private bool HasLibrary => _libraryService.VideosLibrary != null;
 
-        private readonly INavigationService _navigationService;
         private readonly ILibraryService _libraryService;
         private readonly DispatcherQueue _dispatcherQueue;
 
-        public VideosPageViewModel(INavigationService navigationService, ILibraryService libraryService)
+        public VideosPageViewModel(ILibraryService libraryService)
         {
-            _navigationService = navigationService;
             _libraryService = libraryService;
             _libraryService.VideosLibraryContentChanged += OnVideosLibraryContentChanged;
             _hasVideos = true;
             Breadcrumbs = new ObservableCollection<StorageFolder> { KnownFolders.VideosLibrary };
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+            NavigationParameter = new NavigationMetadata(typeof(VideosPageViewModel), KnownFolders.VideosLibrary);
         }
 
         public void UpdateVideos()
@@ -46,12 +46,6 @@ namespace Screenbox.Core.ViewModels
         {
             IReadOnlyList<StorageFolder>? crumbs = e.Parameter as IReadOnlyList<StorageFolder>;
             UpdateBreadcrumbs(crumbs);
-        }
-
-        public void OnBreadcrumbBarItemClicked(int index)
-        {
-            IReadOnlyList<StorageFolder> crumbs = Breadcrumbs.Take(index + 1).ToArray();
-            _navigationService.NavigateChild(typeof(VideosPageViewModel), typeof(FolderViewPageViewModel), crumbs);
         }
 
         private void UpdateBreadcrumbs(IReadOnlyList<StorageFolder>? crumbs)

--- a/Screenbox/Pages/AlbumDetailsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml.cs
@@ -1,8 +1,14 @@
 ﻿#nullable enable
 
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
+using Screenbox.Core;
+using Screenbox.Core.ViewModels;
 using System;
 using System.ComponentModel;
 using System.Numerics;
+using System.Text;
 using Windows.Storage.Streams;
 using Windows.UI;
 using Windows.UI.Composition;
@@ -11,14 +17,8 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.Toolkit.Uwp.UI;
-using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
-using Screenbox.Core.ViewModels;
 using EF = Microsoft.Toolkit.Uwp.UI.Animations.Expressions.ExpressionFunctions;
 using NavigationViewDisplayMode = Windows.UI.Xaml.Controls.NavigationViewDisplayMode;
-using Screenbox.Core;
-using System.Text;
-using CommunityToolkit.Mvvm.DependencyInjection;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -53,10 +53,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            if (e.Parameter is not AlbumViewModel album)
-                throw new ArgumentException("Navigation parameter is not an album");
-
-            ViewModel.Source = album;
+            ViewModel.OnNavigatedTo(e.Parameter);
         }
 
         private void AlbumDetailsPage_OnLoaded(object sender, RoutedEventArgs e)
@@ -78,7 +75,7 @@ namespace Screenbox.Pages
 
             // Get references to our property sets for use with ExpressionNodes
             ManipulationPropertySetReferenceNode scrollingProperties = _scrollerPropertySet.GetSpecializedReference<ManipulationPropertySetReferenceNode>();
-            
+
             CreateHeaderAnimation(scrollingProperties.Translation.Y);
             MediaViewModel firstSong = ViewModel.Source.RelatedSongs[0];
             if (firstSong.ThumbnailSource != null)
@@ -150,7 +147,7 @@ namespace Screenbox.Pages
             artistNameVisual.StartAnimation("Opacity", textFadeAnimation);
             textFadeAnimation.SetScalarParameter("fadeThreshold", 0.2f);
             subtextVisual.StartAnimation("Opacity", textFadeAnimation);
-            
+
 
             // Get the backing visuals for the button containers so that their properties can be animated
             Visual buttonVisual = ElementCompositionPreview.GetElementVisual(ButtonPanel);

--- a/Screenbox/Pages/ArtistDetailsPage.xaml.cs
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml.cs
@@ -1,16 +1,16 @@
-﻿using System;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
+using Screenbox.Core;
+using Screenbox.Core.ViewModels;
+using System;
+using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.Toolkit.Uwp.UI;
-using Microsoft.Toolkit.Uwp.UI.Animations.Expressions;
-using Windows.UI.Composition;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Screenbox.Core.ViewModels;
 using EF = Microsoft.Toolkit.Uwp.UI.Animations.Expressions.ExpressionFunctions;
 using NavigationViewDisplayMode = Windows.UI.Xaml.Controls.NavigationViewDisplayMode;
-using Screenbox.Core;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -42,10 +42,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            if (e.Parameter is not ArtistViewModel artist)
-                throw new ArgumentException("Navigation parameter is not an album");
-
-            ViewModel.Source = artist;
+            ViewModel.OnNavigatedTo(e.Parameter);
         }
 
         private void ArtistDetailsPage_OnLoaded(object sender, RoutedEventArgs e)

--- a/Screenbox/Pages/FolderListViewPage.xaml.cs
+++ b/Screenbox/Pages/FolderListViewPage.xaml.cs
@@ -1,8 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
-using CommunityToolkit.Mvvm.DependencyInjection;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Controls.Interactions;
 using Screenbox.Core.ViewModels;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -27,7 +27,7 @@ namespace Screenbox.Pages
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            await ViewModel.FetchContentAsync(e.Parameter);
+            await ViewModel.OnNavigatedTo(e.Parameter);
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/FolderViewPage.xaml.cs
+++ b/Screenbox/Pages/FolderViewPage.xaml.cs
@@ -1,8 +1,8 @@
-﻿using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
-using CommunityToolkit.Mvvm.DependencyInjection;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Controls.Interactions;
 using Screenbox.Core.ViewModels;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -27,7 +27,7 @@ namespace Screenbox.Pages
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            await ViewModel.FetchContentAsync(e.Parameter);
+            await ViewModel.OnNavigatedTo(e.Parameter);
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -236,14 +236,26 @@ namespace Screenbox.Pages
             }
             else if (ContentFrame.SourcePageType != null)
             {
-                KeyValuePair<string, Type> item = _pages.FirstOrDefault(p => p.Value == e.SourcePageType);
+                muxc.NavigationViewItem? selectedItem = GetNavigationItemForPageType(e.SourcePageType);
 
-                muxc.NavigationViewItem? selectedItem = NavView.MenuItems
-                    .OfType<muxc.NavigationViewItem>()
-                    .FirstOrDefault(n => n.Tag.Equals(item.Key));
+                if (selectedItem == null && e.Parameter is NavigationMetadata metadata)
+                {
+                    selectedItem = GetNavigationItemForPageType(metadata.RootPageType);
+                }
 
                 NavView.SelectedItem = selectedItem;
             }
+        }
+
+        private muxc.NavigationViewItem? GetNavigationItemForPageType(Type pageType)
+        {
+            KeyValuePair<string, Type> item = _pages.FirstOrDefault(p => p.Value == pageType);
+
+            muxc.NavigationViewItem? selectedItem = NavView.MenuItems
+                .OfType<muxc.NavigationViewItem>()
+                .FirstOrDefault(n => n.Tag.Equals(item.Key));
+
+            return selectedItem;
         }
 
         private void NavView_OnDisplayModeChanged(muxc.NavigationView sender, muxc.NavigationViewDisplayModeChangedEventArgs args)

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -238,9 +238,9 @@ namespace Screenbox.Pages
             {
                 muxc.NavigationViewItem? selectedItem = GetNavigationItemForPageType(e.SourcePageType);
 
-                if (selectedItem == null && e.Parameter is NavigationMetadata metadata)
+                if (selectedItem == null && ViewModel.TryGetPageTypeFromParameter(e.Parameter, out Type pageType))
                 {
-                    selectedItem = GetNavigationItemForPageType(metadata.RootPageType);
+                    selectedItem = GetNavigationItemForPageType(pageType);
                 }
 
                 NavView.SelectedItem = selectedItem;

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -166,7 +166,6 @@
                     x:Name="BreadcrumbBar"
                     Grid.Row="0"
                     Margin="0,10,0,12"
-                    ItemClicked="BreadcrumbBar_OnItemClicked"
                     ItemTemplate="{StaticResource BreadcrumbItemTemplate}"
                     ItemsSource="{x:Bind ViewModel.Breadcrumbs}"
                     XYFocusDown="{x:Bind ContentFrame}"

--- a/Screenbox/Pages/VideosPage.xaml.cs
+++ b/Screenbox/Pages/VideosPage.xaml.cs
@@ -49,9 +49,15 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            LibraryNavView.SelectedItem = Common.NavigationStates.TryGetValue(typeof(VideosPage), out string tag)
-                ? LibraryNavView.MenuItems[tag == "folders" ? 0 : 1]
-                : LibraryNavView.MenuItems[0];
+            if (Common.NavigationStates.TryGetValue(typeof(VideosPage), out string navigationState))
+            {
+                ContentFrame.SetNavigationState(navigationState);
+                UpdateSelectedNavItem(ContentSourcePageType);
+            }
+            else
+            {
+                LibraryNavView.SelectedItem = LibraryNavView.MenuItems[0];
+            }
 
             ViewModel.UpdateVideos();
         }
@@ -59,8 +65,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             base.OnNavigatedFrom(e);
-            Common.NavigationStates[typeof(VideosPage)] =
-                LibraryNavView.SelectedItem == LibraryNavView.MenuItems[0] ? "folders" : "all";
+            Common.NavigationStates[typeof(VideosPage)] = ContentFrame.GetNavigationState();
             if (ContentFrame.Content is FolderViewPage page)
             {
                 page.ViewModel.Clean();
@@ -96,7 +101,7 @@ namespace Screenbox.Pages
             // Only navigate if the selected page isn't currently loaded.
             if (pageType is not null && preNavPageType != pageType)
             {
-                ContentFrame.Navigate(pageType, ViewModel.NavigationParameter, new SuppressNavigationTransitionInfo());
+                ContentFrame.Navigate(pageType, "VideosLibrary", new SuppressNavigationTransitionInfo());
             }
         }
 

--- a/Screenbox/Pages/VideosPage.xaml.cs
+++ b/Screenbox/Pages/VideosPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Microsoft.UI.Xaml.Controls;
 using Screenbox.Core;
 using Screenbox.Core.ViewModels;
 using System;
@@ -97,8 +96,7 @@ namespace Screenbox.Pages
             // Only navigate if the selected page isn't currently loaded.
             if (pageType is not null && preNavPageType != pageType)
             {
-                NavigationMetadata metadata = new(typeof(VideosPage), "VideosLibrary");
-                ContentFrame.Navigate(pageType, metadata, new SuppressNavigationTransitionInfo());
+                ContentFrame.Navigate(pageType, ViewModel.NavigationParameter, new SuppressNavigationTransitionInfo());
             }
         }
 
@@ -121,11 +119,6 @@ namespace Screenbox.Pages
                 .FirstOrDefault(n => n.Tag.Equals(item.Key));
 
             LibraryNavView.SelectedItem = selectedItem;
-        }
-
-        private void BreadcrumbBar_OnItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
-        {
-            ViewModel.OnBreadcrumbBarItemClicked(args.Index);
         }
     }
 }

--- a/Screenbox/Pages/VideosPage.xaml.cs
+++ b/Screenbox/Pages/VideosPage.xaml.cs
@@ -50,15 +50,9 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            if (Common.NavigationStates.TryGetValue(typeof(VideosPage), out string navigationState))
-            {
-                ContentFrame.SetNavigationState(navigationState);
-                UpdateSelectedNavItem(ContentSourcePageType);
-            }
-            else
-            {
-                LibraryNavView.SelectedItem = LibraryNavView.MenuItems[0];
-            }
+            LibraryNavView.SelectedItem = Common.NavigationStates.TryGetValue(typeof(VideosPage), out string tag)
+                ? LibraryNavView.MenuItems[tag == "folders" ? 0 : 1]
+                : LibraryNavView.MenuItems[0];
 
             ViewModel.UpdateVideos();
         }
@@ -66,7 +60,8 @@ namespace Screenbox.Pages
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             base.OnNavigatedFrom(e);
-            Common.NavigationStates[typeof(VideosPage)] = ContentFrame.GetNavigationState();
+            Common.NavigationStates[typeof(VideosPage)] =
+                LibraryNavView.SelectedItem == LibraryNavView.MenuItems[0] ? "folders" : "all";
             if (ContentFrame.Content is FolderViewPage page)
             {
                 page.ViewModel.Clean();
@@ -102,7 +97,8 @@ namespace Screenbox.Pages
             // Only navigate if the selected page isn't currently loaded.
             if (pageType is not null && preNavPageType != pageType)
             {
-                ContentFrame.Navigate(pageType, "VideosLibrary", new SuppressNavigationTransitionInfo());
+                NavigationMetadata metadata = new(typeof(VideosPage), "VideosLibrary");
+                ContentFrame.Navigate(pageType, metadata, new SuppressNavigationTransitionInfo());
             }
         }
 


### PR DESCRIPTION
Create `NavigationMetadata` to carry root page association across navigations.

Clicking the first item in Video Folders breadcrumb bar should go back to the Videos main page. `NavigationMetadata` allows `FolderViewWithHeaderPage` to be aware of it being navigated from `VideosPage`.