### PR TITLE
fix: handle exception when add folder to libraries

### DIFF
--- a/Screenbox.Core/Enums/ResourceName.cs
+++ b/Screenbox.Core/Enums/ResourceName.cs
@@ -32,6 +32,7 @@
         FailedToSaveFrameNotificationTitle,
         FailedToOpenFilesNotificationTitle,
         FailedToInitializeNotificationTitle,
+        FailedToAddFolderNotificationTitle,
         FrameSavedNotificationTitle,
         ResumePositionNotificationTitle,
         FailedToLoadMediaNotificationTitle,

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Uwp.UI;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
@@ -29,13 +30,15 @@ namespace Screenbox.Core.ViewModels
         private bool LibraryLoaded => _libraryService.MusicLibrary != null;
 
         private readonly ILibraryService _libraryService;
+        private readonly IResourceService _resourceService;
         private readonly DispatcherQueue _dispatcherQueue;
         private readonly DispatcherQueueTimer _timer;
         private List<MediaViewModel> _songs;
 
-        public MusicPageViewModel(ILibraryService libraryService)
+        public MusicPageViewModel(ILibraryService libraryService, IResourceService resourceService)
         {
             _libraryService = libraryService;
+            _resourceService = resourceService;
             _libraryService.MusicLibraryContentChanged += OnMusicLibraryContentChanged;
             _songs = new List<MediaViewModel>();
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
@@ -81,7 +84,18 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand(CanExecute = nameof(LibraryLoaded))]
         private async Task AddFolder()
         {
-            StorageFolder? addedFolder = await _libraryService.MusicLibrary?.RequestAddFolderAsync();
+            StorageFolder? addedFolder;
+            try
+            {
+                addedFolder = await _libraryService.MusicLibrary?.RequestAddFolderAsync();
+            }
+            catch (Exception e)
+            {
+                Messenger.Send(new ErrorMessage(
+                    _resourceService.GetString(ResourceName.FailedToAddFolderNotificationTitle), e.Message));
+                return;
+            }
+
             if (addedFolder != null)
             {
                 _timer.Debounce(() => IsLoading = _libraryService.IsLoadingMusic, TimeSpan.FromSeconds(1));

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2403,6 +2403,19 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region FailedToAddFolderNotificationTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Couldn't add folder
+        /// </summary>
+        public static string FailedToAddFolderNotificationTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("FailedToAddFolderNotificationTitle");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -2597,6 +2610,7 @@ namespace Screenbox.Strings{
             Options,
             TimingOffset,
             PropertyComposers,
+            FailedToAddFolderNotificationTitle,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -734,4 +734,7 @@
   <data name="PropertyComposers" xml:space="preserve">
     <value>Composers</value>
   </data>
+  <data name="FailedToAddFolderNotificationTitle" xml:space="preserve">
+    <value>Couldn't add folder</value>
+  </data>
 </root>


### PR DESCRIPTION
Handle the exception gracefully and raise an error notification.

This resolves the following crash: 

> \<AddFolder\>d__16.MoveNext ()
System.Exception: The network path was typed incorrectly, does not exist, or the network provider is not currently available. Try retyping the path or contact your network administrator.