### PR TITLE
fix: player focus on file activation

### DIFF
--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -42,6 +42,7 @@ namespace Screenbox.Pages
 
         private readonly DispatcherQueueTimer _delayFlyoutOpenTimer;
         private CancellationTokenSource? _animationCancellationTokenSource;
+        private bool _startup;
 
         public PlayerPage()
         {
@@ -72,6 +73,7 @@ namespace Screenbox.Pages
             {
                 LayoutRoot.Transitions.Clear();
                 ViewModel.PlayerVisibility = PlayerVisibilityState.Visible;
+                _startup = true;
             }
         }
 
@@ -135,6 +137,8 @@ namespace Screenbox.Pages
 
             if (ViewModel.PlayerVisibility == PlayerVisibilityState.Visible)
             {
+                // Focus can fail if player is file activated
+                // At this point, controls are disabled by default
                 PlayerControls.FocusFirstButton();
             }
         }
@@ -251,6 +255,12 @@ namespace Screenbox.Pages
                     break;
                 case nameof(PlayerPageViewModel.NavigationViewDisplayMode) when ViewModel.ViewMode == WindowViewMode.Default:
                     UpdateMiniPlayerMargin();
+                    break;
+                case nameof(PlayerPageViewModel.IsPlaying) when _startup:
+                    // Only when the app is file activated
+                    // Wait till playback starts then focus the player controls
+                    _startup = false;
+                    PlayerControls.FocusFirstButton();
                     break;
             }
         }

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -138,7 +138,7 @@ namespace Screenbox.Pages
             if (ViewModel.PlayerVisibility == PlayerVisibilityState.Visible)
             {
                 // Focus can fail if player is file activated
-                // At this point, controls are disabled by default
+                // Controls are disabled by default until playback is ready
                 PlayerControls.FocusFirstButton();
             }
         }
@@ -256,7 +256,7 @@ namespace Screenbox.Pages
                 case nameof(PlayerPageViewModel.NavigationViewDisplayMode) when ViewModel.ViewMode == WindowViewMode.Default:
                     UpdateMiniPlayerMargin();
                     break;
-                case nameof(PlayerPageViewModel.IsPlaying) when _startup:
+                case nameof(PlayerPageViewModel.IsPlaying) when _startup && ViewModel.IsPlaying:
                     // Only when the app is file activated
                     // Wait till playback starts then focus the player controls
                     _startup = false;


### PR DESCRIPTION
Fixes #194 

When the app is file activated, the player fails to set the correct focus target since all controls are disabled by default due to the media file not yet ready. We should wait for playback and then set the correct focus.