### PR TITLE
fix: album and artist details pages up down nav

### DIFF
--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -129,10 +129,12 @@
                     Orientation="Horizontal"
                     Spacing="16">
                     <Button
+                        x:Name="PlayButton"
                         AutomationProperties.Name="{strings:Resources Key=Play}"
                         Command="{x:Bind ViewModel.PlayCommand}"
                         CommandParameter="{x:Bind ViewModel.SortedItems[0], Mode=OneWay}"
-                        Style="{StaticResource AccentButtonStyle}">
+                        Style="{StaticResource AccentButtonStyle}"
+                        XYFocusDown="{x:Bind ItemList}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xe768;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=Play}" />
@@ -142,7 +144,10 @@
                         </interactivity:Interaction.Behaviors>
                     </Button>
 
-                    <Button AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}" Command="{x:Bind ViewModel.ShuffleAndPlayCommand}">
+                    <Button
+                        AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}"
+                        Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
+                        XYFocusDown="{x:Bind ItemList}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xe8b1;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
@@ -161,7 +166,8 @@
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind GetScrollbarVerticalMargin(Common.ScrollBarMargin), Mode=OneWay}"
             IsItemClickEnabled="True"
             ItemsSource="{x:Bind ViewModel.SortedItems}"
-            SelectionMode="None">
+            SelectionMode="None"
+            XYFocusUp="{x:Bind PlayButton}">
             <ListView.Resources>
                 <XamlUICommand x:Key="MediaListViewItemPlayCommand" Command="{x:Bind ViewModel.PlayCommand}" />
             </ListView.Resources>

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -187,9 +187,11 @@
                     Orientation="Horizontal"
                     Spacing="16">
                     <Button
+                        x:Name="PlayButton"
                         AutomationProperties.Name="{strings:Resources Key=Play}"
                         Command="{x:Bind ViewModel.PlayCommand}"
-                        Style="{StaticResource AccentButtonStyle}">
+                        Style="{StaticResource AccentButtonStyle}"
+                        XYFocusDown="{x:Bind ItemList}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xe768;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=Play}" />
@@ -199,7 +201,10 @@
                         </interactivity:Interaction.Behaviors>
                     </Button>
 
-                    <Button AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}" Command="{x:Bind ViewModel.ShuffleAndPlayCommand}">
+                    <Button
+                        AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}"
+                        Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
+                        XYFocusDown="{x:Bind ItemList}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xe8b1;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
@@ -218,7 +223,8 @@
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind GetScrollbarVerticalMargin(Common.ScrollBarMargin), Mode=OneWay}"
             IsItemClickEnabled="True"
             ItemsSource="{x:Bind AlbumSource.View}"
-            SelectionMode="None">
+            SelectionMode="None"
+            XYFocusUp="{x:Bind PlayButton}">
             <ListView.Resources>
                 <XamlUICommand x:Key="MediaListViewItemPlayCommand" Command="{x:Bind ViewModel.PlayCommand}" />
             </ListView.Resources>


### PR DESCRIPTION
Due to weird margins on both pages, XY navigation is broken. Manually direct XY nav using `XYFocusUp` and `XYFocusDown`.