### PR TITLE
ci: disable ARM bundling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,8 @@ jobs:
         -restore
       env:
         BuildMode: StoreUpload
-        BuildPlatforms: x86|x64|ARM
-        PackageDir: C:\DeployOutput\Packages
+        BuildPlatforms: x86|x64
+        PackageDir: C:\DeployOutput
     
     - name: Create store-upload artifact
       uses: actions/upload-artifact@v3
@@ -96,27 +96,8 @@ jobs:
       with:
         name: store-upload
         path: |
-          C:\DeployOutput\Packages\*.msixupload
-          C:\DeployOutput\Packages\*.appxupload
-
-    # Only allow sideload x64 due to VS packaging issue
-    # See: https://developercommunity.visualstudio.com/t/get-merge-failure-for-shared-merged-pri-file-0x800/107928
-    - name: Build sideload
-      if: github.ref_type == 'tag'
-      run: |
-        msbuild Screenbox.sln `
-        -v:d `
-        -p:Configuration=Release `
-        -p:Platform=x64 `
-        -p:AppxBundle=Always `
-        -p:AppxBundlePlatforms="$env:BuildPlatforms" `
-        -p:UapAppxPackageBuildMode=$env:BuildMode `
-        -p:AppxPackageDir=$env:PackageDir `
-        -p:AppxPackageSigningEnabled=false
-      env:
-        BuildMode: StoreUpload
-        BuildPlatforms: x64
-        PackageDir: C:\DeployOutput
+          C:\DeployOutput\*.msixupload
+          C:\DeployOutput\*.appxupload
 
     - name: Create sideload artifact
       uses: actions/upload-artifact@v3

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -23,7 +23,7 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>False</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
   </PropertyGroup>


### PR DESCRIPTION
Stop building ARM version into the appxbundle due to PRI merging issue. String resources got messed up as a result.

Related: #123 
https://developercommunity.visualstudio.com/t/get-merge-failure-for-shared-merged-pri-file-0x800/107928

Screenshot of WACK raising error
![image](https://github.com/huynhsontung/Screenbox/assets/31434093/905f5738-bd29-49ee-9c37-81fe6be34462)

