### PR TITLE
fix: handle various exceptions

### DIFF
--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -20,6 +20,7 @@ using MediaViewModel = Screenbox.Core.ViewModels.MediaViewModel;
 
 namespace Screenbox.Core.Services
 {
+    // TODO: Break this service into smaller ViewModels and services
     public sealed class LibraryService : ILibraryService
     {
         public event TypedEventHandler<ILibraryService, object>? MusicLibraryContentChanged;

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -422,10 +422,15 @@ namespace Screenbox.Core.Services
             }
             catch (Exception e)
             {
-                files = Array.Empty<StorageFile>();
-                e.Data[nameof(fetchIndex)] = fetchIndex;
-                e.Data[nameof(batchSize)] = batchSize;
-                LogService.Log(e);
+                // System.Exception: The library, drive, or media pool is empty.
+                if (e.HResult != unchecked((int)0x800710D2))
+                {
+                    e.Data[nameof(fetchIndex)] = fetchIndex;
+                    e.Data[nameof(batchSize)] = batchSize;
+                    LogService.Log(e);
+                }
+
+                return new List<MediaViewModel>();
             }
 
             List<MediaViewModel> mediaBatch = files.Select(_mediaFactory.GetSingleton).ToList();

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -709,6 +709,10 @@ namespace Screenbox.Core.ViewModels
                 IEnumerable<MediaViewModel> playlist = media.SubItems.Select(item => _mediaFactory.GetTransient(item));
                 return playlist.ToList();
             }
+            catch (OperationCanceledException)
+            {
+                return Array.Empty<MediaViewModel>();
+            }
             finally
             {
                 _cts = null;

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -172,7 +172,7 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand]
         private async Task RefreshLibrariesAsync()
         {
-            await Task.WhenAll(_libraryService.FetchMusicAsync(), _libraryService.FetchVideosAsync());
+            await Task.WhenAll(RefreshMusicLibrary(), RefreshVideosLibrary());
         }
 
         [RelayCommand]
@@ -321,6 +321,30 @@ namespace Screenbox.Core.ViewModels
                 {
                     RemovableStorageFolders.Add(folder);
                 }
+            }
+        }
+
+        private async Task RefreshMusicLibrary()
+        {
+            try
+            {
+                await _libraryService.FetchMusicAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Music));
+            }
+        }
+
+        private async Task RefreshVideosLibrary()
+        {
+            try
+            {
+                await _libraryService.FetchVideosAsync();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Videos));
             }
         }
 

--- a/Screenbox.Core/ViewModels/UriMediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/UriMediaViewModel.cs
@@ -66,6 +66,10 @@ public sealed class UriMediaViewModel : MediaViewModel
                     break;
             }
         }
+        catch (UnauthorizedAccessException)
+        {
+            // ignored
+        }
         catch (Exception e)
         {
             // System.Exception: The RPC server is unavailable.

--- a/Screenbox.Core/ViewModels/VideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/VideosPageViewModel.cs
@@ -39,12 +39,13 @@ namespace Screenbox.Core.ViewModels
             _resourceService = resourceService;
             _libraryService.VideosLibraryContentChanged += OnVideosLibraryContentChanged;
             _hasVideos = true;
-            Breadcrumbs = new ObservableCollection<StorageFolder> { FirstFolder };
+            Breadcrumbs = new ObservableCollection<StorageFolder>();
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         }
 
         public void UpdateVideos()
         {
+            if (Breadcrumbs.Count == 0) Breadcrumbs.Add(FirstFolder);
             HasVideos = _libraryService.GetVideosFetchResult().Count > 0;
             AddFolderCommand.NotifyCanExecuteChanged();
         }

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -38,8 +38,15 @@ namespace Screenbox
         {
             get
             {
-                string flowDirectionSetting = ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];
-                return flowDirectionSetting == "RTL";
+                try
+                {
+                    string flowDirectionSetting = ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];
+                    return flowDirectionSetting == "RTL";
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return false;
+                }
             }
         }
 

--- a/Screenbox/Controls/OpenUrlDialog.xaml.cs
+++ b/Screenbox/Controls/OpenUrlDialog.xaml.cs
@@ -20,7 +20,10 @@ namespace Screenbox.Controls
         {
             OpenUrlDialog dialog = new();
             ContentDialogResult result = await dialog.ShowAsync();
-            return result != ContentDialogResult.Primary ? null : new Uri(dialog.UrlBox.Text);
+            string url = dialog.UrlBox.Text;
+            return result == ContentDialogResult.Primary && Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri uri)
+                ? uri
+                : null;
         }
 
         private bool CanOpen(string url)

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -132,7 +132,7 @@
                         x:Name="PlayButton"
                         AutomationProperties.Name="{strings:Resources Key=Play}"
                         Command="{x:Bind ViewModel.PlayCommand}"
-                        CommandParameter="{x:Bind ViewModel.SortedItems[0], Mode=OneWay}"
+                        CommandParameter="{x:Bind ViewModel.SortedItems[0], Mode=OneWay, FallbackValue={x:Null}}"
                         Style="{StaticResource AccentButtonStyle}"
                         XYFocusDown="{x:Bind ItemList}">
                         <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
The following changes are included:
- catch task canceled exception when parsing playlist
- handle IsRightToLeftLanguage exception
- enforce try create Uri in open url dialog
- handle UnauthorizedAccessException when getting file from path
- ignore media pool empty exception
- fix binding error for album details page when there is no related item
- handle unauthorized exceptions on manual library refresh
- delay VideosPage breadcrumbs population until navigation