### PR TITLE
feat: auto subtitle load in the same directory

### DIFF
--- a/Screenbox.Core/Playback/IMediaPlayer.cs
+++ b/Screenbox.Core/Playback/IMediaPlayer.cs
@@ -50,6 +50,6 @@ namespace Screenbox.Core.Playback
         void Pause();
         void StepForwardOneFrame();
         void StepBackwardOneFrame();
-        void AddSubtitle(IStorageFile file);
+        void AddSubtitle(IStorageFile file, bool select = true);
     }
 }

--- a/Screenbox.Core/Playback/PlaybackSubtitleTrackList.cs
+++ b/Screenbox.Core/Playback/PlaybackSubtitleTrackList.cs
@@ -5,6 +5,8 @@ namespace Screenbox.Core.Playback
 {
     public sealed class PlaybackSubtitleTrackList : SingleSelectTrackList<SubtitleTrack>
     {
+        // This only allows to add one external subtitle at a time
+        // TODO: Find a better solution for pending subtitle track label
         internal string PendingTrackLabel { get; set; }
 
         private readonly Media _media;
@@ -24,7 +26,7 @@ namespace Screenbox.Core.Playback
             PendingTrackLabel = string.Empty;
         }
 
-        internal async void NotifyTrackAdded(int trackId)
+        internal async void NotifyTrackAdded(int trackId, MediaPlayer mediaPlayer)
         {
             // Delay to wait for _media.Tracks to populate
             // Run in new thread to ensure VLC thread safety
@@ -37,7 +39,10 @@ namespace Screenbox.Core.Playback
                     sub.Label ??= PendingTrackLabel;
                     PendingTrackLabel = string.Empty;
                     TrackList.Add(sub);
-                    SelectedIndex = Count - 1;
+                    if (trackId == mediaPlayer.Spu)
+                    {
+                        SelectedIndex = Count - 1;
+                    }
                     return;
                 }
             }

--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -323,7 +323,7 @@ namespace Screenbox.Core.Playback
             if (PlaybackItem == null || PlaybackState == MediaPlaybackState.Opening) return;
             if (e.Type == TrackType.Text)
             {
-                PlaybackItem.SubtitleTracks.NotifyTrackAdded(e.Id);
+                PlaybackItem.SubtitleTracks.NotifyTrackAdded(e.Id, VlcPlayer);
             }
         }
 
@@ -406,12 +406,12 @@ namespace Screenbox.Core.Playback
             VlcPlayer.SetSpu(sender.SelectedIndex < 0 ? -1 : trackList[sender.SelectedIndex].VlcSpu);
         }
 
