### PR TITLE
fix: wrong media type can be set on file load

### DIFF
--- a/Screenbox.Core/Helpers/FilesHelpers.cs
+++ b/Screenbox.Core/Helpers/FilesHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using Screenbox.Core.Enums;
+using System.Collections.Immutable;
 using Windows.Storage;
 
 namespace Screenbox.Core.Helpers;
@@ -23,4 +24,13 @@ public static class FilesHelpers
     public static bool IsSupportedPlaylist(this IStorageFile file) => SupportedPlaylistFormats.Contains(file.FileType.ToLowerInvariant());
     public static bool IsSupported(this IStorageFile file) => SupportedFormats.Contains(file.FileType.ToLowerInvariant());
     public static bool IsSupportedSubtitle(this IStorageFile file) => SupportedSubtitleFormats.Contains(file.FileType.ToLowerInvariant());
+
+    public static MediaPlaybackType GetMediaTypeForFile(IStorageFile file)
+    {
+        if (file.IsSupportedVideo()) return MediaPlaybackType.Video;
+        if (file.IsSupportedAudio()) return MediaPlaybackType.Music;
+        if (file.ContentType.StartsWith("image")) return MediaPlaybackType.Image;
+        if (file.IsSupportedPlaylist()) return MediaPlaybackType.Playlist;
+        return MediaPlaybackType.Unknown;
+    }
 }

--- a/Screenbox.Core/Models/MediaInfo.cs
+++ b/Screenbox.Core/Models/MediaInfo.cs
@@ -9,16 +9,17 @@ public sealed class MediaInfo
 {
     public MediaPlaybackType MediaType { get; set; }
 
-    public VideoInfo VideoProperties { get; set; }
+    public VideoInfo VideoProperties { get; }
 
-    public MusicInfo MusicProperties { get; set; }
+    public MusicInfo MusicProperties { get; }
 
-    public ulong Size { get; set; }
+    public ulong Size { get; }
 
-    public DateTimeOffset DateModified { get; set; }
+    public DateTimeOffset DateModified { get; }
 
-    public MediaInfo()
+    public MediaInfo(MediaPlaybackType mediaType)
     {
+        MediaType = mediaType;
         VideoProperties = new VideoInfo();
         MusicProperties = new MusicInfo();
     }

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -191,12 +191,12 @@ namespace Screenbox.Core.Services
 
         public async Task<MediaInfo> GetMediaInfoAsync(StorageFile file)
         {
-            if (!file.IsAvailable) return new MediaInfo();
+            MediaPlaybackType mediaType = FilesHelpers.GetMediaTypeForFile(file);
+            if (!file.IsAvailable) return new MediaInfo(mediaType);
 
             try
             {
                 BasicProperties basicProperties = await file.GetBasicPropertiesAsync();
-                MediaPlaybackType mediaType = GetMediaTypeForFile(file);
                 switch (mediaType)
                 {
                     case MediaPlaybackType.Video:
@@ -214,7 +214,7 @@ namespace Screenbox.Core.Services
                     LogService.Log(e);
             }
 
-            return new MediaInfo();
+            return new MediaInfo(mediaType);
         }
 
         private FileOpenPicker GetFilePickerForFormats(IReadOnlyCollection<string> formats)
@@ -238,15 +238,6 @@ namespace Screenbox.Core.Services
             }
 
             return picker;
-        }
-
-        private static MediaPlaybackType GetMediaTypeForFile(IStorageFile file)
-        {
-            if (file.IsSupportedVideo()) return MediaPlaybackType.Video;
-            if (file.IsSupportedAudio()) return MediaPlaybackType.Music;
-            if (file.ContentType.StartsWith("image")) return MediaPlaybackType.Image;
-            if (file.IsSupportedPlaylist()) return MediaPlaybackType.Playlist;
-            return MediaPlaybackType.Unknown;
         }
     }
 }

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -43,15 +43,12 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private bool _isPlaying;
         [ObservableProperty] private bool _isPlayingBadge;
         [ObservableProperty] private bool _isOpening;
+        [ObservableProperty] private bool _audioOnly;
         [ObservableProperty] private bool _showPlayPauseBadge;
         [ObservableProperty] private WindowViewMode _viewMode;
         [ObservableProperty] private NavigationViewDisplayMode _navigationViewDisplayMode;
         [ObservableProperty] private MediaViewModel? _media;
         [ObservableProperty] private ElementTheme _actualTheme;
-
-        [ObservableProperty]
-        [NotifyPropertyChangedFor(nameof(AudioOnly))]
-        private MediaPlaybackType _mediaType;
 
         [ObservableProperty]
         [NotifyPropertyChangedRecipients]
@@ -62,8 +59,6 @@ namespace Screenbox.Core.ViewModels
         private MediaPlaybackState _playbackState;
 
         public bool SeekBarPointerInteracting { get; set; }
-
-        public bool AudioOnly => MediaType == MediaPlaybackType.Music;
 
         private readonly DispatcherQueue _dispatcherQueue;
         private readonly DispatcherQueueTimer _openingTimer;
@@ -589,7 +584,7 @@ namespace Screenbox.Core.ViewModels
             {
                 await current.LoadDetailsAsync(_filesService);
                 await current.LoadThumbnailAsync(_filesService);
-                MediaType = current.MediaType;
+                AudioOnly = current.MediaType == MediaPlaybackType.Music;
                 bool shouldBeVisible = _settingsService.PlayerAutoResize == PlayerAutoResizeOption.Always && !AudioOnly;
                 if (PlayerVisibility != PlayerVisibilityState.Visible)
                 {


### PR DESCRIPTION
Try best to guess the media type as early as possible. Relying on async methods can fail and leave media with unknown media type.