### PR TITLE
fix: audio subtitle picker header style

### DIFF
--- a/Screenbox/Controls/AudioTrackSubtitlePicker.xaml
+++ b/Screenbox/Controls/AudioTrackSubtitlePicker.xaml
@@ -23,7 +23,8 @@
                     <TextBlock
                         Margin="15,0,0,0"
                         VerticalAlignment="Center"
-                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
                         Text="{strings:Resources Key=Audio}" />
                 </Border>
             </ListView.Header>
@@ -46,7 +47,8 @@
                     <TextBlock
                         Margin="15,0,0,0"
                         VerticalAlignment="Center"
-                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
                         Text="{strings:Resources Key=Subtitles}" />
                     <HyperlinkButton
                         Grid.Column="1"


### PR DESCRIPTION
![image](https://github.com/huynhsontung/Screenbox/assets/31434093/0d0d5e39-48b9-437f-9224-d47a4c72912d)
