### PR TITLE
fix: Convert text to resource string

### DIFF
--- a/Screenbox/Controls/OpenUrlDialog.xaml
+++ b/Screenbox/Controls/OpenUrlDialog.xaml
@@ -6,8 +6,8 @@
     xmlns:local="using:Screenbox.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="Open a URL"
-    CloseButtonText="Close"
+    Title="{strings:Resources Key=OpenUrlTitle}"
+    CloseButtonText="{strings:Resources Key=Close}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind CanOpen(UrlBox.Text), Mode=OneWay}"
     PrimaryButtonText="{strings:Resources Key=Open}"
@@ -15,6 +15,6 @@
     mc:Ignorable="d">
 
     <Grid>
-        <TextBox x:Name="UrlBox" PlaceholderText="Enter the URL for a file or stream" />
+        <TextBox x:Name="UrlBox" PlaceholderText="{strings:Resources Key=EnterUrlPlaceholder}" />
     </Grid>
 </ContentDialog>

--- a/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
+++ b/Screenbox/MultilingualResources/Screenbox.zh-Hans.xlf
@@ -861,6 +861,14 @@
           <source>Failed to open file(s)</source>
           <target state="translated">无法打开文件</target>
         </trans-unit>
+        <trans-unit id="OpenUrlTitle" translate="yes" xml:space="preserve">
+          <source>Open a URL</source>
+          <target state="new"></target>
+        </trans-unit>
+        <trans-unit id="EnterUrlPlaceholder" translate="yes" xml:space="preserve">
+          <source>Enter the URL for a file or stream</source>
+          <target state="new"></target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Screenbox/Strings/af-ZA/Resources.resw
+++ b/Screenbox/Strings/af-ZA/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ar-SA/Resources.resw
+++ b/Screenbox/Strings/ar-SA/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ca-ES/Resources.resw
+++ b/Screenbox/Strings/ca-ES/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/cs-CZ/Resources.resw
+++ b/Screenbox/Strings/cs-CZ/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/da-DK/Resources.resw
+++ b/Screenbox/Strings/da-DK/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/de-DE/Resources.resw
+++ b/Screenbox/Strings/de-DE/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/el-GR/Resources.resw
+++ b/Screenbox/Strings/el-GR/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2078,6 +2078,32 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region OpenUrlTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Open a URL
+        /// </summary>
+        public static string OpenUrlTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("OpenUrlTitle");
+            }
+        }
+        #endregion
+
+        #region EnterUrlPlaceholder
+        /// <summary>
+        ///   Looks up a localized string similar to: Enter the URL for a file or stream
+        /// </summary>
+        public static string EnterUrlPlaceholder
+        {
+            get
+            {
+                return _resourceLoader.GetString("EnterUrlPlaceholder");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2247,6 +2273,8 @@ namespace Screenbox.Strings{
             CriticalError,
             CriticalErrorDirect3D11NotAvailable,
             FailedToOpenFilesNotificationTitle,
+            OpenUrlTitle,
+            EnterUrlPlaceholder,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/es-ES/Resources.resw
+++ b/Screenbox/Strings/es-ES/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/fi-FI/Resources.resw
+++ b/Screenbox/Strings/fi-FI/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/fr-FR/Resources.resw
+++ b/Screenbox/Strings/fr-FR/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/he-IL/Resources.resw
+++ b/Screenbox/Strings/he-IL/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/hu-HU/Resources.resw
+++ b/Screenbox/Strings/hu-HU/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/it-IT/Resources.resw
+++ b/Screenbox/Strings/it-IT/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ja-JP/Resources.resw
+++ b/Screenbox/Strings/ja-JP/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ko-KR/Resources.resw
+++ b/Screenbox/Strings/ko-KR/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/nl-NL/Resources.resw
+++ b/Screenbox/Strings/nl-NL/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/no-NO/Resources.resw
+++ b/Screenbox/Strings/no-NO/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/pl-PL/Resources.resw
+++ b/Screenbox/Strings/pl-PL/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/pt-BR/Resources.resw
+++ b/Screenbox/Strings/pt-BR/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/pt-PT/Resources.resw
+++ b/Screenbox/Strings/pt-PT/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ro-RO/Resources.resw
+++ b/Screenbox/Strings/ro-RO/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ru-RU/Resources.resw
+++ b/Screenbox/Strings/ru-RU/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/sr-SP/Resources.resw
+++ b/Screenbox/Strings/sr-SP/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/sv-SE/Resources.resw
+++ b/Screenbox/Strings/sv-SE/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/tr-TR/Resources.resw
+++ b/Screenbox/Strings/tr-TR/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/uk-UA/Resources.resw
+++ b/Screenbox/Strings/uk-UA/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/vi/Resources.resw
+++ b/Screenbox/Strings/vi/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/zh-Hans/Resources.resw
+++ b/Screenbox/Strings/zh-Hans/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>无法打开文件</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>

--- a/Screenbox/Strings/zh-Hant/Resources.resw
+++ b/Screenbox/Strings/zh-Hant/Resources.resw
@@ -553,4 +553,10 @@
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>
+  <data name="OpenUrlTitle" xml:space="preserve">
+    <value>Open a URL</value>
+  </data>
+  <data name="EnterUrlPlaceholder" xml:space="preserve">
+    <value>Enter the URL for a file or stream</value>
+  </data>
 </root>


### PR DESCRIPTION
Converted the remaining missing strings on the 'Open URL dialog' View.