### PR TITLE
style: about section visual refresh

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -54,6 +54,8 @@
                     <Thickness x:Key="ContentPageScrollBarMargin">0,0,0,100</Thickness>
                     <Thickness x:Key="ContentPageBottomMargin">0,0,0,106</Thickness>
                     <x:Double x:Key="ContentPageBottomPaddingHeight">106</x:Double>
+                    <Thickness x:Key="HyperlinkButtonInlineMargin">-12,0,0,0</Thickness>
+
                     <FontFamily x:Key="ScreenboxCustomIconsFontFamily">ms-appx:///Assets/Screenbox-Custom-Icons.ttf#Screenbox-Custom-Icons</FontFamily>
                     <x:Double x:Key="DefaultIconFontSize">16</x:Double>
                     <x:Double x:Key="PanelIconFontSize">126</x:Double>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -290,7 +290,7 @@
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkSourceCode}" NavigateUri="https://github.com/huynhsontung/Screenbox" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkDiscord}" NavigateUri="https://discord.gg/HZPZXjANxz" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkSponsor}" NavigateUri="https://github.com/sponsors/huynhsontung" />
-                                <HyperlinkButton Content="Help translate" NavigateUri="https://crowdin.com/project/screenbox" />
+                                <HyperlinkButton Content="{strings:Resources Key=HyperlinkTranslate}" NavigateUri="https://crowdin.com/project/screenbox" />
                             </StackPanel>
                         </labs:SettingsCard>
                         <labs:SettingsCard
@@ -318,9 +318,9 @@
                                 <TextBlock
                                     Margin="0,8,8,8"
                                     FontWeight="SemiBold"
-                                    Text="Related links" />
-                                <HyperlinkButton Content="Privacy policy" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
-                                <HyperlinkButton Content="License" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
+                                    Text="{strings:Resources Key=RelatedLinks}" />
+                                <HyperlinkButton Content="{strings:Resources Key=PrivacyPolicy}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
+                                <HyperlinkButton Content="{strings:Resources Key=License}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
                             </StackPanel>
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -31,7 +31,10 @@
             <CornerRadius x:Key="SettingsCardBottomCornerRadius">0,0,3,3</CornerRadius>
 
             <!--  Section Header text style  -->
-            <Style x:Key="SettingsSectionHeaderTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyStrongTextBlockStyle}">
+            <Style
+                x:Key="SettingsSectionHeaderTextBlockStyle"
+                BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+                TargetType="TextBlock">
                 <Setter Property="Margin" Value="1,28,0,4" />
             </Style>
 
@@ -249,7 +252,10 @@
                     IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                     <ToggleSwitch x:Name="AdvancedModeToggleSwitch" IsOn="{x:Bind ViewModel.AdvancedMode, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
-                        <labs:SettingsCard Header="{strings:Resources Key=SettingsGlobalArgumentsHeader}" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
+                        <labs:SettingsCard
+                            CornerRadius="{StaticResource SettingsCardBottomCornerRadius}"
+                            Header="{strings:Resources Key=SettingsGlobalArgumentsHeader}"
+                            IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                             <labs:SettingsCard.Description>
                                 <TextBlock>
                                     <Run Text="{strings:Resources Key=SettingsGlobalArgumentsDescription}" /><LineBreak /><Run Text="{x:Bind VlcCommandLineHelpTextParts[0]}" />

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -281,7 +281,8 @@
                     Margin="0,0,0,24"
                     Description="Made with ❤️ by Tung Huynh"
                     Header="{strings:Resources Key=AppFriendlyName}"
-                    HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/Square44x44Logo.scale-200.png}">
+                    HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/Square44x44Logo.scale-200.png}"
+                    IsExpanded="True">
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         IsTextSelectionEnabled="True"
@@ -298,7 +299,7 @@
                         <labs:SettingsCard
                             HorizontalContentAlignment="Left"
                             ContentAlignment="Vertical"
-                            Description="Huge thanks to the contributors of the following libraries:"
+                            Description="Huge thanks to the contributors of the following libraries"
                             Header="Open source libraries">
                             <VariableSizedWrapGrid
                                 Margin="{StaticResource HyperlinkButtonInlineMargin}"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -25,6 +25,16 @@
             <x:Double x:Key="ToggleSwitchPreContentMargin">4</x:Double>
             <x:Double x:Key="ToggleSwitchPostContentMargin">4</x:Double>
             <x:Double x:Key="SettingsCardWrapThreshold">400</x:Double>
