### PR TITLE
chore: Update to deprecated glyphs

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -310,7 +310,7 @@
                 <MenuFlyoutItem
                     x:Name="FullscreenMenuItem"
                     Command="{x:Bind ViewModel.ToggleFullscreenCommand}"
-                    Icon="{ui:FontIcon Glyph=&#xE1D9;}"
+                    Icon="{ui:FontIcon Glyph=&#xE740;}"
                     Text="{x:Bind strings:Resources.FullscreenToggle(ViewModel.IsFullscreen), Mode=OneWay}"
                     Visibility="Collapsed">
                     <MenuFlyoutItem.KeyboardAccelerators>
@@ -371,7 +371,7 @@
                 Command="{x:Bind ViewModel.Playlist.PreviousCommand}"
                 CornerRadius="4,0,0,4"
                 Style="{StaticResource PlayerButtonStyle}">
-                <FontIcon Glyph="&#xE100;" />
+                <FontIcon Glyph="&#xE892;" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="PageUp" />
                 </Button.KeyboardAccelerators>
@@ -383,7 +383,7 @@
                 Command="{x:Bind ViewModel.Playlist.NextCommand}"
                 CornerRadius="0,4,4,0"
                 Style="{StaticResource PlayerButtonStyle}">
-                <FontIcon Glyph="&#xE101;" />
+                <FontIcon Glyph="&#xE893;" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="PageDown" />
                 </Button.KeyboardAccelerators>
@@ -500,7 +500,7 @@
                     <KeyboardAccelerator Key="F" />
                     <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsFullscreen, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
-                <FontIcon x:Name="FullscreenButtonIcon" Glyph="&#xE1D9;" />
+                <FontIcon x:Name="FullscreenButtonIcon" Glyph="&#xE740;" />
             </Button>
 
             <Button
@@ -510,7 +510,7 @@
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 ToolTipService.ToolTip="{x:Bind strings:Resources.More}">
-                <FontIcon Glyph="&#xE10C;" />
+                <FontIcon Glyph="&#xE712;" />
             </Button>
         </StackPanel>
 
@@ -560,7 +560,7 @@
                         <StateTrigger IsActive="{x:Bind ViewModel.IsFullscreen, Mode=OneWay}" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="FullscreenButtonIcon.Glyph" Value="&#xE1D8;" />
+                        <Setter Target="FullscreenButtonIcon.Glyph" Value="&#xE73F;" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="Compact">

--- a/Screenbox/Converters/PlayPauseGlyphConverter.cs
+++ b/Screenbox/Converters/PlayPauseGlyphConverter.cs
@@ -8,10 +8,10 @@ internal class PlayPauseGlyphConverter : IValueConverter
     {
         if (value is bool b)
         {
-            return b ? "\uE103" : "\uE102";
+            return b ? "\uE769" : "\uE768";
         }
 
-        return "\uE102";
+        return "\uE768";
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
According to @Jay-o-Way findings [here](https://github.com/microsoft/PowerToys/issues/10331), those deprecated glyphs ([Segoe Fluent Icons font](https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font#icon-list)) cause issues with CJK languages.

Maybe affected #123.