### PR TITLE
fix: alternate layout not updating on previously loaded list views

### DIFF
--- a/Screenbox/Controls/Interactions/AlternatingListViewBehavior.cs
+++ b/Screenbox/Controls/Interactions/AlternatingListViewBehavior.cs
@@ -54,9 +54,20 @@ namespace Screenbox.Controls.Interactions
 
             AssociatedObject.ActualThemeChanged += OnActualThemeChanged;
             AssociatedObject.ContainerContentChanging += OnContainerContentChanging;
-            if (AssociatedObject.Items != null)
+            if (AssociatedObject.Items == null) return;
+            AssociatedObject.Items.VectorChanged += ItemsOnVectorChanged;
+            if (AssociatedObject.Items.Count > 0)
             {
-                AssociatedObject.Items.VectorChanged += ItemsOnVectorChanged;
+                // Update alternate layout on attached if there are items.
+                // Item containers may be cached if the list is previously loaded
+                // and ContainerContentChanging event is not triggered.
+                for (int i = 0; i < AssociatedObject.Items.Count; i++)
+                {
+                    if (AssociatedObject.ContainerFromIndex(i) is SelectorItem itemContainer)
+                    {
+                        UpdateAlternateLayout(itemContainer, i);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Item containers may be cached if the list is previously loaded and `ContainerContentChanging` event is not triggered. Always refresh layout container on behavior attached.

https://github.com/huynhsontung/Screenbox/assets/31434093/84f443b7-6afb-43b2-a18d-5d7249ae5245

