### PR TITLE
fix: settings page visual and XY navigability

### DIFF
--- a/Screenbox/Controls/Interactions/SettingsExpanderXYNavigationBehavior.cs
+++ b/Screenbox/Controls/Interactions/SettingsExpanderXYNavigationBehavior.cs
@@ -1,0 +1,22 @@
+﻿using CommunityToolkit.Labs.WinUI;
+using Microsoft.Toolkit.Uwp.UI;
+using Microsoft.Toolkit.Uwp.UI.Behaviors;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+
+namespace Screenbox.Controls.Interactions;
+internal class SettingsExpanderXYNavigationBehavior : BehaviorBase<SettingsExpander>
+{
+    public Control? XYFocusRight { get; set; }
+
+    protected override void OnAssociatedObjectLoaded()
+    {
+        base.OnAssociatedObjectLoaded();
+        if (XYFocusRight == null) return;
+        if (AssociatedObject.FindDescendant<ToggleButton>() is { } button)
+        {
+            button.XYFocusRight = XYFocusRight;
+            XYFocusRight.XYFocusRight = button;
+        }
+    }
+}

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -27,7 +27,7 @@
             <x:Double x:Key="ToggleSwitchPreContentMargin">4</x:Double>
             <x:Double x:Key="ToggleSwitchPostContentMargin">4</x:Double>
             <x:Double x:Key="SettingsCardWrapThreshold">400</x:Double>
-            <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+            <Thickness x:Key="SettingsCardMargin">0,0,0,4</Thickness>
 
             <!--  SettingsExpander bottom corners radius temporary (hopefully) fix  -->
             <CornerRadius x:Key="SettingsCardBottomCornerRadius">0,0,3,3</CornerRadius>
@@ -37,16 +37,12 @@
                 x:Key="SettingsSectionHeaderTextBlockStyle"
                 BasedOn="{StaticResource BodyStrongTextBlockStyle}"
                 TargetType="TextBlock">
-                <Setter Property="Margin" Value="1,28,0,4" />
+                <Setter Property="Margin" Value="1,28,0,8" />
                 <Setter Property="AutomationProperties.HeadingLevel" Value="Level2" />
             </Style>
 
             <ThemeShadow x:Key="SharedShadow" />
             <converters:ResourceNameToResourceStringConverter x:Key="ResourceNameToResourceStringConverter" />
-            <muxc:StackLayout
-                x:Name="VerticalStackLayout"
-                Orientation="Vertical"
-                Spacing="12" />
 
             <XamlUICommand
                 x:Key="RemoveMusicFolderCommand"
@@ -119,9 +115,7 @@
             <StackPanel
                 x:Name="ContentRoot"
                 Margin="{x:Bind Common.FooterBottomPaddingMargin, Mode=OneWay}"
-                Padding="{StaticResource PageContentMargin}"
-                SizeChanged="ContentRoot_OnSizeChanged"
-                Spacing="{StaticResource SettingsCardSpacing}">
+                Padding="{StaticResource PageContentMargin}">
                 <StackPanel.ChildrenTransitions>
                     <RepositionThemeTransition IsStaggeringEnabled="False" />
                 </StackPanel.ChildrenTransitions>
@@ -131,11 +125,12 @@
 
                 <!--  Libraries section  -->
                 <TextBlock
-                    Margin="1,8,0,4"
+                    Margin="1,8,0,8"
                     Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
                     Text="{strings:Resources Key=SettingsCategoryLibraries}"
                     Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}" />
                 <labs:SettingsExpander
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{x:Bind strings:Resources.LocationSpecified(ViewModel.MusicLocations.Count), Mode=OneWay, FallbackValue={x:Null}}"
                     Header="{strings:Resources Key=SettingsMusicLibraryLocationsHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe8d6;}"
@@ -153,6 +148,7 @@
                     </Button>
                 </labs:SettingsExpander>
                 <labs:SettingsExpander
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{x:Bind strings:Resources.LocationSpecified(ViewModel.VideoLocations.Count), Mode=OneWay, FallbackValue={x:Null}}"
                     Header="{strings:Resources Key=SettingsVideoLibraryLocationsHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe8b2;}"
@@ -173,6 +169,7 @@
                 <!--  General section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
                 <labs:SettingsExpander
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsShowRecentDescription}"
                     Header="{strings:Resources Key=SettingsShowRecentHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe8b7;}">
@@ -187,6 +184,7 @@
                 <!--  Player section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />
                 <labs:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsAutoResizeDescription}"
                     Header="{strings:Resources Key=SettingsAutoResizeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe799;}"
@@ -203,6 +201,7 @@
                     </ComboBox>
                 </labs:SettingsCard>
                 <labs:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsVolumeBoostDescription}"
                     Header="{strings:Resources Key=SettingsVolumeBoostHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe767;}">
@@ -219,6 +218,7 @@
                     </ComboBox>
                 </labs:SettingsCard>
                 <labs:SettingsExpander
+                    Margin="{StaticResource SettingsCardMargin}"
                     Header="{strings:Resources Key=SettingsGesturesHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xeda4;}"
                     IsExpanded="True"
@@ -239,6 +239,7 @@
                 <!--  Advanced section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryAdvanced}" />
                 <labs:SettingsExpander