+            <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+            <!--  SettingsExpander bottom corners radius temporary (hopefully) fix  -->
+            <CornerRadius x:Key="SettingsCardBottomCornerRadius">0,0,3,3</CornerRadius>
+
+            <!--  Section Header text style  -->
+            <Style x:Key="SettingsSectionHeaderTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyStrongTextBlockStyle}">
+                <Setter Property="Margin" Value="1,28,0,4" />
+            </Style>
+
             <converters:ResourceNameToResourceStringConverter x:Key="ResourceNameToResourceStringConverter" />
             <muxc:StackLayout
                 x:Name="VerticalStackLayout"
@@ -35,16 +45,14 @@
                 x:Key="RemoveMusicFolderCommand"
                 Command="{x:Bind ViewModel.RemoveMusicFolderCommand}"
                 Description="{strings:Resources Key=RemoveFolder}"
-                IconSource="{ui:FontIconSource FontSize=16,
-                                               Glyph=&#xe894;}"
+                IconSource="{ui:FontIconSource Glyph=&#xe894;}"
                 Label="{strings:Resources Key=Remove}" />
 
             <XamlUICommand
                 x:Key="RemoveVideosFolderCommand"
                 Command="{x:Bind ViewModel.RemoveVideosFolderCommand}"
                 Description="{strings:Resources Key=RemoveFolder}"
-                IconSource="{ui:FontIconSource FontSize=16,
-                                               Glyph=&#xe894;}"
+                IconSource="{ui:FontIconSource Glyph=&#xe894;}"
                 Label="{strings:Resources Key=Remove}" />
 
             <DataTemplate x:Key="VideosLibraryLocationTemplate" x:DataType="storage:StorageFolder">
@@ -56,7 +64,7 @@
                         BorderThickness="0"
                         Command="{StaticResource RemoveVideosFolderCommand}"
                         CommandParameter="{x:Bind}">
-                        <FontIcon FontSize="16" Glyph="&#xe894;" />
+                        <FontIcon Glyph="&#xe894;" />
                     </Button>
                 </labs:SettingsCard>
             </DataTemplate>
@@ -70,7 +78,7 @@
                         BorderThickness="0"
                         Command="{StaticResource RemoveMusicFolderCommand}"
                         CommandParameter="{x:Bind}">
-                        <FontIcon FontSize="16" Glyph="&#xe894;" />
+                        <FontIcon Glyph="&#xe894;" />
                     </Button>
                 </labs:SettingsCard>
             </DataTemplate>
@@ -120,7 +128,7 @@
                 Margin="{x:Bind Common.FooterBottomPaddingMargin, Mode=OneWay}"
                 Padding="{StaticResource ContentPageRightMargin}"
                 SizeChanged="ContentRoot_OnSizeChanged"
-                Spacing="4">
+                Spacing="{StaticResource SettingsCardSpacing}">
                 <StackPanel.Transitions>
                     <EntranceThemeTransition />
                 </StackPanel.Transitions>
@@ -130,8 +138,10 @@
                 <interactivity:Interaction.Behaviors>
                     <interactions:BringIntoViewWithOffsetBehavior FromBottom="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
                 </interactivity:Interaction.Behaviors>
+
+                <!--  Libraries section  -->
                 <TextBlock
-                    Margin="0,8,0,4"
+                    Margin="1,8,0,4"
                     FontWeight="SemiBold"
                     Text="{strings:Resources Key=SettingsCategoryLibraries}"
                     Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}" />
@@ -164,26 +174,22 @@
                     </Button>
                 </labs:SettingsExpander>
 
-                <TextBlock
-                    Margin="0,24,0,4"
-                    FontWeight="SemiBold"
-                    Text="{strings:Resources Key=SettingsCategoryGeneral}" />
+                <!--  General section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
                 <labs:SettingsExpander
                     Description="{strings:Resources Key=SettingsShowRecentDescription}"
                     Header="{strings:Resources Key=SettingsShowRecentHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe8b7;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRecent, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
-                        <labs:SettingsCard Header="{strings:Resources Key=SettingsClearRecentHeader}">
+                        <labs:SettingsCard CornerRadius="{StaticResource SettingsCardBottomCornerRadius}" Header="{strings:Resources Key=SettingsClearRecentHeader}">
                             <Button Command="{x:Bind ViewModel.ClearRecentHistoryCommand}" Content="{strings:Resources Key=Clear}" />
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>
 
