### PR TITLE
fix: navigation from playlist flyout

### DIFF
--- a/Screenbox.Core/Services/INavigationService.cs
+++ b/Screenbox.Core/Services/INavigationService.cs
@@ -6,6 +6,7 @@ namespace Screenbox.Core.Services
 {
     public interface INavigationService
     {
+        event EventHandler? Navigated;
         void Navigate(Type vmType, object? parameter = null);
         void NavigateChild(Type parentVmType, Type targetVmType, object? parameter = null);
         void NavigateExisting(Type vmType, object? parameter = null);

--- a/Screenbox.Core/Services/NavigationService.cs
+++ b/Screenbox.Core/Services/NavigationService.cs
@@ -9,6 +9,8 @@ namespace Screenbox.Core.Services
 {
     public sealed class NavigationService : INavigationService
     {
+        public event EventHandler? Navigated;
+
         private readonly Dictionary<Type, Type> _vmPageMapping;
 
         public NavigationService(params KeyValuePair<Type, Type>[] mapping)
@@ -29,6 +31,7 @@ namespace Screenbox.Core.Services
             if (rootFrame.Content is IContentFrame page)
             {
                 page.NavigateContent(pageType, parameter);
+                Navigated?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -44,6 +47,7 @@ namespace Screenbox.Core.Services
                 if (page.ContentSourcePageType == parentPageType && page.FrameContent is IContentFrame childPage)
                 {
                     childPage.NavigateContent(targetPageType, parameter);
+                    Navigated?.Invoke(this, EventArgs.Empty);
                     return;
                 }
 
@@ -62,6 +66,7 @@ namespace Screenbox.Core.Services
                 if (page.ContentSourcePageType == pageType)
                 {
                     page.NavigateContent(pageType, parameter);
+                    Navigated?.Invoke(this, EventArgs.Empty);
                     break;
                 }
 

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Helpers;
 using Screenbox.Controls;
 using Screenbox.Core.Enums;
+using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
 using System;
 using System.ComponentModel;
@@ -67,6 +68,17 @@ namespace Screenbox.Pages
             ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
             AlbumArtImage.RegisterPropertyChangedCallback(Image.SourceProperty, AlbumArtImageOnSourceChanged);
             LayoutRoot.ActualThemeChanged += OnActualThemeChanged;
+
+            INavigationService navigationService = Ioc.Default.GetRequiredService<INavigationService>();   // For navigation events
+            navigationService.Navigated += NavigationServiceOnNavigated;
+        }
+
+        private void NavigationServiceOnNavigated(object sender, EventArgs e)
+        {
+            if (ViewModel.PlayerVisibility != PlayerVisibilityState.Visible) return;
+            ViewModel.GoBack();
+            if (PlayQueueFlyout.IsOpen)
+                PlayQueueFlyout.Hide();
         }
 
         private void ThemeListenerOnThemeChanged(ThemeListener sender)


### PR DESCRIPTION
Navigation from the playlist flyout when the player is visible does not work as expected. The app gets stuck in a non-recoverable UI state.

Fixes #331 