### PR TITLE
fix: improve item processing on playlist enqueue

### DIFF
--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -425,30 +425,13 @@ namespace Screenbox.Core.Playback
             VlcPlayer.Pause();
         }
 
-        public async void Play()
+        public void Play()
         {
             if (PlaybackItem?.Media == null) return;
             if (_readyToPlay)
             {
                 _readyToPlay = false;
-                Media media = PlaybackItem.Media;
-                if (media.Mrl.StartsWith("winrt://"))
-                {
-                    VlcPlayer.Play(media);
-                }
-                else
-                {
-                    while (!media.IsParsed || media.ParsedStatus == MediaParsedStatus.Skipped)
-                    {
-                        await media.Parse(MediaParseOptions.ParseNetwork);
-                        if (media.SubItems.Count > 0)
-                        {
-                            media = media.SubItems[0] ?? media;
-                        }
-                    }
-
-                    VlcPlayer.Play(media);
-                }
+                VlcPlayer.Play(PlaybackItem.Media);
             }
             else
             {

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -451,6 +451,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (media.Item == null
                 || media.Item.Media is { IsParsed: true, SubItems.Count: 0 }
+                || (media.Source is IStorageFile file && !file.IsSupportedPlaylist())
                 || await ParsePlaylistAsync(media) is not { Count: > 0 } playlist)
             {
                 Items.Add(media);


### PR DESCRIPTION
Simplify item processing logic across `VlcMediaPlayer` and `MediaListViewModel`. Consolidate all item parsing on enqueue in `MediaListViewModel`.

Fixes #257 