-                <TextBlock
-                    Margin="0,24,0,4"
-                    FontWeight="SemiBold"
-                    Text="{strings:Resources Key=SettingsCategoryPlayer}" />
+                <!--  Player section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />
                 <labs:SettingsCard
                     Description="{strings:Resources Key=SettingsAutoResizeDescription}"
                     Header="{strings:Resources Key=SettingsAutoResizeHeader}"
@@ -228,16 +234,14 @@
                         <labs:SettingsCard ContentAlignment="Left">
                             <CheckBox Content="{strings:Resources Key=SettingsGestureVolume}" IsChecked="{x:Bind ViewModel.PlayerVolumeGesture, Mode=TwoWay}" />
                         </labs:SettingsCard>
-                        <labs:SettingsCard ContentAlignment="Left">
+                        <labs:SettingsCard ContentAlignment="Left" CornerRadius="{StaticResource SettingsCardBottomCornerRadius}">
                             <CheckBox Content="{strings:Resources Key=SettingsGestureTap}" IsChecked="{x:Bind ViewModel.PlayerTapGesture, Mode=TwoWay}" />
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>
 
-                <TextBlock
-                    Margin="0,24,0,4"
-                    FontWeight="SemiBold"
-                    Text="{strings:Resources Key=SettingsCategoryAdvanced}" />
+                <!--  Advanced section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryAdvanced}" />
                 <labs:SettingsExpander
                     Description="{strings:Resources Key=SettingsAdvancedModeDescription}"
                     Header="{strings:Resources Key=SettingsAdvancedModeHeader}"
@@ -265,36 +269,59 @@
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>
 
-                <TextBlock
-                    Margin="0,24,0,4"
-                    FontWeight="SemiBold"
-                    Text="{strings:Resources Key=SettingsCategoryAbout}" />
-                <labs:SettingsCard
+                <!--  About section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryAbout}" />
+                <labs:SettingsExpander
                     Margin="0,0,0,24"
-                    HorizontalContentAlignment="Left"
-                    ContentAlignment="Vertical"
+                    Description="Made with ❤️ by Tung Huynh"
                     Header="{strings:Resources Key=AppFriendlyName}"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xe946;}">
-                    <labs:SettingsCard.Description>
-                        <TextBlock><Run Text="{x:Bind strings:Resources.VersionText}" />
-                            <LineBreak />
-                            Made with ❤️ by Tung Huynh</TextBlock>
-                    </labs:SettingsCard.Description>
-                    <StackPanel Margin="0,8,0,0" Orientation="Vertical">
-                        <HyperlinkButton
-                            Margin="-12,0,0,0"
-                            Content="{strings:Resources Key=HyperlinkSourceCode}"
-                            NavigateUri="https://github.com/huynhsontung/Screenbox" />
-                        <HyperlinkButton
-                            Margin="-12,0,0,0"
-                            Content="{strings:Resources Key=HyperlinkDiscord}"
-                            NavigateUri="https://discord.gg/HZPZXjANxz" />
-                        <HyperlinkButton
-                            Margin="-12,0,0,0"
-                            Content="{strings:Resources Key=HyperlinkSponsor}"
-                            NavigateUri="https://github.com/sponsors/huynhsontung" />
-                    </StackPanel>
-                </labs:SettingsCard>
+                    HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/Square44x44Logo.scale-200.png}">
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        IsTextSelectionEnabled="True"
+                        Text="{x:Bind strings:Resources.VersionText}" />
+                    <labs:SettingsExpander.Items>
+                        <labs:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
+                            <StackPanel Margin="{StaticResource HyperlinkButtonInlineMargin}" Orientation="Vertical">
+                                <HyperlinkButton Content="{strings:Resources Key=HyperlinkSourceCode}" NavigateUri="https://github.com/huynhsontung/Screenbox" />
+                                <HyperlinkButton Content="{strings:Resources Key=HyperlinkDiscord}" NavigateUri="https://discord.gg/HZPZXjANxz" />
+                                <HyperlinkButton Content="{strings:Resources Key=HyperlinkSponsor}" NavigateUri="https://github.com/sponsors/huynhsontung" />
+                                <HyperlinkButton Content="Help translate" NavigateUri="https://crowdin.com/project/screenbox" />
+                            </StackPanel>
+                        </labs:SettingsCard>
+                        <labs:SettingsCard
+                            HorizontalContentAlignment="Left"
+                            ContentAlignment="Vertical"
+                            Description="Huge thanks to the contributors of the following libraries:"
+                            Header="Open source libraries">
+                            <VariableSizedWrapGrid
+                                Margin="{StaticResource HyperlinkButtonInlineMargin}"
+                                ItemWidth="272"
+                                Orientation="Horizontal">
+                                <HyperlinkButton Content="LibVLCSharp" NavigateUri="https://github.com/videolan/libvlcsharp" />
+                                <HyperlinkButton Content="protobuf-net" NavigateUri="https://github.com/protobuf-net/protobuf-net" />
+                                <HyperlinkButton Content="ReswPlus" NavigateUri="https://github.com/DotNetPlus/ReswPlus" />
+                                <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit" />
+                                <HyperlinkButton Content="Windows Community Toolkit Labs" NavigateUri="https://github.com/CommunityToolkit/Labs-Windows" />
+                                <HyperlinkButton Content="WinUI" NavigateUri="https://github.com/microsoft/microsoft-ui-xaml" />
+                            </VariableSizedWrapGrid>
+                        </labs:SettingsCard>
+                        <labs:SettingsCard
+                            Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                            ContentAlignment="Left"
+                            CornerRadius="{StaticResource SettingsCardBottomCornerRadius}">
+                            <StackPanel Margin="-40,0,0,0" Orientation="Horizontal">
+                                <TextBlock
+                                    Margin="0,8,8,8"
+                                    FontWeight="SemiBold"
+                                    Text="Related links" />
+                                <HyperlinkButton Content="Privacy policy" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
+                                <HyperlinkButton Content="License" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
+                            </StackPanel>
+                        </labs:SettingsCard>
+                    </labs:SettingsExpander.Items>
+                </labs:SettingsExpander>
+
             </StackPanel>
         </ScrollViewer>
 

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -285,43 +285,23 @@
                         IsTextSelectionEnabled="True"
                         Text="{x:Bind strings:Resources.VersionText}" />
                     <labs:SettingsExpander.Items>
