### PR TITLE
fix(ui): minor UI fixes

### DIFF
--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -87,7 +87,7 @@
             Grid.Column="1"
             Width="32"
             Height="32"
-            Padding="7"
+            Padding="0"
             VerticalAlignment="Center"
             CommandParameter="{Binding}"
             Style="{StaticResource SubtleButtonStyle}"

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -98,7 +98,7 @@
                 <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
                 <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
                 <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
-                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
+                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
                 <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
                 <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
             </Button.Resources>

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -98,7 +98,7 @@
                 <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
                 <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
                 <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
-                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="HyperlinkButtonForeground" />
+                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
                 <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
                 <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
             </Button.Resources>

--- a/Screenbox/Controls/Styles/Subtle_themeresources.xaml
+++ b/Screenbox/Controls/Styles/Subtle_themeresources.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls">
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -69,6 +69,7 @@
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        muxc:AnimatedIcon.State="Normal"
                         AutomationProperties.AccessibilityView="Raw"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
@@ -96,6 +97,9 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="ContentPresenter.(muxc:AnimatedIcon.State)" Value="PointerOver" />
+                                    </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Pressed">
@@ -110,6 +114,9 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="ContentPresenter.(muxc:AnimatedIcon.State)" Value="Pressed" />
+                                    </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Disabled">
@@ -124,6 +131,10 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
+                                    <VisualState.Setters>
+                                        <!--  DisabledVisual Should be handled by the control, not the animated icon.  -->
+                                        <Setter Target="ContentPresenter.(muxc:AnimatedIcon.State)" Value="Normal" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>

--- a/Screenbox/Controls/Styles/Subtle_themeresources.xaml
+++ b/Screenbox/Controls/Styles/Subtle_themeresources.xaml
@@ -139,7 +139,7 @@
         TargetType="Button">
         <Setter Property="Width" Value="40" />
         <Setter Property="Height" Value="40" />
-        <Setter Property="Padding" Value="11" />
+        <Setter Property="Padding" Value="0" />
     </Style>
     <Style
         x:Key="SmallPlayerButtonStyle"
@@ -147,7 +147,7 @@
         TargetType="Button">
         <Setter Property="Width" Value="36" />
         <Setter Property="Height" Value="36" />
-        <Setter Property="Padding" Value="9" />
+        <Setter Property="Padding" Value="0" />
     </Style>
 
     <!--  Custom ToggleButton style that is transparent and has no border.  -->
@@ -345,7 +345,7 @@
         TargetType="ToggleButton">
         <Setter Property="Width" Value="40" />
         <Setter Property="Height" Value="40" />
-        <Setter Property="Padding" Value="11" />
+        <Setter Property="Padding" Value="0" />
     </Style>
     <Style
         x:Key="SmallPlayerToggleButtonStyle"
@@ -353,7 +353,7 @@
         TargetType="ToggleButton">
         <Setter Property="Width" Value="36" />
         <Setter Property="Height" Value="36" />
-        <Setter Property="Padding" Value="9" />
+        <Setter Property="Padding" Value="0" />
     </Style>
 
 </ResourceDictionary>

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -32,44 +32,37 @@
                     <Color x:Key="BackgroundAcrylicTintColor">#202020</Color>
                     <Color x:Key="BackgroundAcrylicTintFallbackColor">#C92C2C2C</Color>
                     <x:Double x:Key="BackgroundAcrylicTintOpacity">0.5</x:Double>
-                    <StaticResource x:Key="RestoreButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
-                    <StaticResource x:Key="RestoreButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
-                    <StaticResource x:Key="HeaderBackgroundBrush" ResourceKey="HeaderLinearGradient" />
-                    <StaticResource x:Key="ControlsBackgroundBrush" ResourceKey="ControlsLinearGradient" />
+                    <StaticResource x:Key="HeaderBackgroundGradientBrush" ResourceKey="HeaderBackgroundLinearGradient" />
+                    <StaticResource x:Key="ControlsBackgroundGradientBrush" ResourceKey="ControlsBackgroundLinearGradient" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <Color x:Key="BackgroundAcrylicTintColor">#FCFCFC</Color>
                     <Color x:Key="BackgroundAcrylicTintFallbackColor">#C9F9F9F9</Color>
                     <x:Double x:Key="BackgroundAcrylicTintOpacity">0.45</x:Double>
-                    <StaticResource x:Key="RestoreButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
-                    <StaticResource x:Key="RestoreButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />
-                    <StaticResource x:Key="HeaderBackgroundBrush" ResourceKey="HeaderLinearGradient" />
-                    <StaticResource x:Key="ControlsBackgroundBrush" ResourceKey="ControlsLinearGradient" />
+                    <StaticResource x:Key="HeaderBackgroundGradientBrush" ResourceKey="HeaderBackgroundLinearGradient" />
+                    <StaticResource x:Key="ControlsBackgroundGradientBrush" ResourceKey="ControlsBackgroundLinearGradient" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <StaticResource x:Key="BackgroundAcrylicTintColor" ResourceKey="SystemColorWindowColor" />
                     <StaticResource x:Key="BackgroundAcrylicTintFallbackColor" ResourceKey="SystemColorWindowColor" />
                     <x:Double x:Key="BackgroundAcrylicTintOpacity">1</x:Double>
