### PR TITLE
fix: search box not behaving correctly with keyboard/gamepad

### DIFF
--- a/Screenbox.Core/ViewModels/MainPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MainPageViewModel.cs
@@ -139,27 +139,23 @@ namespace Screenbox.Core.ViewModels
             {
                 SearchResult result = _searchService.SearchLocalLibrary(searchQuery);
                 _navigationService.Navigate(typeof(SearchResultPageViewModel), result);
-                SearchQuery = string.Empty;
-                if (this.NavigationViewDisplayMode != NavigationViewDisplayMode.Expanded)
-                {
-                    IsPaneOpen = false;
-                }
             }
-        }
-
-        public void AutoSuggestBox_OnSuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
-        {
-            switch (args.SelectedItem)
+            else
             {
-                case MediaViewModel media:
-                    Messenger.Send(new PlayMediaMessage(media));
-                    break;
-                case AlbumViewModel album:
-                    _navigationService.Navigate(typeof(AlbumDetailsPageViewModel), album);
-                    break;
-                case ArtistViewModel artist:
-                    _navigationService.Navigate(typeof(ArtistDetailsPageViewModel), artist);
-                    break;
+                switch (args.ChosenSuggestion)
+                {
+                    case MediaViewModel media:
+                        Messenger.Send(new PlayMediaMessage(media));
+                        break;
+                    case AlbumViewModel album:
+                        _navigationService.Navigate(typeof(AlbumDetailsPageViewModel), album);
+                        break;
+                    case ArtistViewModel artist:
+                        _navigationService.Navigate(typeof(ArtistDetailsPageViewModel), artist);
+                        break;
+                    default:
+                        return;
+                }
             }
 
             SearchQuery = string.Empty;

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -139,7 +139,6 @@
                     PlaceholderText="{x:Bind strings:Resources.SearchBoxPlaceholderText}"
                     QueryIcon="Find"
                     QuerySubmitted="{x:Bind ViewModel.AutoSuggestBox_OnQuerySubmitted}"
-                    SuggestionChosen="{x:Bind ViewModel.AutoSuggestBox_OnSuggestionChosen}"
                     Text="{x:Bind ViewModel.SearchQuery, Mode=TwoWay}"
                     TextChanged="{x:Bind ViewModel.AutoSuggestBox_OnTextChanged}"
                     UpdateTextOnSelect="False" />


### PR DESCRIPTION
Moving focus on a suggested item would always execute the submit action. This was due to incorrect usage of `AutoSuggestBox.SuggestionChosen` event.