### PR TITLE
refactor: split one common media vm into subclasses

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -237,6 +237,7 @@
     <Compile Include="ViewModels\CastControlViewModel.cs" />
     <Compile Include="ViewModels\ChapterViewModel.cs" />
     <Compile Include="ViewModels\CommonViewModel.cs" />
+    <Compile Include="ViewModels\FileMediaViewModel.cs" />
     <Compile Include="ViewModels\FolderListViewPageViewModel.cs" />
     <Compile Include="ViewModels\FolderViewPageViewModel.cs" />
     <Compile Include="ViewModels\HomePageViewModel.cs" />
@@ -258,6 +259,7 @@
     <Compile Include="ViewModels\SongSearchResultPageViewModel.cs" />
     <Compile Include="ViewModels\SongsPageViewModel.cs" />
     <Compile Include="ViewModels\StorageItemViewModel.cs" />
+    <Compile Include="ViewModels\UriMediaViewModel.cs" />
     <Compile Include="ViewModels\VideoSearchResultPageViewModel.cs" />
     <Compile Include="ViewModels\VideosPageViewModel.cs" />
     <Compile Include="ViewModels\VolumeViewModel.cs" />

--- a/Screenbox.Core/Services/SystemMediaTransportControlsService.cs
+++ b/Screenbox.Core/Services/SystemMediaTransportControlsService.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using Screenbox.Core.Helpers;
+using Screenbox.Core.ViewModels;
 using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
