### PR TITLE
fix: seek bar value propagation logic

### DIFF
--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -79,7 +79,10 @@ namespace Screenbox.Core.Playback
                 if (VlcPlayer.State == VLCState.Ended)
                 {
                     if (value == NaturalDuration)
+                    {
+                        _position = value;
                         return;
+                    }
 
                     Replay();
                 }

--- a/Screenbox/Controls/SeekBar.xaml
+++ b/Screenbox/Controls/SeekBar.xaml
@@ -56,6 +56,6 @@
             ThumbToolTipValueConverter="{StaticResource HumanizedDurationConverter}"
             ValueChanged="{x:Bind ViewModel.OnSeekBarValueChanged}"
             Visibility="{x:Bind ProgressOnly, Mode=OneWay, Converter={StaticResource InverseBoolToVisibilityConverter}}"
-            Value="{x:Bind ViewModel.Time, Mode=TwoWay}" />
+            Value="{x:Bind ViewModel.Time, Mode=OneWay}" />
     </Grid>
 </UserControl>

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -169,7 +169,8 @@ namespace Screenbox.Pages
         private void SeekBarPointerReleasedEventHandler(object s, PointerRoutedEventArgs e)
         {
             ViewModel.SeekBarPointerInteracting = false;
-            PlayerControls.FocusFirstButton();
+            if (ViewModel.PlayerVisibility == PlayerVisibilityState.Visible)
+                PlayerControls.FocusFirstButton();
         }
 
         private void SeekBarPointerExitedEventHandler(object s, PointerRoutedEventArgs e)


### PR DESCRIPTION
Separate setter logic for UI Time value `SeekBarViewModel.Time` and the player's Position value `IMediaPlayer.Position` to avoid accidental value changes for both sides.