### PR TITLE
fix: set playback speed cannot handle invalid string

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -268,7 +268,8 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand]
         private void SetPlaybackSpeed(string speedText)
         {
-            PlaybackSpeed = double.Parse(speedText);
+            if (!double.TryParse(speedText, out double speed)) return;
+            PlaybackSpeed = speed;
         }
 
         [RelayCommand]


### PR DESCRIPTION
This resolve the following crash report

> PlayerControlsViewModel.SetPlaybackSpeed (String)
System.FormatException: Input string was not in a correct format.