-                    <StaticResource x:Key="RestoreButtonBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
-                    <StaticResource x:Key="RestoreButtonBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
-                    <StaticResource x:Key="HeaderBackgroundBrush" ResourceKey="SystemColorWindowColor" />
-                    <StaticResource x:Key="ControlsBackgroundBrush" ResourceKey="SystemColorWindowColor" />
+                    <StaticResource x:Key="HeaderBackgroundGradientBrush" ResourceKey="SystemColorWindowColorBrush" />
+                    <StaticResource x:Key="ControlsBackgroundGradientBrush" ResourceKey="SystemColorWindowColorBrush" />
+                    <StaticResource x:Key="ProgressBarBackground" ResourceKey="SystemColorButtonTextColorBrush" />
                     <Thickness x:Key="ProgressBarBorderThemeThickness">0</Thickness>
-                    <StaticResource x:Key="ProgressBarBackground" ResourceKey="SystemColorWindowTextColor" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
-            <!--  Background brushes  -->
-            <LinearGradientBrush x:Key="HeaderLinearGradient" StartPoint="0.5,0" EndPoint="0.5,1">
+            <LinearGradientBrush x:Key="HeaderBackgroundLinearGradient" StartPoint="0.5,0" EndPoint="0.5,1">
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0" Color="#B31C1C1C" />
+                    <GradientStop Offset="0" Color="{StaticResource SystemChromeBlackMediumLowColor}" />
                     <GradientStop Offset="1" Color="#00000000" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
-            <LinearGradientBrush x:Name="ControlsLinearGradient" StartPoint="0.5,0" EndPoint="0.5,1">
+            <LinearGradientBrush x:Name="ControlsBackgroundLinearGradient" StartPoint="0.5,0" EndPoint="0.5,1">
                 <LinearGradientBrush.GradientStops>
                     <GradientStop Offset="0" Color="#00000000" />
-                    <GradientStop Offset="1" Color="#B31C1C1C" />
+                    <GradientStop Offset="1" Color="{StaticResource SystemChromeBlackMediumLowColor}" />
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
 
@@ -165,7 +158,7 @@
             MinHeight="32"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
-            Background="{ThemeResource HeaderBackgroundBrush}"
+            Background="{ThemeResource HeaderBackgroundGradientBrush}"
             Canvas.ZIndex="3" />
 
         <Grid
@@ -388,9 +381,25 @@
             Command="{x:Bind ViewModel.RestorePlayerCommand}"
             Visibility="Collapsed">
             <Button.Resources>
-                <StaticResource x:Key="ButtonBackground" ResourceKey="SystemControlTransparentBrush" />
-                <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="RestoreButtonBackgroundPointerOver" />
-                <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="RestoreButtonBackgroundPressed" />
+                <ResourceDictionary>
+                    <ResourceDictionary.ThemeDictionaries>
+                        <ResourceDictionary x:Key="Default">
+                            <StaticResource x:Key="ButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="Light">
+                            <StaticResource x:Key="ButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="HighContrast">
+                            <StaticResource x:Key="ButtonBackground" ResourceKey="SystemControlTransparentBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+                            <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+                        </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                </ResourceDictionary>
             </Button.Resources>
             <Button.KeyboardAccelerators>
                 <KeyboardAccelerator Key="I" />
@@ -492,7 +501,7 @@
             x:Name="PlayerControlsBackground"
             Grid.Row="2"
             Grid.Column="0"
-            Background="{ThemeResource ControlsBackgroundBrush}"
+            Background="{ThemeResource ControlsBackgroundGradientBrush}"
             Tapped="PlayerControlsBackground_OnTapped" />
 
         <controls:PlayerControls

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -55,7 +55,7 @@
                     <Button
                         Width="32"
                         Height="32"
-                        Padding="7"
+                        Padding="0"
                         VerticalAlignment="Center"
                         Command="{StaticResource RemoveVideosFolderCommand}"
                         CommandParameter="{x:Bind}"
@@ -70,7 +70,7 @@
                     <Button
                         Width="32"
                         Height="32"
-                        Padding="7"
+                        Padding="0"
                         VerticalAlignment="Center"
                         Command="{StaticResource RemoveMusicFolderCommand}"
                         CommandParameter="{x:Bind}"


### PR DESCRIPTION
### Describe the changes

- Revert the beginning of the PlayerPage gradients to a pure black shade

- Brings back the 'Back' button animation on PlayerPage

- Reworked the padding on a couple of buttons to prevent glyph cut-off at some scales
![Example of glyph cut-off problem at 150 scale](https://github.com/huynhsontung/Screenbox/assets/698155/54ee1c39-2b2e-43db-9918-9d15c352c38d)

- (HighContrast) Use the same foreground brush on the MediaListView buttons
