### PR TITLE
fix: no video subtext string change

### DIFF
--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -678,8 +678,8 @@
           <target state="translated">我们找不到任何视频</target>
         </trans-unit>
         <trans-unit id="NoVideosPanelSubtext" translate="yes" xml:space="preserve">
-          <source>Your music library doesn't contain any music content.</source>
-          <target state="translated">您的音乐资料库不包含任何音乐内容。</target>
+          <source>Your video library doesn't contain any video content.</source>
+          <target state="needs-review-translation">您的音乐资料库不包含任何音乐内容。</target>
         </trans-unit>
         <trans-unit id="OpenPrivacySettingsButtonText" translate="yes" xml:space="preserve">
           <source>Open privacy settings</source>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -1518,7 +1518,7 @@ namespace Screenbox.Strings{
 
         #region NoVideosPanelSubtext
         /// <summary>
-        ///   Looks up a localized string similar to: Your music library doesn't contain any music content.
+        ///   Looks up a localized string similar to: Your video library doesn't contain any video content.
         /// </summary>
         public static string NoVideosPanelSubtext
         {

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -523,7 +523,7 @@
     <value>We couldn't find any videos</value>
   </data>
   <data name="NoVideosPanelSubtext" xml:space="preserve">
-    <value>Your music library doesn't contain any music content.</value>
+    <value>Your video library doesn't contain any video content.</value>
   </data>
   <data name="OpenPrivacySettingsButtonText" xml:space="preserve">
     <value>Open privacy settings</value>


### PR DESCRIPTION
Minor fix.

I think the other translation made the same mistake. Passed through a translator and see the same.
Not fluent or knowledgeable enough to attempt to fix it.