### PR TITLE
fix: inconsistent ID between Uri media and file media

### DIFF
--- a/Screenbox.Core/ViewModels/FileMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/FileMediaViewModel.cs
@@ -32,7 +32,6 @@ public sealed class FileMediaViewModel : MediaViewModel
         Name = file.Name;
         MediaInfo.MediaType = GetMediaTypeForFile(file);
         Location = file.Path;
-        Id = file.Path;
         File = file;
     }
 

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -25,8 +25,6 @@ namespace Screenbox.Core.ViewModels
 
         public object Source { get; }
 
-        public string Id { get; protected set; }
-
         public bool IsFromLibrary { get; set; }
 
         public StorageItemThumbnail? ThumbnailSource { get; set; }
@@ -95,7 +93,6 @@ namespace Screenbox.Core.ViewModels
             Options = new ReadOnlyCollection<string>(_options);
             Location = source.Location;
             Source = source.Source;
-            Id = source.Id;
         }
 
         protected MediaViewModel(object source, IMediaService mediaService, AlbumViewModelFactory albumFactory, ArtistViewModelFactory artistFactory)
@@ -104,7 +101,6 @@ namespace Screenbox.Core.ViewModels
             _albumFactory = albumFactory;
             _artistFactory = artistFactory;
             Source = source;
-            Id = string.Empty;
             Location = string.Empty;
             _name = string.Empty;
             _mediaInfo = new MediaInfo();
@@ -117,7 +113,6 @@ namespace Screenbox.Core.ViewModels
             : this(media, mediaService, albumFactory, artistFactory)
         {
             Location = media.Mrl;
-            Id = Location;
 
             // Media is already loaded, create PlaybackItem
             _loaded = true;

--- a/Screenbox.Core/ViewModels/UriMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/UriMediaViewModel.cs
@@ -26,7 +26,7 @@ public sealed class UriMediaViewModel : MediaViewModel
     {
         _filesService = fileService;
         Name = uri.Segments.Length > 0 ? Uri.UnescapeDataString(uri.Segments.Last()) : string.Empty;
-        Location = uri.ToString();
+        Location = uri.OriginalString;  // Important. Must be the original string to be consistent with StorageFile.Path
         Id = uri.OriginalString;
         Uri = uri;
     }

--- a/Screenbox.Core/ViewModels/UriMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/UriMediaViewModel.cs
@@ -27,7 +27,6 @@ public sealed class UriMediaViewModel : MediaViewModel
         _filesService = fileService;
         Name = uri.Segments.Length > 0 ? Uri.UnescapeDataString(uri.Segments.Last()) : string.Empty;
         Location = uri.OriginalString;  // Important. Must be the original string to be consistent with StorageFile.Path
-        Id = uri.OriginalString;
         Uri = uri;
     }
 


### PR DESCRIPTION
LibraryService cannot reliably create and restore cache due to inconsistent `Location` values between `UriMediaViewModel` and `FileMediaViewModel`. 