### PR TITLE
fix: chromecast can't finding cast targets

### DIFF
--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1093,7 +1093,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="LibVLC.UWP">
-      <Version>3.0.20-2403201858</Version>
+      <Version>3.0.20-2404030615</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -66,9 +66,9 @@
       },
       "LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.0.20-2403201858, )",
-        "resolved": "3.0.20-2403201858",
-        "contentHash": "JWPF5AzL9bmPTOeonpMWXGV41iwceTCHIJDe6QJ+9cvjRNwqRcyjQvijBMrHWtImpx3xQs1C4vF4HJ18g6l1wQ=="
+        "requested": "[3.0.20-2404030615, )",
+        "resolved": "3.0.20-2404030615",
+        "contentHash": "J7sFZMPGWC6tCRDXcZdZ/usoGZCxsjM6c0M3di+k+UjaW1oPlqoC4jVSgMvzdvahoIHVG09+BWVdzeXer7BXOQ=="
       },
       "Microsoft.AppCenter.Analytics": {
         "type": "Direct",


### PR DESCRIPTION
Fixes #345 

LibVLC built with Mingw-w64 version higher than v9.0.0 fails to find Chromecast targets. Fixed in https://github.com/huynhsontung/libvlc-nuget/pull/18