### PR TITLE
fix: Slider step size when using gamepad

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -120,6 +120,7 @@
                         IsThumbToolTipEnabled="False"
                         Maximum="2"
                         Minimum="0.05"
+                        SmallChange="0.05"
                         StepFrequency="0.05"
                         ValueChanged="SpeedSlider_OnValueChanged"
                         Value="1.0" />
@@ -149,6 +150,7 @@
                         IsThumbToolTipEnabled="False"
                         Maximum="3000"
                         Minimum="-3000"
+                        SmallChange="50"
                         StepFrequency="100"
                         ValueChanged="TimingOffsetSlider_OnValueChanged"
                         Value="0" />

--- a/Screenbox/Controls/SeekBar.xaml
+++ b/Screenbox/Controls/SeekBar.xaml
@@ -50,7 +50,7 @@
             Minimum="0"
             PointerExited="SeekBarSlider_OnPointerExited"
             SizeChanged="SeekBarSlider_OnSizeChanged"
-            SmallChange="1000"
+            SmallChange="5000"
             Style="{StaticResource DefaultSliderStyle}"
             ThumbToolTipValueConverter="{StaticResource HumanizedDurationConverter}"
             ValueChanged="{x:Bind ViewModel.OnSeekBarValueChanged}"


### PR DESCRIPTION
Some Sliders don't have `SmallChange` set, which is used for gamepad interaction.