### PR TITLE
style: change speed glyph

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -67,6 +67,7 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private string? _titleName; // TODO: Handle VLC title name
         [ObservableProperty] private string? _chapterName;
         [ObservableProperty] private double _playbackSpeed;
+        [ObservableProperty] private string _playbackSpeedGlyph;
         [ObservableProperty] private bool _isAdvancedModeActive;
         [ObservableProperty] private bool _isMinimal;
 
@@ -107,6 +108,7 @@ namespace Screenbox.Core.ViewModels
             _settingsService = settingsService;
             _windowService.ViewModeChanged += WindowServiceOnViewModeChanged;
             _playbackSpeed = 1.0;
+            _playbackSpeedGlyph = GetPlaybackSpeedGlyph();
             _isAdvancedModeActive = settingsService.AdvancedMode;
             _isMinimal = true;
             Playlist = playlist;
@@ -218,6 +220,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (_mediaPlayer == null) return;
             _mediaPlayer.PlaybackRate = value;
+            PlaybackSpeedGlyph = GetPlaybackSpeedGlyph();
         }
 
         private void PlaylistViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -390,6 +393,17 @@ namespace Screenbox.Core.ViewModels
             if (!HasActiveItem) return;
             Messenger.Send(new ShowPlayPauseBadgeMessage(!IsPlaying));
             PlayPause();
+        }
+
+        /// <summary>
+        /// Get the Playback Speed glyph for a particular speed.
+        /// </summary>
+        /// <returns>Speed Medium glyph if PlaybackSpeed is 1 x, Speed High glyph if is faster, Speed Off glyph if is slower</returns>
+        private string GetPlaybackSpeedGlyph()
+        {
+            if (PlaybackSpeed > 1.01) return "\uec4a";
+            if (PlaybackSpeed < 0.99) return "\uec48";
+            return "\uec49";
         }
     }
 }

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -67,7 +67,6 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private string? _titleName; // TODO: Handle VLC title name
         [ObservableProperty] private string? _chapterName;
         [ObservableProperty] private double _playbackSpeed;
-        [ObservableProperty] private string _playbackSpeedGlyph;
         [ObservableProperty] private bool _isAdvancedModeActive;
         [ObservableProperty] private bool _isMinimal;
 
@@ -108,7 +107,6 @@ namespace Screenbox.Core.ViewModels
             _settingsService = settingsService;
             _windowService.ViewModeChanged += WindowServiceOnViewModeChanged;
             _playbackSpeed = 1.0;
-            _playbackSpeedGlyph = GetPlaybackSpeedGlyph();
             _isAdvancedModeActive = settingsService.AdvancedMode;
             _isMinimal = true;
             Playlist = playlist;
@@ -220,7 +218,6 @@ namespace Screenbox.Core.ViewModels
         {
             if (_mediaPlayer == null) return;
             _mediaPlayer.PlaybackRate = value;
-            PlaybackSpeedGlyph = GetPlaybackSpeedGlyph();
         }
 
         private void PlaylistViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -393,17 +390,6 @@ namespace Screenbox.Core.ViewModels
             if (!HasActiveItem) return;
             Messenger.Send(new ShowPlayPauseBadgeMessage(!IsPlaying));
             PlayPause();
-        }
-
-        /// <summary>
-        /// Get the Playback Speed glyph for a particular speed.
-        /// </summary>
-        /// <returns>Speed Medium glyph if PlaybackSpeed is 1 x, Speed High glyph if is faster, Speed Off glyph if is slower</returns>
-        private string GetPlaybackSpeedGlyph()
-        {
-            if (PlaybackSpeed > 1.01) return "\uec4a";
-            if (PlaybackSpeed < 0.99) return "\uec48";
-            return "\uec49";
         }
     }
 }

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -177,10 +177,10 @@
                         <KeyboardAccelerator Key="I" Modifiers="Control" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
-                <MenuFlyoutSubItem
-                    x:Name="PlaybackSpeedSubMenu"
-                    Icon="{ui:FontIcon Glyph=&#xEC57;}"
-                    Text="{x:Bind strings:Resources.PlaybackSpeed}">
+                <MenuFlyoutSubItem x:Name="PlaybackSpeedSubMenu" Text="{x:Bind strings:Resources.PlaybackSpeed}">
+                    <MenuFlyoutSubItem.Icon>
+                        <FontIcon Glyph="{x:Bind ViewModel.PlaybackSpeedGlyph, Mode=OneWay}" />
+                    </MenuFlyoutSubItem.Icon>
                     <muxc:RadioMenuFlyoutItem
                         x:Name="PlaybackSpeed025MenuItem"
                         Command="{x:Bind ViewModel.SetPlaybackSpeedCommand}"

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -179,7 +179,7 @@
                 </MenuFlyoutItem>
                 <MenuFlyoutSubItem x:Name="PlaybackSpeedSubMenu" Text="{x:Bind strings:Resources.PlaybackSpeed}">
                     <MenuFlyoutSubItem.Icon>
-                        <FontIcon Glyph="{x:Bind ViewModel.PlaybackSpeedGlyph, Mode=OneWay}" />
+                        <FontIcon Glyph="{x:Bind GetPlaybackSpeedGlyph(ViewModel.PlaybackSpeed), Mode=OneWay}" />
                     </MenuFlyoutSubItem.Icon>
                     <muxc:RadioMenuFlyoutItem
                         x:Name="PlaybackSpeed025MenuItem"

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -118,6 +118,20 @@ namespace Screenbox.Controls
             }
         }
 
+        /// <summary>
+        /// Get the Playback Speed glyph for a particular speed.
+        /// </summary>
+        /// <returns>Speed Medium glyph if PlaybackSpeed is 1 x, Speed High glyph if is faster, Speed Off glyph if is slower</returns>
+        private string GetPlaybackSpeedGlyph(double playbackSpeed)
+        {
+            return playbackSpeed switch
+            {
+                > 1.01 => "\uec4a",
+                < 0.99 => "\uec48",
+                _ => "\uec49"
+            };
+        }
+
         private bool IsCastButtonEnabled(bool hasActiveItem)
         {
             if (_castFlyout?.Content is CastControl control)


### PR DESCRIPTION
Allows, at a glance, to view how the playback speed is set on the context menu.
Switched to a more appropriate glyph.