### PR TITLE
feat: add support for multi stream playlist

### DIFF
--- a/Screenbox.Core/Factories/MediaViewModelFactory.cs
+++ b/Screenbox.Core/Factories/MediaViewModelFactory.cs
@@ -1,4 +1,5 @@
-﻿using Screenbox.Core.Services;
+﻿using LibVLCSharp.Shared;
+using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +34,11 @@ namespace Screenbox.Core.Factories
         public MediaViewModel GetTransient(Uri uri)
         {
             return new MediaViewModel(_filesService, _mediaService, _albumFactory, _artistFactory, uri);
+        }
+
+        public MediaViewModel GetTransient(Media media)
+        {
+            return new MediaViewModel(_filesService, _mediaService, _albumFactory, _artistFactory, media);
         }
 
         public MediaViewModel GetSingleton(IStorageFile file)

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -173,6 +173,9 @@ namespace Screenbox.Core.ViewModels
                     continue;
                 }
 
+                // TODO: Add support for playing playlist file from home page
+                if (file.IsSupportedPlaylist()) continue;
+
                 if (i >= Recent.Count)
                 {
                     Recent.Add(new MediaViewModelWithMruToken(token, _mediaFactory.GetSingleton(file)));

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -62,7 +62,6 @@ namespace Screenbox.Core.ViewModels
         private object? _delayPlay;
         private StorageFileQueryResult? _neighboringFilesQuery;
         private object? _lastUpdated;
-        private bool _isExternalPlaylist;
         private CancellationTokenSource? _cts;
 
         private const int MediaBufferCapacity = 5;
@@ -523,7 +522,6 @@ namespace Screenbox.Core.ViewModels
 
         private void ClearPlaylist()
         {
-            _isExternalPlaylist = false;
             _shuffleBackup = null;
 
             foreach (MediaViewModel item in Items)
@@ -637,7 +635,7 @@ namespace Screenbox.Core.ViewModels
                         sender.Position = TimeSpan.Zero;
                         break;
                     default:
-                        if (Items.Count > 1 && !_isExternalPlaylist) _ = NextAsync();
+                        if (Items.Count > 1) _ = NextAsync();
                         break;
                 }
             });

--- a/Screenbox.Core/ViewModels/PlaylistViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlaylistViewModel.cs
@@ -42,6 +42,11 @@ namespace Screenbox.Core.ViewModels
             Playlist.Items.CollectionChanged += ItemsOnCollectionChanged;
         }
 
+        public async Task EnqueuePlaylistAsync(IReadOnlyList<IStorageItem> items)
+        {
+            await Playlist.EnqueueAsync(items);
+        }
+
         private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             HasItems = Playlist.Items.Count > 0;
@@ -165,7 +170,7 @@ namespace Screenbox.Core.ViewModels
             {
                 IReadOnlyList<StorageFile>? files = await _filesService.PickMultipleFilesAsync();
                 if (files == null || files.Count == 0) return;
-                Playlist.Enqueue(files);
+                await Playlist.EnqueueAsync(files);
             }
             catch (Exception e)
             {

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -77,7 +77,7 @@ namespace Screenbox.Controls
             IReadOnlyList<IStorageItem>? items = await e.DataView.GetStorageItemsAsync();
             if (items?.Count > 0)
             {
-                ViewModel.Playlist.Enqueue(items);
+                await ViewModel.EnqueuePlaylistAsync(items);
             }
         }
 


### PR DESCRIPTION
Closes #114

This feature allows Screenbox to support IPTV.

Stream file parsing uses Lua scripts. Find a solution to reliably load Lua scripts. See related LibVLC issues

[Add lua support to LibVLC.UWP](https://code.videolan.org/videolan/libvlc-nuget/-/issues/13)

[lua: discard basedir and DIR_SEP on UWP](https://code.videolan.org/videolan/vlc/-/merge_requests/846)

Edit: Thanks to #246, this is now possible.