### PR TITLE
fix: wack test fails in PRs from a fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,8 @@ jobs:
   wack:
     needs: build
     runs-on: windows-latest
+    permissions:
+      checks: write
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v3


### PR DESCRIPTION
WACK job did not have sufficient permissions.