### PR TITLE
fix: multi-stream playlist parse

### DIFF
--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -654,7 +654,7 @@ namespace Screenbox.Core.ViewModels
                 _cts = cts;
                 Media media = source.Item.Media;
                 MediaParsedStatus parsedStatus = await media.Parse(
-                    MediaParseOptions.ParseNetwork | MediaParseOptions.FetchNetwork | MediaParseOptions.DoInteract,
+                    MediaParseOptions.ParseNetwork | MediaParseOptions.DoInteract,
                     5000, cts.Token);
 
                 // Only playlist with more than 1 sub items should be insert into the current playlist

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1044,7 +1044,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
-      <Version>3.3.3-alpha</Version>
+      <Version>3.3.3-20231219</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -132,9 +132,9 @@
       },
       "VideoLAN.LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.3.3-alpha, )",
-        "resolved": "3.3.3-alpha",
-        "contentHash": "sFjQialPiNeW9qxbybv8x/N0YE0ELZHFrwgCtL2ZM6Yu/veUktZU5qIy+ucymI69k1p4sRFMLUhxNSOajPsj3A=="
+        "requested": "[3.3.3-20231219, )",
+        "resolved": "3.3.3-20231219",
+        "contentHash": "kXH/UY6Eqn6L8ZKDua37374Fymw6jTcZgFMOxehUSlVCR0A9g35TMj/ZDkYeflgPv+yWDhMQXZqcbnEIHkzGwQ=="
       },
       "CommunityToolkit.Common": {
         "type": "Transitive",
@@ -469,12 +469,6 @@
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
-      },
-      "background": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.14, )"
-        }
       },
       "screenbox.core": {
         "type": "Project",


### PR DESCRIPTION
Fix an issue where playlist files are not parsed on load. VLC would skip parsing the file because `winrt` protocol is an unknown type. Fixed in https://github.com/huynhsontung/libvlc-nuget/pull/11