@@ -43,8 +44,9 @@ namespace Screenbox.Core.Services
 
             try
             {
-                if (item.Source is StorageFile file)
+                if (item is FileMediaViewModel fileItem)
                 {
+                    StorageFile file = fileItem.File;
                     if (file.IsSupportedAudio())
                     {
                         bool success = await displayUpdater.CopyFromFileAsync(MediaPlaybackType.Music, file);

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -61,7 +61,7 @@ namespace Screenbox.Core.ViewModels
         public async void Receive(PlaylistCurrentItemChangedMessage message)
         {
             if (_mediaPlayer == null) return;
-            if (message.Value?.Source is not StorageFile file) return;
+            if (message.Value is not FileMediaViewModel { File: { } file }) return;
             QueryOptions options = new(CommonFileQuery.DefaultQuery, FilesHelpers.SupportedSubtitleFormats)
             {
                 ApplicationSearchFilter = $"System.FileName:$<\"{Path.GetFileNameWithoutExtension(file.Name)}\""

--- a/Screenbox.Core/ViewModels/FileMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/FileMediaViewModel.cs
@@ -72,7 +72,7 @@ public sealed class FileMediaViewModel : MediaViewModel
 
     private async Task LoadDetailsInternalAsync()
     {
-        if (Source is not StorageFile { IsAvailable: true } file) return;
+        if (!File.IsAvailable) return;
         string[] additionalPropertyKeys =
         {
                 SystemProperties.Title,
@@ -82,13 +82,13 @@ public sealed class FileMediaViewModel : MediaViewModel
 
         try
         {
-            IDictionary<string, object> additionalProperties = await file.Properties.RetrievePropertiesAsync(additionalPropertyKeys);
+            IDictionary<string, object> additionalProperties = await File.Properties.RetrievePropertiesAsync(additionalPropertyKeys);
             if (additionalProperties[SystemProperties.Title] is string name && !string.IsNullOrEmpty(name))
             {
                 Name = name;
-                if (MediaType == MediaPlaybackType.Video && name != file.Name)
+                if (MediaType == MediaPlaybackType.Video && name != File.Name)
                 {
-                    AltCaption = file.Name;
+                    AltCaption = File.Name;
                 }
             }
 
@@ -99,15 +99,15 @@ public sealed class FileMediaViewModel : MediaViewModel
                 Caption = Humanizer.ToDuration(duration);
             }
 
-            BasicProperties ??= await file.GetBasicPropertiesAsync();
+            BasicProperties ??= await File.GetBasicPropertiesAsync();
 
             switch (MediaType)
             {
                 case MediaPlaybackType.Video:
-                    VideoProperties ??= await file.Properties.GetVideoPropertiesAsync();
+                    VideoProperties ??= await File.Properties.GetVideoPropertiesAsync();
                     break;
                 case MediaPlaybackType.Music:
-                    MusicProperties ??= await file.Properties.GetMusicPropertiesAsync();
+                    MusicProperties ??= await File.Properties.GetMusicPropertiesAsync();
                     if (MusicProperties != null)
                     {
                         TrackNumber = MusicProperties.TrackNumber;
@@ -156,9 +156,9 @@ public sealed class FileMediaViewModel : MediaViewModel
 
     private async Task LoadThumbnailInternalAsync()
     {
-        if (Thumbnail == null && Source is StorageFile file)
+        if (Thumbnail == null)
         {
-            StorageItemThumbnail? source = ThumbnailSource = await _filesService.GetThumbnailAsync(file);
+            StorageItemThumbnail? source = ThumbnailSource = await _filesService.GetThumbnailAsync(File);
             if (source == null) return;
             BitmapImage image = new();
             await image.SetSourceAsync(ThumbnailSource);

--- a/Screenbox.Core/ViewModels/FileMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/FileMediaViewModel.cs
@@ -1,0 +1,177 @@
+﻿#nullable enable
+
+using Screenbox.Core.Factories;
+using Screenbox.Core.Helpers;
+using Screenbox.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.Media;
+using Windows.Storage;
+using Windows.Storage.FileProperties;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Screenbox.Core.ViewModels;
+public sealed class FileMediaViewModel : MediaViewModel
+{
+    public StorageFile File { get; }
+
+    private readonly IFilesService _filesService;
+    private readonly AlbumViewModelFactory _albumFactory;
+    private readonly ArtistViewModelFactory _artistFactory;
+    private Task _loadTask;
+    private Task _loadThumbnailTask;
+
+    public FileMediaViewModel(IFilesService filesService, IMediaService mediaService,
+        AlbumViewModelFactory albumFactory, ArtistViewModelFactory artistFactory, StorageFile file)
+        : base(file, mediaService)
+    {
+        _filesService = filesService;
+        _albumFactory = albumFactory;
+        _artistFactory = artistFactory;
+        _loadTask = Task.CompletedTask;
+        _loadThumbnailTask = Task.CompletedTask;
+
+        Name = file.Name;
+        MediaType = GetMediaTypeForFile(file);
+        Location = file.Path;
+        File = file;
+    }
+
+    private FileMediaViewModel(FileMediaViewModel source) : base(source)
+    {
+        _filesService = source._filesService;
+        _albumFactory = source._albumFactory;
+        _artistFactory = source._artistFactory;
+        _loadTask = source._loadTask;
+        _loadThumbnailTask = source._loadThumbnailTask;
+        File = source.File;
+    }
+
+    public override MediaViewModel Clone()
+    {
+        return new FileMediaViewModel(this);
+    }
+
+    public async Task LoadTitleAsync()
+    {
+        string[] propertyKeys = { SystemProperties.Title };
+        IDictionary<string, object> properties = await File.Properties.RetrievePropertiesAsync(propertyKeys);
+        if (properties[SystemProperties.Title] is string name && !string.IsNullOrEmpty(name))
+        {
+            Name = name;
+        }
+    }
+
+    public override Task LoadDetailsAsync()
+    {
+        if (!_loadTask.IsCompleted) return _loadTask;
+        _loadTask = LoadDetailsInternalAsync();
+        return _loadTask;
+    }
+
+    private async Task LoadDetailsInternalAsync()
+    {
+        if (Source is not StorageFile { IsAvailable: true } file) return;
+        string[] additionalPropertyKeys =
+        {
+                SystemProperties.Title,
+                SystemProperties.Music.Artist,
+                SystemProperties.Media.Duration
+            };
+
+        try
+        {
+            IDictionary<string, object> additionalProperties = await file.Properties.RetrievePropertiesAsync(additionalPropertyKeys);
+            if (additionalProperties[SystemProperties.Title] is string name && !string.IsNullOrEmpty(name))
+            {
+                Name = name;
+                if (MediaType == MediaPlaybackType.Video && name != file.Name)
+                {
+                    AltCaption = file.Name;
+                }
+            }
+
+            if (additionalProperties[SystemProperties.Media.Duration] is ulong ticks and > 0)
+            {
+                TimeSpan duration = TimeSpan.FromTicks((long)ticks);
+                Duration = duration;
+                Caption = Humanizer.ToDuration(duration);
+            }
+
+            BasicProperties ??= await file.GetBasicPropertiesAsync();
+
+            switch (MediaType)
+            {
+                case MediaPlaybackType.Video:
+                    VideoProperties ??= await file.Properties.GetVideoPropertiesAsync();
+                    break;
+                case MediaPlaybackType.Music:
+                    MusicProperties ??= await file.Properties.GetMusicPropertiesAsync();
+                    if (MusicProperties != null)
+                    {
+                        TrackNumber = MusicProperties.TrackNumber;
+                        Year = MusicProperties.Year;
+                        Genre ??= MusicProperties.Genre.Count > 0 ? MusicProperties.Genre[0] : null;
+                        Album ??= _albumFactory.AddSongToAlbum(this, MusicProperties.Album, MusicProperties.AlbumArtist, Year);
+
+                        if (Artists.Length == 0)
+                        {
+                            string[] contributingArtists =
+                                additionalProperties[SystemProperties.Music.Artist] as string[] ??
+                                Array.Empty<string>();
+                            Artists = _artistFactory.ParseArtists(contributingArtists, this);
+                        }
+
+                        if (string.IsNullOrEmpty(MusicProperties.Artist))
+                        {
+                            AltCaption = MusicProperties.Album;
+                        }
+                        else
+                        {
+                            Caption = MusicProperties.Artist;
+                            AltCaption = string.IsNullOrEmpty(MusicProperties.Album)
+                                ? MusicProperties.Artist
+                                : $"{MusicProperties.Artist} – {MusicProperties.Album}";
+                        }
+                    }
+
+                    break;
+            }
+        }
+        catch (Exception e)
+        {
+            // System.Exception: The RPC server is unavailable.
+            if (e.HResult != unchecked((int)0x800706BA))
+                LogService.Log(e);
+        }
+    }
+
+    public override Task LoadThumbnailAsync()
+    {
+        if (!_loadThumbnailTask.IsCompleted) return _loadThumbnailTask;
+        _loadThumbnailTask = LoadThumbnailInternalAsync();
+        return _loadThumbnailTask;
+    }
+
+    private async Task LoadThumbnailInternalAsync()
+    {
+        if (Thumbnail == null && Source is StorageFile file)
+        {
+            StorageItemThumbnail? source = ThumbnailSource = await _filesService.GetThumbnailAsync(file);
+            if (source == null) return;
+            BitmapImage image = new();
+            await image.SetSourceAsync(ThumbnailSource);
+            Thumbnail = image;
+        }
+    }
+
+    private static MediaPlaybackType GetMediaTypeForFile(IStorageFile file)
+    {
+        if (file.IsSupportedVideo()) return MediaPlaybackType.Video;
+        if (file.IsSupportedAudio()) return MediaPlaybackType.Music;
+        if (file.ContentType.StartsWith("image")) return MediaPlaybackType.Image;
+        // TODO: Support playlist type
+        return MediaPlaybackType.Unknown;
+    }
+}

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -49,7 +49,7 @@ namespace Screenbox.Core.ViewModels
 
         public async void Receive(PlaylistCurrentItemChangedMessage message)
         {
-            if (message.Value is { Source: IStorageItem } && _settingsService.ShowRecent)
+            if (message.Value is FileMediaViewModel && _settingsService.ShowRecent)
             {
                 await UpdateRecentMediaListAsync().ConfigureAwait(false);
             }
@@ -180,7 +180,7 @@ namespace Screenbox.Core.ViewModels
                 {
                     Recent.Add(new MediaViewModelWithMruToken(token, _mediaFactory.GetSingleton(file)));
                 }
-                else if (Recent[i].Media.Source is IStorageItem existing)
+                else if (Recent[i].Media is FileMediaViewModel { File: { } existing })
                 {
                     try
                     {
@@ -213,7 +213,7 @@ namespace Screenbox.Core.ViewModels
             int existingIndex = -1;
             for (int j = desiredIndex + 1; j < Recent.Count; j++)
             {
-                if (file.IsEqual(Recent[j].Media.Source as IStorageItem))
+                if (Recent[j].Media is FileMediaViewModel { File: { } existingFile } && file.IsEqual(existingFile))
                 {
                     existingIndex = j;
                     break;

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -462,7 +462,7 @@ namespace Screenbox.Core.ViewModels
             return playlist[0];
         }
 
-        private async Task<MediaViewModel> EnqueueAsync(IStorageFile file)
+        private async Task<MediaViewModel> EnqueueAsync(StorageFile file)
         {
             MediaViewModel media = _mediaFactory.GetSingleton(file);
             if (file.IsSupportedPlaylist() && await RecursiveParsePlaylistAsync(media) is { Count: > 0 } playlist)
@@ -496,7 +496,7 @@ namespace Screenbox.Core.ViewModels
 
         private async Task<MediaViewModel?> DispatchEnqueueAsync(object value) => value switch
         {
-            IStorageFile file => await EnqueueAsync(file),
+            StorageFile file => await EnqueueAsync(file),
             Uri uri => await EnqueueAsync(uri),
             IReadOnlyList<IStorageItem> files => await EnqueueAsync(files),
             MediaViewModel media => await EnqueueAsync(media),

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -224,7 +224,7 @@ namespace Screenbox.Core.ViewModels
 
         async partial void OnCurrentItemChanged(MediaViewModel? value)
         {
-            if (value is { Source: IStorageItem item })
+            if (value is FileMediaViewModel { File: { } item })
             {
                 _filesService.AddToRecent(item);
             }
@@ -451,7 +451,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (media.Item == null
                 || media.Item.Media is { IsParsed: true, SubItems.Count: 0 }
-                || (media.Source is IStorageFile file && !file.IsSupportedPlaylist())
+                || (media is FileMediaViewModel { File: { } file } && !file.IsSupportedPlaylist())
                 || await RecursiveParsePlaylistAsync(media) is not { Count: > 0 } playlist)
             {
                 Items.Add(media);
@@ -565,7 +565,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (Items.Count == 0 || CurrentItem == null) return;
             int index = CurrentIndex;
-            if (Items.Count == 1 && _neighboringFilesQuery != null && CurrentItem.Source is IStorageFile file)
+            if (Items.Count == 1 && _neighboringFilesQuery != null && CurrentItem is FileMediaViewModel { File: { } file })
             {
                 StorageFile? nextFile = await _filesService.GetNextFileAsync(file, _neighboringFilesQuery);
                 if (nextFile != null)
@@ -603,7 +603,7 @@ namespace Screenbox.Core.ViewModels
             }
 
             int index = CurrentIndex;
-            if (Items.Count == 1 && _neighboringFilesQuery != null && CurrentItem.Source is IStorageFile file)
+            if (Items.Count == 1 && _neighboringFilesQuery != null && CurrentItem is FileMediaViewModel { File: { } file })
             {
                 StorageFile? previousFile = await _filesService.GetPreviousFileAsync(file, _neighboringFilesQuery);
                 if (previousFile != null)

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -30,7 +30,7 @@ namespace Screenbox.Core.ViewModels
         public PlaybackItem? Item
         {
             get => _item ?? GetPlaybackItem();
-            internal set => _loaded = (_item = value) != null;
+            internal set => _loaded = (_item = value) != null;  // Only set on init. Don't need to worry about clean up in this case.
         }
 
         public IReadOnlyList<string> Options { get; }

--- a/Screenbox.Core/ViewModels/PlayQueuePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayQueuePageViewModel.cs
@@ -45,7 +45,7 @@ namespace Screenbox.Core.ViewModels
                 StorageFolder? folder = await _filesService.PickFolderAsync();
                 if (folder == null) return;
                 IReadOnlyList<IStorageItem> items = await _filesService.GetSupportedItems(folder).GetItemsAsync();
-                MediaViewModel[] files = items.OfType<IStorageFile>().Select(f => _mediaFactory.GetSingleton(f)).ToArray();
+                MediaViewModel[] files = items.OfType<StorageFile>().Select(f => _mediaFactory.GetSingleton(f)).ToArray();
                 if (files.Length == 0) return;
                 Messenger.Send(new QueuePlaylistMessage(files));
             }

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -582,6 +582,7 @@ namespace Screenbox.Core.ViewModels
             {
                 await current.LoadDetailsAsync();
                 await current.LoadThumbnailAsync();
+                current.UpdateMediaType();
                 MediaType = current.MediaType;
                 bool shouldBeVisible = _settingsService.PlayerAutoResize == PlayerAutoResizeOption.Always && !AudioOnly;
                 if (PlayerVisibility != PlayerVisibilityState.Visible)

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -80,7 +80,7 @@ namespace Screenbox.Core.ViewModels
                     break;
             }
 
-            if (media.Source is StorageFile file)
+            if (media is FileMediaViewModel { File: { } file })
             {
                 CanNavigateToFile = true;
                 _mediaFile = file;

--- a/Screenbox.Core/ViewModels/UriMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/UriMediaViewModel.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using Screenbox.Core.Services;
+using System;
+using System.Linq;
+
+namespace Screenbox.Core.ViewModels;
+public sealed class UriMediaViewModel : MediaViewModel
+{
+    public Uri Uri { get; }
+
+    public UriMediaViewModel(IMediaService mediaService, Uri uri)
+        : base(uri, mediaService)
+    {
+        Name = uri.Segments.Length > 0 ? Uri.UnescapeDataString(uri.Segments.Last()) : string.Empty;
+        Location = uri.ToString();
+        Uri = uri;
+    }
+
+    private UriMediaViewModel(UriMediaViewModel source) : base(source)
+    {
+        Uri = source.Uri;
+    }
+
+    public override MediaViewModel Clone()
+    {
+        return new UriMediaViewModel(this);
+    }
+}


### PR DESCRIPTION
Split `MediaViewModel` into `FileMediaViewModel` and `UriMediaViewModel`. Both new classes are derived from `MediaViewModel`.