-        public void AddSubtitle(IStorageFile file)
+        public void AddSubtitle(IStorageFile file, bool select = true)
         {
             if (PlaybackItem == null) return;
             string mrl = "winrt://" + StorageApplicationPermissions.FutureAccessList.Add(file, "subtitle");
             PlaybackItem.SubtitleTracks.PendingTrackLabel = file.Name;
-            VlcPlayer.AddSlave(MediaSlaveType.Subtitle, mrl, true);
+            VlcPlayer.AddSlave(MediaSlaveType.Subtitle, mrl, select);
         }
 
         public void Close()

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -19,13 +19,13 @@ namespace Screenbox.Core.Services
 {
     public sealed class FilesService : IFilesService
     {
-        public async Task<StorageFileQueryResult?> GetNeighboringFilesQueryAsync(StorageFile file)
+        public async Task<StorageFileQueryResult?> GetNeighboringFilesQueryAsync(StorageFile file, QueryOptions? options = null)
         {
             try
             {
                 StorageFolder? parent = await file.GetParentAsync();
-                StorageFileQueryResult? queryResult =
-                    parent?.CreateFileQueryWithOptions(new QueryOptions(CommonFileQuery.DefaultQuery, FilesHelpers.SupportedFormats));
+                options ??= new QueryOptions(CommonFileQuery.DefaultQuery, FilesHelpers.SupportedFormats);
+                StorageFileQueryResult? queryResult = parent?.CreateFileQueryWithOptions(options);
                 return queryResult;
             }
             catch (Exception)

--- a/Screenbox.Core/Services/IFilesService.cs
+++ b/Screenbox.Core/Services/IFilesService.cs
@@ -1,18 +1,18 @@
 ﻿#nullable enable
 
+using Screenbox.Core.Playback;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
-using Windows.Storage.Search;
-using Screenbox.Core.Playback;
 using Windows.Storage.FileProperties;
+using Windows.Storage.Search;
 
 namespace Screenbox.Core.Services
 {
     public interface IFilesService
     {
-        public Task<StorageFileQueryResult?> GetNeighboringFilesQueryAsync(StorageFile file);
+        public Task<StorageFileQueryResult?> GetNeighboringFilesQueryAsync(StorageFile file, QueryOptions? options = null);
         public Task<StorageFile?> GetNextFileAsync(IStorageFile currentFile,
             StorageFileQueryResult neighboringFilesQuery);
         public Task<StorageFile?> GetPreviousFileAsync(IStorageFile currentFile,

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -8,15 +8,20 @@ using Screenbox.Core.Messages;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Windows.Storage.Search;
 using AudioTrack = Screenbox.Core.Playback.AudioTrack;
 using SubtitleTrack = Screenbox.Core.Playback.SubtitleTrack;
 
 namespace Screenbox.Core.ViewModels
 {
-    public sealed partial class AudioTrackSubtitleViewModel : ObservableRecipient, IRecipient<MediaPlayerChangedMessage>
+    public sealed partial class AudioTrackSubtitleViewModel : ObservableRecipient,
+        IRecipient<PlaylistActiveItemChangedMessage>,
+        IRecipient<MediaPlayerChangedMessage>
     {
         public ObservableCollection<string> SubtitleTracks { get; }
 
@@ -46,6 +51,27 @@ namespace Screenbox.Core.ViewModels
         public void Receive(MediaPlayerChangedMessage message)
         {
             _mediaPlayer = message.Value;
+        }
+
+        /// <summary>
+        /// Try load a subtitle in the same directory with the same name
+        /// </summary>
+        public async void Receive(PlaylistActiveItemChangedMessage message)
+        {
+            if (_mediaPlayer == null) return;
+            if (message.Value?.Source is not StorageFile file) return;
+            QueryOptions options = new(CommonFileQuery.DefaultQuery, new[] { ".srt", ".ass" })
+            {
+                ApplicationSearchFilter = $"System.FileName:$<\"{Path.GetFileNameWithoutExtension(file.Name)}\""
+            };
+
+            StorageFileQueryResult? query = await _filesService.GetNeighboringFilesQueryAsync(file, options);
+            if (query == null) return;
+            IReadOnlyList<StorageFile> subtitles = await query.GetFilesAsync(0, 1);
+            if (subtitles.Count <= 0) return;
+            StorageFile subtitle = subtitles[0];
+            _mediaPlayer.AddSubtitle(subtitle);
+            // Messenger.Send(new SubtitleAddedNotificationMessage(subtitle));
         }
 
         partial void OnSubtitleTrackIndexChanged(int value)

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -70,8 +70,8 @@ namespace Screenbox.Core.ViewModels
             IReadOnlyList<StorageFile> subtitles = await query.GetFilesAsync(0, 1);
             if (subtitles.Count <= 0) return;
             StorageFile subtitle = subtitles[0];
-            _mediaPlayer.AddSubtitle(subtitle);
-            // Messenger.Send(new SubtitleAddedNotificationMessage(subtitle));
+            // Preload subtitle but don't select it
+            _mediaPlayer.AddSubtitle(subtitle, false);
         }
 
         partial void OnSubtitleTrackIndexChanged(int value)
@@ -138,7 +138,7 @@ namespace Screenbox.Core.ViewModels
             {
                 SubtitleTrack subtitleTrack = ItemSubtitleTrackList[index];
                 string defaultTrackLabel = _resourceService.GetString(ResourceName.TrackIndex, index + 1);
-                SubtitleTracks.Add(subtitleTrack.Label ?? defaultTrackLabel);
+                SubtitleTracks.Add(string.IsNullOrEmpty(subtitleTrack.Label) ? defaultTrackLabel : subtitleTrack.Label!);
             }
         }
     }


### PR DESCRIPTION
Resolves #190 

Automatically load a subtitle when there is one with the same name in the same directory. The loaded subtitle is not displayed by default and is available to select in the subtitle picker.