### PR TITLE
fix: status message disappears too quickly when using touch gestures

### DIFF
--- a/Screenbox.Core/Messages/UpdateStatusMessage.cs
+++ b/Screenbox.Core/Messages/UpdateStatusMessage.cs
@@ -6,11 +6,8 @@ namespace Screenbox.Core.Messages
 {
     public sealed class UpdateStatusMessage : ValueChangedMessage<string?>
     {
-        public bool Persistent { get; }
-
-        public UpdateStatusMessage(string? value, bool persistent = false) : base(value)
+        public UpdateStatusMessage(string? value) : base(value)
         {
-            Persistent = persistent;
         }
     }
 }

--- a/Screenbox.Core/Messages/UpdateVolumeStatusMessage.cs
+++ b/Screenbox.Core/Messages/UpdateVolumeStatusMessage.cs
@@ -4,11 +4,8 @@ namespace Screenbox.Core.Messages
 {
     public sealed class UpdateVolumeStatusMessage : ValueChangedMessage<int>
     {
-        public bool Persistent { get; }
-
-        public UpdateVolumeStatusMessage(int value, bool persistent) : base(value)
+        public UpdateVolumeStatusMessage(int value) : base(value)
         {
-            Persistent = persistent;
         }
     }
 }

--- a/Screenbox.Core/ViewModels/MainPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MainPageViewModel.cs
@@ -111,7 +111,7 @@ namespace Screenbox.Core.ViewModels
             if (volumeChange != 0)
             {
                 int volume = Messenger.Send(new ChangeVolumeRequestMessage(volumeChange, true));
-                Messenger.Send(new UpdateVolumeStatusMessage(volume, false));
+                Messenger.Send(new UpdateVolumeStatusMessage(volume));
             }
 
             args.Handled = true;

--- a/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
@@ -131,14 +131,13 @@ namespace Screenbox.Core.ViewModels
             PointerPoint? pointer = e.GetCurrentPoint((UIElement)e.OriginalSource);
             int mouseWheelDelta = pointer.Properties.MouseWheelDelta;
             int volume = Messenger.Send(new ChangeVolumeRequestMessage(mouseWheelDelta > 0 ? 5 : -5, true));
-            Messenger.Send(new UpdateVolumeStatusMessage(volume, false));
+            Messenger.Send(new UpdateVolumeStatusMessage(volume));
         }
 
         public void VideoView_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
         {
             if (_manipulationLock == ManipulationLock.None) return;
             Messenger.Send(new OverrideControlsHideDelayMessage(100));
-            Messenger.Send(new UpdateStatusMessage(null));
             Messenger.Send(new TimeChangeOverrideMessage(false));
         }
 
@@ -159,7 +158,7 @@ namespace Screenbox.Core.ViewModels
             {
                 _manipulationLock = ManipulationLock.Vertical;
                 int volume = Messenger.Send(new ChangeVolumeRequestMessage((int)-verticalChange, true));
-                Messenger.Send(new UpdateVolumeStatusMessage(volume, true));
+                Messenger.Send(new UpdateVolumeStatusMessage(volume));
                 return;
             }
 
@@ -176,7 +175,7 @@ namespace Screenbox.Core.ViewModels
                 string changeText = Humanizer.ToDuration(newTime - _timeBeforeManipulation);
                 if (changeText[0] != '-') changeText = '+' + changeText;
                 string status = $"{Humanizer.ToDuration(newTime)} ({changeText})";
-                Messenger.Send(new UpdateStatusMessage(status, true));
+                Messenger.Send(new UpdateStatusMessage(status));
             }
         }
 

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -145,7 +145,7 @@ namespace Screenbox.Core.ViewModels
         public void Receive(UpdateVolumeStatusMessage message)
         {
             Receive(new UpdateStatusMessage(
-                _resourceService.GetString(ResourceName.VolumeChangeStatusMessage, message.Value), message.Persistent));
+                _resourceService.GetString(ResourceName.VolumeChangeStatusMessage, message.Value)));
         }
 
         public void Receive(UpdateStatusMessage message)
@@ -156,7 +156,12 @@ namespace Screenbox.Core.ViewModels
             _dispatcherQueue.TryEnqueue(() =>
             {
                 StatusMessage = message.Value;
-                if (message.Persistent || message.Value == null) return;
+                if (message.Value == null)
+                {
+                    _statusMessageTimer.Stop();
+                    return;
+                }
+
                 _statusMessageTimer.Debounce(() => StatusMessage = null, TimeSpan.FromSeconds(1));
             });
         }
@@ -274,7 +279,7 @@ namespace Screenbox.Core.ViewModels
             }
 
             int volume = Messenger.Send(new ChangeVolumeRequestMessage(volumeChange, true));
-            Messenger.Send(new UpdateVolumeStatusMessage(volume, false));
+            Messenger.Send(new UpdateVolumeStatusMessage(volume));
             args.Handled = true;
         }
 


### PR DESCRIPTION
Fixes #266

Persistent status message forces the caller to manually dismiss the status message. We lose timeout ability this way. Just remove it and force every caller to follow the same timeout.