### PR TITLE
fix: add missing Composers property in PropertiesView

### DIFF
--- a/Screenbox.Core/Enums/ResourceName.cs
+++ b/Screenbox.Core/Enums/ResourceName.cs
@@ -7,6 +7,7 @@
         PropertyYear,
         PropertyProducers,
         PropertyWriters,
+        PropertyComposers,
         PropertyLength,
         PropertyResolution,
         PropertyBitRate,

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -1,12 +1,12 @@
 ﻿#nullable enable
 
-using System.Collections.Generic;
-using Windows.Media;
-using Windows.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Services;
+using System.Collections.Generic;
+using Windows.Media;
+using Windows.Storage;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -26,7 +26,7 @@ namespace Screenbox.Core.ViewModels
 
         private readonly IFilesService _filesService;
         private readonly IResourceService _resourceService;
-        private StorageFile? _mediaFile; 
+        private StorageFile? _mediaFile;
 
         public PropertyViewModel(IFilesService filesService, IResourceService resourceService)
         {
@@ -68,7 +68,7 @@ namespace Screenbox.Core.ViewModels
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyContributingArtists)] = media.MusicProperties.Artist;
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyAlbum)] = media.MusicProperties.Album;
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyAlbumArtist)] = media.MusicProperties.AlbumArtist;
-                    MediaProperties[_resourceService.GetString(ResourceName.PropertyWriters)] = string.Join("; ", media.MusicProperties.Composers);
+                    MediaProperties[_resourceService.GetString(ResourceName.PropertyComposers)] = string.Join("; ", media.MusicProperties.Composers);
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyGenre)] = string.Join("; ", media.MusicProperties.Genre);
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyTrack)] = media.MusicProperties.TrackNumber.ToString();
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyYear)] = media.MusicProperties.Year > 0

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -68,6 +68,7 @@ namespace Screenbox.Core.ViewModels
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyContributingArtists)] = media.MusicProperties.Artist;
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyAlbum)] = media.MusicProperties.Album;
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyAlbumArtist)] = media.MusicProperties.AlbumArtist;
+                    MediaProperties[_resourceService.GetString(ResourceName.PropertyWriters)] = string.Join("; ", media.MusicProperties.Composers);
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyGenre)] = string.Join("; ", media.MusicProperties.Genre);
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyTrack)] = media.MusicProperties.TrackNumber.ToString();
                     MediaProperties[_resourceService.GetString(ResourceName.PropertyYear)] = media.MusicProperties.Year > 0

--- a/Screenbox/Strings/ar-SA/Resources.resw
+++ b/Screenbox/Strings/ar-SA/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2390,6 +2390,19 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region PropertyComposers
+        /// <summary>
+        ///   Looks up a localized string similar to: Composers
+        /// </summary>
+        public static string PropertyComposers
+        {
+            get
+            {
+                return _resourceLoader.GetString("PropertyComposers");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2583,6 +2596,7 @@ namespace Screenbox.Strings{
             HyperlinkTranslate,
             Options,
             TimingOffset,
+            PropertyComposers,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>

--- a/Screenbox/Strings/es-ES/Resources.resw
+++ b/Screenbox/Strings/es-ES/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ro-RO/Resources.resw
+++ b/Screenbox/Strings/ro-RO/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>

--- a/Screenbox/Strings/ru-RU/Resources.resw
+++ b/Screenbox/Strings/ru-RU/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>

--- a/Screenbox/Strings/zh-Hans/Resources.resw
+++ b/Screenbox/Strings/zh-Hans/Resources.resw
@@ -731,4 +731,7 @@
   <data name="TimingOffset" xml:space="preserve">
     <value>Timing offset</value>
   </data>
+  <data name="PropertyComposers" xml:space="preserve">
+    <value>Composers</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds the [composer property](https://learn.microsoft.com/en-us/uwp/api/windows.storage.fileproperties.musicproperties.composers?view=winrt-22621) for audio files to the PropertiesView dialog. I've provisionally reused the writers string.

### Example
<img width="436" alt="Properties view dialog with the writers property highlighted" src="https://github.com/huynhsontung/Screenbox/assets/698155/c1afb211-21e0-453f-b00a-dca096053b2d">

### Task
- [x] Create a Composers string
