### PR TITLE
fix: media starts where last one ends

### DIFF
--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -214,7 +214,7 @@ namespace Screenbox.Core.ViewModels
                 _dispatcherQueue.TryEnqueue(() =>
                 {
                     // Check if Time is close enough to Length. Sometimes a new file is already loaded at this point.
-                    if (Math.Abs(Length - Time) < 400)
+                    if (Length - Time is > 0 and < 400)
                     {
                         // Round Time to Length to avoid gap at the end
                         Time = Length;

--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -211,7 +211,15 @@ namespace Screenbox.Core.ViewModels
         {
             if (!_timeChangeOverride)
             {
-                _dispatcherQueue.TryEnqueue(() => Time = Length);
+                _dispatcherQueue.TryEnqueue(() =>
+                {
+                    // Check if Time is close enough to Length. Sometimes a new file is already loaded at this point.
+                    if (Math.Abs(Length - Time) < 400)
+                    {
+                        // Round Time to Length to avoid gap at the end
+                        Time = Length;
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
When one media ends, the rounding logic that sets seek bar value to media duration doesn't check if a new media has been loaded or not. 