### PR TITLE
fix: downgrade libvlc and libvlcsharp

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -283,7 +283,7 @@
       <Version>8.2.2</Version>
     </PackageReference>
     <PackageReference Include="LibVLCSharp">
-      <Version>3.8.2</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.8.6</Version>

--- a/Screenbox.Core/packages.lock.json
+++ b/Screenbox.Core/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "LibVLCSharp": {
         "type": "Direct",
-        "requested": "[3.8.2, )",
-        "resolved": "3.8.2",
-        "contentHash": "P61Pkc+2GgX9PGJmm0MTVYKh0zPbak25rkyb5MU8Vq7x/VgFV/0h3L2bP7H4Oz5sfmm03H8T010cqEKQVA4Jew==",
+        "requested": "[3.7.0, )",
+        "resolved": "3.7.0",
+        "contentHash": "N9NV+BamKr+1YiRktX9JroE4m9C+pEszUNW4qa3A5mychhCWBvvoDolZKWk2yxhZvHewgaXXahBcw5ivCXjKYA==",
         "dependencies": {
           "System.Memory": "4.5.4"
         }

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1037,7 +1037,7 @@
       <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
-      <Version>3.3.2</Version>
+      <Version>3.3.1</Version>
     </PackageReference>
     <PackageReference Include="ReswPlusLib">
       <Version>2.0.0</Version>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -132,9 +132,9 @@
       },
       "VideoLAN.LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.3.2, )",
-        "resolved": "3.3.2",
-        "contentHash": "VOdfDFXIuaF1lPzB3K5BkQ7QKVSOQ8qIU79r/N3amWhDsVnLFROJUSgoZ9eHj5G80gjEshCV3zr/Mv0jgjJ/KA=="
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "JdvRcXpskkSKobjaDPO2bw+/tVDDkdRIIKylt+zs0MTuzCl1DcPc/AQqVX8rhNONBTqOV20PizqnkG0//dsmFA=="
       },
       "CommunityToolkit.Common": {
         "type": "Transitive",
@@ -180,8 +180,8 @@
       },
       "LibVLCSharp": {
         "type": "Transitive",
-        "resolved": "3.8.2",
-        "contentHash": "P61Pkc+2GgX9PGJmm0MTVYKh0zPbak25rkyb5MU8Vq7x/VgFV/0h3L2bP7H4Oz5sfmm03H8T010cqEKQVA4Jew==",
+        "resolved": "3.7.0",
+        "contentHash": "N9NV+BamKr+1YiRktX9JroE4m9C+pEszUNW4qa3A5mychhCWBvvoDolZKWk2yxhZvHewgaXXahBcw5ivCXjKYA==",
         "dependencies": {
           "SharpDX.Direct3D11": "4.2.0",
           "System.Memory": "4.5.4",
@@ -482,7 +482,7 @@
           "CommunityToolkit.Diagnostics": "[8.2.2, )",
           "CommunityToolkit.Mvvm": "[8.2.2, )",
           "CommunityToolkit.Uwp.Extensions": "[8.0.230907, )",
-          "LibVLCSharp": "[3.8.2, )",
+          "LibVLCSharp": "[3.7.0, )",
           "Microsoft.AppCenter.Analytics": "[5.0.3, )",
           "Microsoft.AppCenter.Crashes": "[5.0.3, )",
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.14, )",


### PR DESCRIPTION
Downgrade LibVLCSharp due to a [subtitle rendering with a semi-transparent background issue](https://code.videolan.org/videolan/LibVLCSharp/-/issues/631).

Downgrade LibVLC due to an audio issue #230 