+                    Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsAdvancedModeDescription}"
                     Header="{strings:Resources Key=SettingsAdvancedModeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe756;}"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -26,7 +26,6 @@
 
             <x:Double x:Key="ToggleSwitchPreContentMargin">4</x:Double>
             <x:Double x:Key="ToggleSwitchPostContentMargin">4</x:Double>
-            <x:Double x:Key="SettingsCardWrapThreshold">400</x:Double>
             <Thickness x:Key="SettingsCardMargin">0,0,0,4</Thickness>
 
             <!--  SettingsExpander bottom corners radius temporary (hopefully) fix  -->
@@ -137,7 +136,11 @@
                     ItemTemplate="{StaticResource MusicLibraryLocationTemplate}"
                     ItemsSource="{x:Bind ViewModel.MusicLocations, Mode=OneWay}"
                     Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}">
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:SettingsExpanderXYNavigationBehavior XYFocusRight="{x:Bind AddMusicFolderButton}" />
+                    </interactivity:Interaction.Behaviors>
                     <Button
+                        x:Name="AddMusicFolderButton"
                         AutomationProperties.Name="{strings:Resources Key=AddFolder}"
                         Command="{x:Bind ViewModel.AddMusicFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}">
@@ -155,7 +158,11 @@
                     ItemTemplate="{StaticResource VideosLibraryLocationTemplate}"
                     ItemsSource="{x:Bind ViewModel.VideoLocations, Mode=OneWay}"
                     Visibility="{x:Bind helpers:SystemInformationExtensions.IsDesktop}">
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:SettingsExpanderXYNavigationBehavior XYFocusRight="{x:Bind AddVideoFolderButton}" />
+                    </interactivity:Interaction.Behaviors>
                     <Button
+                        x:Name="AddVideoFolderButton"
                         AutomationProperties.Name="{strings:Resources Key=AddFolder}"
                         Command="{x:Bind ViewModel.AddVideosFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}">
@@ -173,7 +180,10 @@
                     Description="{strings:Resources Key=SettingsShowRecentDescription}"
                     Header="{strings:Resources Key=SettingsShowRecentHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe8b7;}">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRecent, Mode=TwoWay}" />
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:SettingsExpanderXYNavigationBehavior XYFocusRight="{x:Bind ShowRecentToggleSwitch}" />
+                    </interactivity:Interaction.Behaviors>
+                    <ToggleSwitch x:Name="ShowRecentToggleSwitch" IsOn="{x:Bind ViewModel.ShowRecent, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
                         <labs:SettingsCard CornerRadius="{StaticResource SettingsCardBottomCornerRadius}" Header="{strings:Resources Key=SettingsClearRecentHeader}">
                             <Button Command="{x:Bind ViewModel.ClearRecentHistoryCommand}" Content="{strings:Resources Key=Clear}" />
@@ -244,6 +254,9 @@
                     Header="{strings:Resources Key=SettingsAdvancedModeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xe756;}"
                     IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:SettingsExpanderXYNavigationBehavior XYFocusRight="{x:Bind AdvancedModeToggleSwitch}" />
+                    </interactivity:Interaction.Behaviors>
                     <ToggleSwitch x:Name="AdvancedModeToggleSwitch" IsOn="{x:Bind ViewModel.AdvancedMode, Mode=TwoWay}" />
                     <labs:SettingsExpander.Items>
                         <labs:SettingsCard Header="{strings:Resources Key=SettingsGlobalArgumentsHeader}" IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -1,12 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -42,18 +39,6 @@ namespace Screenbox.Pages
         {
             base.OnNavigatedTo(e);
             await ViewModel.LoadLibraryLocations();
-        }
-
-        private void ContentRoot_OnSizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            StackPanel panel = (StackPanel)sender;
-            ButtonBase? settingsCard = panel.Children.OfType<ButtonBase>().FirstOrDefault();
-            if (settingsCard == null) return;
-            IEnumerable<TextBlock> sectionHeaders = panel.Children.OfType<TextBlock>();
-            foreach (TextBlock sectionHeader in sectionHeaders)
-            {
-                sectionHeader.Width = settingsCard.ActualWidth;
-            }
         }
     }
 }

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Controls\Interactions\BringIntoViewWithOffsetBehavior.cs" />
     <Compile Include="Controls\Interactions\GamepadXYNavigationBehavior.cs" />
     <Compile Include="Controls\Interactions\FocusOnItemClickBehavior.cs" />
+    <Compile Include="Controls\Interactions\SettingsExpanderXYNavigationBehavior.cs" />
     <Compile Include="Controls\Interactions\SplitButtonXYNavigationBehavior.cs" />
     <Compile Include="Controls\Interactions\ThumbnailGridViewBehavior.cs" />
     <Compile Include="Controls\Interactions\AlternatingListViewBehavior.cs" />


### PR DESCRIPTION
Before
![Screenshot_2023-10-30_21-41-07](https://github.com/huynhsontung/Screenbox/assets/31434093/cddd350b-78c9-4b0d-8692-57b480e38b96)

After
![Screenshot_2023-10-30_22-48-02](https://github.com/huynhsontung/Screenbox/assets/31434093/e4a69157-f9b8-409c-995a-caff71fa47b2)