-                        <labs:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
-                            <StackPanel Margin="{StaticResource HyperlinkButtonInlineMargin}" Orientation="Vertical">
+                        <labs:SettingsCard
+                            HorizontalContentAlignment="Left"
+                            ContentAlignment="Vertical"
+                            CornerRadius="{StaticResource SettingsCardBottomCornerRadius}"
+                            Header="{strings:Resources Key=RelatedLinks}">
+                            <VariableSizedWrapGrid
+                                Margin="{StaticResource HyperlinkButtonInlineMargin}"
+                                ItemWidth="242"
+                                Orientation="Horizontal">
+                                <!--  TODO: Add third-party license notice  -->
+                                <HyperlinkButton Content="{strings:Resources Key=PrivacyPolicy}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
+                                <HyperlinkButton Content="{strings:Resources Key=License}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkSourceCode}" NavigateUri="https://github.com/huynhsontung/Screenbox" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkDiscord}" NavigateUri="https://discord.gg/HZPZXjANxz" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkSponsor}" NavigateUri="https://github.com/sponsors/huynhsontung" />
                                 <HyperlinkButton Content="{strings:Resources Key=HyperlinkTranslate}" NavigateUri="https://crowdin.com/project/screenbox" />
-                            </StackPanel>
-                        </labs:SettingsCard>
-                        <labs:SettingsCard
-                            HorizontalContentAlignment="Left"
-                            ContentAlignment="Vertical"
-                            Description="Huge thanks to the contributors of the following libraries"
-                            Header="Open source libraries">
-                            <VariableSizedWrapGrid
-                                Margin="{StaticResource HyperlinkButtonInlineMargin}"
-                                ItemWidth="272"
-                                Orientation="Horizontal">
-                                <HyperlinkButton Content="LibVLCSharp" NavigateUri="https://github.com/videolan/libvlcsharp" />
-                                <HyperlinkButton Content="protobuf-net" NavigateUri="https://github.com/protobuf-net/protobuf-net" />
-                                <HyperlinkButton Content="ReswPlus" NavigateUri="https://github.com/DotNetPlus/ReswPlus" />
-                                <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit" />
-                                <HyperlinkButton Content="Windows Community Toolkit Labs" NavigateUri="https://github.com/CommunityToolkit/Labs-Windows" />
-                                <HyperlinkButton Content="WinUI" NavigateUri="https://github.com/microsoft/microsoft-ui-xaml" />
                             </VariableSizedWrapGrid>
