### PR TITLE
fix: chapter not updating properly

### DIFF
--- a/Screenbox.Core/Playback/PlaybackItem.cs
+++ b/Screenbox.Core/Playback/PlaybackItem.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 
-using System;
 using LibVLCSharp.Shared;
 using Screenbox.Core.Services;
+using System;
 
 namespace Screenbox.Core.Playback
 {
@@ -34,7 +34,7 @@ namespace Screenbox.Core.Playback
             AudioTracks = new PlaybackAudioTrackList(media);
             VideoTracks = new PlaybackVideoTrackList(media);
             SubtitleTracks = new PlaybackSubtitleTrackList(media);
-            Chapters = new PlaybackChapterList();
+            Chapters = new PlaybackChapterList(this);
             StartTime = TimeSpan.Zero;
         }
     }

--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -1,10 +1,7 @@
 ﻿#nullable enable
 
 using LibVLCSharp.Shared;
-using LibVLCSharp.Shared.Structures;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Windows.Devices.Enumeration;
 using Windows.Foundation;
 using Windows.Media.Core;
@@ -331,26 +328,6 @@ namespace Screenbox.Core.Playback
                 NaturalVideoHeight = py;
                 NaturalVideoSizeChanged?.Invoke(this, null);
             }
-
-            if (PlaybackItem == null) return;
-
-            // Update chapter list
-            if (VlcPlayer.ChapterCount > 0)
-            {
-                List<ChapterDescription> chapterDescriptions = new();
-                for (int i = 0; i < VlcPlayer.TitleCount; i++)
-                {
-                    chapterDescriptions.AddRange(VlcPlayer.FullChapterDescriptions(i));
-                }
-
-                PlaybackItem.Chapters.Load(chapterDescriptions);
-            }
-            else
-            {
-                PlaybackItem.Chapters.Load(VlcPlayer.FullChapterDescriptions());
-            }
-
-            Chapter = PlaybackItem.Chapters.FirstOrDefault();
         }
 
         private void VlcPlayer_EndReached(object sender, EventArgs e)

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -27,7 +27,7 @@ namespace Screenbox.Core.ViewModels
 
         public ArtistViewModel? MainArtist => Artists.FirstOrDefault();
 
-        public PlaybackItem? Item => GetPlaybackItem();
+        public PlaybackItem? Item => _item ?? GetPlaybackItem();
 
         public bool ShouldDisplayTrackNumber => TrackNumber > 0;    // Helper for binding
 
@@ -127,24 +127,22 @@ namespace Screenbox.Core.ViewModels
             return new MediaViewModel(this);
         }
 
-        public PlaybackItem? GetPlaybackItem()
+        private PlaybackItem? GetPlaybackItem()
         {
-            if (!_loaded)
+            if (_loaded) return _item;
+            _loaded = true;
+            try
             {
-                _loaded = true;
-                try
-                {
-                    _item = new PlaybackItem(Source, _mediaService);
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // Coding error. Rethrow.
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    Messenger.Send(new MediaLoadFailedNotificationMessage(e.Message, Location));
-                }
+                _item = new PlaybackItem(Source, _mediaService);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Coding error. Rethrow.
+                throw;
+            }
+            catch (Exception e)
+            {
+                Messenger.Send(new MediaLoadFailedNotificationMessage(e.Message, Location));
             }
 
             return _item;

--- a/Screenbox/Controls/ChapterProgressBar.xaml
+++ b/Screenbox/Controls/ChapterProgressBar.xaml
@@ -18,11 +18,11 @@
 
             <DataTemplate x:Key="ItemTemplate" x:DataType="viewModels:ChapterViewModel">
                 <muxc:ProgressBar
-                    Width="{x:Bind Width, Mode=OneWay}"
-                    Maximum="{x:Bind Maximum, Mode=OneWay}"
-                    Minimum="{x:Bind Minimum, Mode=OneWay}"
+                    Width="{Binding Width}"
+                    Maximum="{Binding Maximum}"
+                    Minimum="{Binding Minimum}"
                     Style="{StaticResource NoAnimationProgressBar}"
-                    Value="{x:Bind Value, Mode=OneWay}" />
+                    Value="{Binding Value}" />
             </DataTemplate>
 
             <muxc:StackLayout


### PR DESCRIPTION
- Fixed thread conflict can occur when updating the chapter list. [Exception](https://appcenter.ms/users/highpine/apps/Screenbox/crashes/errors/2598909319u/overview). Initiate chapter list update from UI thread.
- Fixed chapter progress bar item in ChapterProgressBar sometimes has Min and Max value drift.