### PR TITLE
fix: snapshot name exposes VLC naming

### DIFF
--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -141,15 +141,13 @@ namespace Screenbox.Core.Services
                     throw new Exception("VLC failed to save snapshot");
 
                 StorageFile file = (await tempFolder.GetFilesAsync()).First();
-                await file.RenameAsync($"Screenbox_{DateTime.Now:yyyymmdd_HHmmss}{file.FileType}",
-                    NameCollisionOption.GenerateUniqueName);
-
                 StorageLibrary pictureLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
                 StorageFolder defaultSaveFolder = pictureLibrary.SaveFolder;
                 StorageFolder destFolder =
                     await defaultSaveFolder.CreateFolderAsync("Screenbox",
                         CreationCollisionOption.OpenIfExists);
-                return await file.CopyAsync(destFolder);
+                return await file.CopyAsync(destFolder, $"Screenbox_{DateTime.Now:yyyymmdd_HHmmss}{file.FileType}",
+                    NameCollisionOption.GenerateUniqueName);
             }
             finally
             {

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -131,24 +131,25 @@ namespace Screenbox.Core.Services
                 throw new NotImplementedException("Not supported on non VLC players");
             }
 
-            StorageFolder? tempFolder = await ApplicationData.Current.TemporaryFolder.CreateFolderAsync(
+            StorageFolder tempFolder = await ApplicationData.Current.TemporaryFolder.CreateFolderAsync(
                     $"snapshot_{DateTimeOffset.Now.Ticks}",
                     CreationCollisionOption.FailIfExists);
 
             try
             {
-                if (player.VlcPlayer.TakeSnapshot(0, tempFolder.Path, 0, 0))
-                {
-                    StorageFile? file = (await tempFolder.GetFilesAsync()).First();
-                    StorageLibrary? pictureLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
-                    StorageFolder? defaultSaveFolder = pictureLibrary.SaveFolder;
-                    StorageFolder? destFolder =
-                        await defaultSaveFolder.CreateFolderAsync("Screenbox",
-                            CreationCollisionOption.OpenIfExists);
-                    return await file.CopyAsync(destFolder);
-                }
+                if (!player.VlcPlayer.TakeSnapshot(0, tempFolder.Path, 0, 0))
+                    throw new Exception("VLC failed to save snapshot");
 
-                throw new Exception("VLC failed to save snapshot");
+                StorageFile file = (await tempFolder.GetFilesAsync()).First();
+                await file.RenameAsync($"Screenbox_{DateTime.Now:yyyymmdd_HHmmss}{file.FileType}",
+                    NameCollisionOption.GenerateUniqueName);
+
+                StorageLibrary pictureLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
+                StorageFolder defaultSaveFolder = pictureLibrary.SaveFolder;
+                StorageFolder destFolder =
+                    await defaultSaveFolder.CreateFolderAsync("Screenbox",
+                        CreationCollisionOption.OpenIfExists);
+                return await file.CopyAsync(destFolder);
             }
             finally
             {


### PR DESCRIPTION
When exporting a video frame into a snapshot, the snapshot name is similar to `vlcsnap-2022-03-06-13h51m21s111.png`. We should avoid exposing VLC naming scheme.

Proposing new name pattern: `Screenbox_20230813_110824.png`