-                        </labs:SettingsCard>
-                        <labs:SettingsCard
-                            Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                            ContentAlignment="Left"
-                            CornerRadius="{StaticResource SettingsCardBottomCornerRadius}">
-                            <StackPanel Margin="-40,0,0,0" Orientation="Horizontal">
-                                <TextBlock
-                                    Margin="0,8,8,8"
-                                    FontWeight="SemiBold"
-                                    Text="{strings:Resources Key=RelatedLinks}" />
-                                <HyperlinkButton Content="{strings:Resources Key=PrivacyPolicy}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
-                                <HyperlinkButton Content="{strings:Resources Key=License}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
-                            </StackPanel>
                         </labs:SettingsCard>
                     </labs:SettingsExpander.Items>
                 </labs:SettingsExpander>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -132,9 +132,6 @@
                 Padding="{StaticResource ContentPageRightMargin}"
                 SizeChanged="ContentRoot_OnSizeChanged"
                 Spacing="{StaticResource SettingsCardSpacing}">
-                <StackPanel.Transitions>
-                    <EntranceThemeTransition />
-                </StackPanel.Transitions>
                 <StackPanel.ChildrenTransitions>
                     <RepositionThemeTransition IsStaggeringEnabled="False" />
                 </StackPanel.ChildrenTransitions>

--- a/Screenbox/Strings/ar-SA/Resources.resw
+++ b/Screenbox/Strings/ar-SA/Resources.resw
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -712,5 +712,17 @@
   </data>
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>Failed to initialize</value>
+  </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
   </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2312,6 +2312,58 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region RelatedLinks
+        /// <summary>
+        ///   Looks up a localized string similar to: Related links
+        /// </summary>
+        public static string RelatedLinks
+        {
+            get
+            {
+                return _resourceLoader.GetString("RelatedLinks");
+            }
+        }
+        #endregion
+
+        #region PrivacyPolicy
+        /// <summary>
+        ///   Looks up a localized string similar to: Privacy policy
+        /// </summary>
+        public static string PrivacyPolicy
+        {
+            get
+            {
+                return _resourceLoader.GetString("PrivacyPolicy");
+            }
+        }
+        #endregion
+
+        #region License
+        /// <summary>
+        ///   Looks up a localized string similar to: License
+        /// </summary>
+        public static string License
+        {
+            get
+            {
+                return _resourceLoader.GetString("License");
+            }
+        }
+        #endregion
+
+        #region HyperlinkTranslate
+        /// <summary>
+        ///   Looks up a localized string similar to: Help translate
+        /// </summary>
+        public static string HyperlinkTranslate
+        {
+            get
+            {
+                return _resourceLoader.GetString("HyperlinkTranslate");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2499,6 +2551,10 @@ namespace Screenbox.Strings{
             PendingChanges,
             RelaunchForChangesMessage,
             FailedToInitializeNotificationTitle,
+            RelatedLinks,
+            PrivacyPolicy,
+            License,
+            HyperlinkTranslate,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -713,4 +713,16 @@
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>Failed to initialize</value>
   </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
+  </data>
 </root>

--- a/Screenbox/Strings/es-ES/Resources.resw
+++ b/Screenbox/Strings/es-ES/Resources.resw
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -712,5 +712,17 @@
   </data>
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>Failed to initialize</value>
+  </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
   </data>
 </root>

--- a/Screenbox/Strings/ro-RO/Resources.resw
+++ b/Screenbox/Strings/ro-RO/Resources.resw
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -712,5 +712,17 @@
   </data>
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>Failed to initialize</value>
+  </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
   </data>
 </root>

--- a/Screenbox/Strings/ru-RU/Resources.resw
+++ b/Screenbox/Strings/ru-RU/Resources.resw
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -712,5 +712,17 @@
   </data>
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>Failed to initialize</value>
+  </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
   </data>
 </root>

--- a/Screenbox/Strings/zh-Hans/Resources.resw
+++ b/Screenbox/Strings/zh-Hans/Resources.resw
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -712,5 +712,17 @@
   </data>
   <data name="FailedToInitializeNotificationTitle" xml:space="preserve">
     <value>初始化失败</value>
+  </data>
+  <data name="RelatedLinks" xml:space="preserve">
+    <value>Related links</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Privacy policy</value>
+  </data>
+  <data name="License" xml:space="preserve">
+    <value>License</value>
+  </data>
+  <data name="HyperlinkTranslate" xml:space="preserve">
+    <value>Help translate</value>
   </data>
 </root>


### PR DESCRIPTION
Feel free to discard the comments and the footer from the about expander. Also I removed some "superfluous" FontIcon sizes.

Not 100% sure all libraries were included.

Convert the new fields to strings and please do a copywrite pass, thanks.