### PR TITLE
fix: incorrect color space when rendering HDR content on SDR screen

### DIFF
--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1044,7 +1044,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
-      <Version>3.3.3-20231219</Version>
+      <Version>3.3.3-20231224</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -132,9 +132,9 @@
       },
       "VideoLAN.LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.3.3-20231219, )",
-        "resolved": "3.3.3-20231219",
-        "contentHash": "kXH/UY6Eqn6L8ZKDua37374Fymw6jTcZgFMOxehUSlVCR0A9g35TMj/ZDkYeflgPv+yWDhMQXZqcbnEIHkzGwQ=="
+        "requested": "[3.3.3-20231224, )",
+        "resolved": "3.3.3-20231224",
+        "contentHash": "1pwJ6JETCvs/FB5ecJsDyFm7wGffQrVKPPSZmRswwab/W48A1mooydcabesdYEhEuBJgA7nxMvMKnD/mW8B7ag=="
       },
       "CommunityToolkit.Common": {
         "type": "Transitive",


### PR DESCRIPTION
HDR contents appear blown out on an SDR screen. Fixed in LibVLC: https://github.com/huynhsontung/libvlc-nuget/pull/12

![image](https://github.com/huynhsontung/Screenbox/assets/31434093/73336cd8-e47c-4c1e-9743-988640ea2f5d)
