### PR TITLE
chore: add tooltips to overflowed textblocks

### DIFF
--- a/Screenbox/Controls/CommonGridViewItem.xaml
+++ b/Screenbox/Controls/CommonGridViewItem.xaml
@@ -80,8 +80,11 @@
             HorizontalTextAlignment="{x:Bind HorizontalTextAlignment}"
             MaxLines="2"
             Style="{StaticResource BodyStrongTextBlockStyle}"
-            Text="{Binding Name}"
-            TextWrapping="Wrap" />
+            Text="{Binding Name}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <TextBlock
             x:Name="CaptionText"
@@ -90,7 +93,12 @@
             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
             HorizontalTextAlignment="{x:Bind HorizontalTextAlignment}"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{x:Bind Caption, Mode=OneWay}" />
+            Text="{x:Bind Caption, Mode=OneWay}"
+            TextWrapping="NoWrap">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="CommonStates">

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -52,47 +52,48 @@
             ToolTipService.ToolTip="{strings:Resources Key=IsPlaying}"
             Visibility="Collapsed" />
 
-        <Grid Grid.Column="1">
-            <TextBlock
-                x:Name="TrackNumberText"
-                Padding="0,0,8,0"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Center"
-                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                IsHitTestVisible="False"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding TrackNumberText, FallbackValue=''}"
-                TextWrapping="NoWrap"
-                Visibility="{x:Bind IsTrackNumberVisible}" />
-            <FontIcon
-                x:Name="ItemMediaTypeIcon"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Glyph="{Binding Converter={StaticResource MediaGlyphConverter}}"
-                IsHitTestVisible="False"
-                Visibility="{x:Bind IsIconVisible}" />
-            <Button
-                x:Name="PlayButton"
-                Width="32"
-                Height="32"
-                Padding="0"
-                VerticalAlignment="Center"
-                Command="{x:Bind PlayCommand, Mode=OneWay}"
-                CommandParameter="{Binding}"
-                Style="{StaticResource SubtleButtonStyle}"
-                ToolTipService.ToolTip="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}"
-                Visibility="Collapsed">
-                <FontIcon Glyph="{Binding IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}}" />
-                <Button.Resources>
-                    <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
-                    <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
-                    <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
-                    <StaticResource x:Key="SubtleButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
-                    <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
-                    <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
-                </Button.Resources>
-            </Button>
-        </Grid>
+        <TextBlock
+            x:Name="TrackNumberText"
+            Grid.Column="1"
+            Padding="0,0,8,0"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Center"
+            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+            IsHitTestVisible="False"
+            Style="{StaticResource CaptionTextBlockStyle}"
+            Text="{Binding TrackNumberText, FallbackValue=''}"
+            TextWrapping="NoWrap"
+            Visibility="{x:Bind IsTrackNumberVisible}" />
+        <FontIcon
+            x:Name="ItemMediaTypeIcon"
+            Grid.Column="1"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Glyph="{Binding Converter={StaticResource MediaGlyphConverter}}"
+            IsHitTestVisible="False"
+            Visibility="{x:Bind IsIconVisible}" />
+        <Button
+            x:Name="PlayButton"
+            Grid.Column="1"
+            Width="32"
+            Height="32"
+            Padding="0"
+            VerticalAlignment="Center"
+            Command="{x:Bind PlayCommand, Mode=OneWay}"
+            CommandParameter="{Binding}"
+            Style="{StaticResource SubtleButtonStyle}"
+            ToolTipService.ToolTip="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}"
+            Visibility="Collapsed">
+            <FontIcon Glyph="{Binding IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}}" />
+            <Button.Resources>
+                <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
+                <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
+                <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
+                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+                <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
+                <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
+            </Button.Resources>
+        </Button>
 
         <TextBlock
             x:Name="TitleText"

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -52,63 +52,60 @@
             ToolTipService.ToolTip="{strings:Resources Key=IsPlaying}"
             Visibility="Collapsed" />
 
-        <TextBlock
-            x:Name="TrackNumberText"
-            Grid.Column="1"
-            Margin="8"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Center"
-            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-            IsHitTestVisible="False"
-            MaxLines="1"
-            Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding TrackNumberText, FallbackValue=''}"
-            Visibility="{x:Bind IsTrackNumberVisible}" />
-
-        <FontIcon
-            x:Name="ItemIcon"
-            Grid.Column="1"
-            Margin="8"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Center"
-            FontFamily="{StaticResource SymbolThemeFontFamily}"
-            FontSize="{StaticResource DefaultIconFontSize}"
-            Glyph="{Binding Converter={StaticResource MediaGlyphConverter}}"
-            IsHitTestVisible="False"
-            Visibility="{x:Bind IsIconVisible}" />
-
-        <Button
-            x:Name="PlayButton"
-            Grid.Column="1"
-            Width="32"
-            Height="32"
-            Padding="0"
-            VerticalAlignment="Center"
-            Command="{x:Bind PlayCommand, Mode=OneWay}"
-            CommandParameter="{Binding}"
-            Style="{StaticResource SubtleButtonStyle}"
-            ToolTipService.ToolTip="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}"
-            Visibility="Collapsed">
-            <FontIcon FontSize="{StaticResource DefaultIconFontSize}" Glyph="{Binding IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}}" />
-            <Button.Resources>
-                <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
-                <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
-                <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
-                <StaticResource x:Key="SubtleButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
-                <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
-                <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
-            </Button.Resources>
-        </Button>
+        <Grid Grid.Column="1">
+            <TextBlock
+                x:Name="TrackNumberText"
+                Padding="0,0,8,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                IsHitTestVisible="False"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{Binding TrackNumberText, FallbackValue=''}"
+                TextWrapping="NoWrap"
+                Visibility="{x:Bind IsTrackNumberVisible}" />
+            <FontIcon
+                x:Name="ItemMediaTypeIcon"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Glyph="{Binding Converter={StaticResource MediaGlyphConverter}}"
+                IsHitTestVisible="False"
+                Visibility="{x:Bind IsIconVisible}" />
+            <Button
+                x:Name="PlayButton"
+                Width="32"
+                Height="32"
+                Padding="0"
+                VerticalAlignment="Center"
+                Command="{x:Bind PlayCommand, Mode=OneWay}"
+                CommandParameter="{Binding}"
+                Style="{StaticResource SubtleButtonStyle}"
+                ToolTipService.ToolTip="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}"
+                Visibility="Collapsed">
+                <FontIcon Glyph="{Binding IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}}" />
+                <Button.Resources>
+                    <StaticResource x:Key="SubtleButtonBackground" ResourceKey="HyperlinkButtonBackground" />
+                    <StaticResource x:Key="SubtleButtonBackgroundPointerOver" ResourceKey="HyperlinkButtonBackgroundPointerOver" />
+                    <StaticResource x:Key="SubtleButtonBackgroundPressed" ResourceKey="HyperlinkButtonBackgroundPressed" />
+                    <StaticResource x:Key="SubtleButtonForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+                    <StaticResource x:Key="SubtleButtonForegroundPointerOver" ResourceKey="HyperlinkButtonForegroundPointerOver" />
+                    <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="HyperlinkButtonForegroundPressed" />
+                </Button.Resources>
+            </Button>
+        </Grid>
 
         <TextBlock
             x:Name="TitleText"
             Grid.Column="2"
-            Margin="8,0,8,0"
+            Margin="8,0,0,0"
             VerticalAlignment="Center"
-            MaxLines="1"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{Binding Name}"
-            TextTrimming="CharacterEllipsis" />
+            TextWrapping="NoWrap">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <HyperlinkButton
             x:Name="ArtistButton"
@@ -122,9 +119,13 @@
             Visibility="Collapsed">
             <TextBlock
                 x:Name="ArtistText"
-                MaxLines="1"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding MainArtist.Name, FallbackValue=''}" />
+                Text="{Binding MainArtist.Name, FallbackValue=''}"
+                TextWrapping="NoWrap">
+                <interactivity:Interaction.Behaviors>
+                    <interactions:OverflowTextToolTipBehavior />
+                </interactivity:Interaction.Behaviors>
+            </TextBlock>
         </HyperlinkButton>
 
         <HyperlinkButton
@@ -139,9 +140,13 @@
             Visibility="Collapsed">
             <TextBlock
                 x:Name="AlbumText"
-                MaxLines="1"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Album.Name, FallbackValue=''}" />
+                Text="{Binding Album.Name, FallbackValue=''}"
+                TextWrapping="NoWrap">
+                <interactivity:Interaction.Behaviors>
+                    <interactions:OverflowTextToolTipBehavior />
+                </interactivity:Interaction.Behaviors>
+            </TextBlock>
         </HyperlinkButton>
 
         <TextBlock
@@ -150,21 +155,25 @@
             Margin="4,0"
             VerticalAlignment="Center"
             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-            MaxLines="1"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{Binding MediaInfo.MusicProperties.Genre, Converter={StaticResource GenreTextConverter}}"
-            Visibility="Collapsed" />
+            TextWrapping="NoWrap"
+            Visibility="Collapsed">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <TextBlock
             x:Name="DurationText"
             Grid.Column="6"
-            Margin="8,0,16,0"
+            Margin="0,0,16,0"
             HorizontalAlignment="Right"
             VerticalAlignment="Center"
             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-            MaxLines="1"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding DurationText}" />
+            Text="{Binding DurationText}"
+            TextWrapping="NoWrap" />
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="ActivityStates">
@@ -175,7 +184,7 @@
                     <VisualState.Setters>
                         <Setter Target="PlayingIndicator.Visibility" Value="Visible" />
                         <Setter Target="TrackNumberText.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
-                        <Setter Target="ItemIcon.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                        <Setter Target="ItemMediaTypeIcon.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                         <Setter Target="TitleText.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                         <Setter Target="ArtistButton.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                         <Setter Target="AlbumButton.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
@@ -222,16 +231,16 @@
             <VisualStateGroup x:Name="MultiSelectStates">
                 <VisualState x:Name="MultiSelectDisabled">
                     <VisualState.Setters>
-                        <Setter Target="PlayingIndicator.Opacity" Value="1" />
-                        <Setter Target="ItemIcon.Opacity" Value="1" />
                         <Setter Target="RootGridTranslateTransform.X" Value="0" />
+                        <Setter Target="PlayingIndicator.Opacity" Value="1" />
+                        <Setter Target="ItemMediaTypeIcon.Opacity" Value="1" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="MultiSelectEnabled">
                     <VisualState.Setters>
-                        <Setter Target="PlayingIndicator.Opacity" Value="0" />
-                        <Setter Target="ItemIcon.Opacity" Value="0" />
                         <Setter Target="RootGridTranslateTransform.X" Value="-32" />
+                        <Setter Target="PlayingIndicator.Opacity" Value="0" />
+                        <Setter Target="ItemMediaTypeIcon.Opacity" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -288,9 +297,9 @@
                 <VisualState x:Name="Normal" />
                 <VisualState x:Name="PointerOver">
                     <VisualState.Setters>
-                        <Setter Target="PlayButton.Visibility" Value="Visible" />
                         <Setter Target="TrackNumberText.Visibility" Value="Collapsed" />
-                        <Setter Target="ItemIcon.Visibility" Value="Collapsed" />
+                        <Setter Target="ItemMediaTypeIcon.Visibility" Value="Collapsed" />
+                        <Setter Target="PlayButton.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -103,21 +103,34 @@
                     Orientation="Vertical">
                     <TextBlock
                         x:Name="AlbumTitleText"
-                        MaxLines="1"
                         Style="{StaticResource TitleTextBlockStyle}"
-                        Text="{x:Bind ViewModel.Source.Name}" />
+                        Text="{x:Bind ViewModel.Source.Name}"
+                        TextWrapping="NoWrap">
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
                     <TextBlock
                         x:Name="ArtistNameText"
                         FontWeight="Normal"
-                        MaxLines="1"
                         Style="{StaticResource SubtitleTextBlockStyle}"
-                        Text="{x:Bind ViewModel.Source.ArtistName}" />
+                        Text="{x:Bind ViewModel.Source.ArtistName}"
+                        TextWrapping="NoWrap">
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
                     <TextBlock
                         x:Name="Subtext"
                         Margin="0,8,0,0"
                         Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                        MaxLines="1"
-                        Text="{x:Bind local:AlbumDetailsPage.GetSubtext(ViewModel.Year, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}" />
+                        Style="{StaticResource BodyTextBlockStyle}"
+                        Text="{x:Bind local:AlbumDetailsPage.GetSubtext(ViewModel.Year, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}"
+                        TextWrapping="NoWrap">
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
                 </StackPanel>
 
                 <StackPanel

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -67,7 +67,11 @@
                                 x:Name="AlbumTitle"
                                 MaxLines="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Key.Name}" />
+                                Text="{Binding Key.Name}">
+                                <interactivity:Interaction.Behaviors>
+                                    <interactions:OverflowTextToolTipBehavior />
+                                </interactivity:Interaction.Behaviors>
+                            </TextBlock>
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"
@@ -178,14 +182,21 @@
                         x:Name="TitleText"
                         Style="{StaticResource TitleTextBlockStyle}"
                         Text="{x:Bind ViewModel.Source.Name}"
-                        TextWrapping="NoWrap" />
+                        TextWrapping="NoWrap">
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
                     <TextBlock
                         x:Name="Subtext"
                         FontWeight="Normal"
                         MaxLines="2"
                         Style="{StaticResource SubtitleTextBlockStyle}"
-                        Text="{x:Bind local:ArtistDetailsPage.GetSubtext(ViewModel.AlbumsCount, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}"
-                        TextWrapping="Wrap" />
+                        Text="{x:Bind local:ArtistDetailsPage.GetSubtext(ViewModel.AlbumsCount, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}">
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
                 </StackPanel>
 
                 <StackPanel

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -58,20 +58,23 @@
                 <FontIcon
                     Grid.Column="0"
                     HorizontalAlignment="Center"
-                    FontSize="16"
                     Glyph="{x:Bind StorageItem, Converter={StaticResource MediaGlyphConverter}}" />
                 <TextBlock
                     Grid.Column="1"
-                    Margin="0,0,16,0"
-                    MaxLines="1"
+                    Margin="8,0,16,0"
                     Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{x:Bind Name}" />
+                    Text="{x:Bind Name}"
+                    TextWrapping="NoWrap">
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:OverflowTextToolTipBehavior />
+                    </interactivity:Interaction.Behaviors>
+                </TextBlock>
                 <TextBlock
                     Grid.Column="2"
                     HorizontalAlignment="Right"
-                    MaxLines="1"
                     Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{x:Bind CaptionText, Mode=OneWay}" />
+                    Text="{x:Bind CaptionText, Mode=OneWay}"
+                    TextWrapping="NoWrap" />
             </Grid>
         </DataTemplate>
     </Page.Resources>

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -113,7 +113,8 @@
         <!--  Empty content  -->
         <TextBlock
             x:Name="NoContentText"
-            Margin="{StaticResource PageContentMargin}"
+            Margin="{StaticResource TopLargeMargin}"
+            Padding="{StaticResource PageContentMargin}"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
             Text="{strings:Resources Key=EmptyFolder}"
@@ -133,7 +134,7 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="ListView.Padding" Value="{StaticResource PageContentMarginMinimal}" />
-                        <Setter Target="NoContentText.Margin" Value="{StaticResource PageContentMarginMinimal}" />
+                        <Setter Target="NoContentText.Padding" Value="{StaticResource PageContentMarginMinimal}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -72,8 +72,13 @@
             MinHeight="{StaticResource PageHeaderMinHeight}"
             Margin="{StaticResource BottomMediumMargin}"
             Padding="{StaticResource PageContentMargin}"
+            MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind ViewModel.TitleText}" />
+            Text="{x:Bind ViewModel.TitleText}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <muxc:BreadcrumbBar
             x:Name="BreadcrumbBar"

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -139,7 +139,8 @@
         <TextBlock
             x:Name="NoContentText"
             Grid.Row="2"
-            Margin="{StaticResource PageContentMargin}"
+            Margin="{StaticResource TopLargeMargin}"
+            Padding="{StaticResource PageContentMargin}"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
             Text="{strings:Resources Key=EmptyFolder}"
@@ -161,7 +162,7 @@
                         <Setter Target="TitleText.Padding" Value="{StaticResource PageContentMarginMinimal}" />
                         <Setter Target="BreadcrumbBar.Margin" Value="{StaticResource PageContentMarginMinimal}" />
                         <Setter Target="FolderView.Padding" Value="{StaticResource PageThumbnailMarginMinimal}" />
-                        <Setter Target="NoContentText.Margin" Value="{StaticResource PageContentMarginMinimal}" />
+                        <Setter Target="NoContentText.Padding" Value="{StaticResource PageContentMarginMinimal}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -259,9 +259,11 @@
 
                 <TextBlock
                     x:Name="SubtitleText"
+                    Foreground="{StaticResource TextFillColorSecondaryBrush}"
                     OpticalMarginAlignment="TrimSideBearings"
+                    Style="{StaticResource BodyTextBlockStyle}"
                     Text="{x:Bind ViewModel.Media.AltCaption, Mode=OneWay, FallbackValue={}}"
-                    TextTrimming="CharacterEllipsis"
+                    TextWrapping="NoWrap"
                     Visibility="{x:Bind ViewModel.Media.AltCaption, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}, FallbackValue=Collapsed}" />
             </StackPanel>
         </Grid>

--- a/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
@@ -48,7 +48,7 @@
         <GridView
             x:Name="AlbumGridView"
             Grid.Row="1"
-            Margin="0,12,0,0"
+            Margin="{StaticResource TopLargeMargin}"
             Padding="{StaticResource PageThumbnailMargin}"
             ui:ListViewExtensions.Command="{x:Bind Common.OpenAlbumCommand}"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"

--- a/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
@@ -39,7 +39,11 @@
             Padding="{StaticResource PageContentMargin}"
             MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind strings:Resources.SearchResultAlbumHeader(ViewModel.SearchQuery), FallbackValue={}}" />
+            Text="{x:Bind strings:Resources.SearchResultAlbumHeader(ViewModel.SearchQuery), FallbackValue={}}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <GridView
             x:Name="AlbumGridView"

--- a/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
@@ -4,6 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:interactions="using:Screenbox.Controls.Interactions"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
@@ -34,7 +36,11 @@
             Padding="{StaticResource PageContentMargin}"
             MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind strings:Resources.SearchResultArtistHeader(ViewModel.SearchQuery), FallbackValue={}}" />
+            Text="{x:Bind strings:Resources.SearchResultArtistHeader(ViewModel.SearchQuery), FallbackValue={}}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <GridView
             x:Name="ArtistGridView"

--- a/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
@@ -45,7 +45,7 @@
         <GridView
             x:Name="ArtistGridView"
             Grid.Row="1"
-            Margin="0,12,0,0"
+            Margin="{StaticResource TopLargeMargin}"
             Padding="{StaticResource PageThumbnailMargin}"
             ui:ListViewExtensions.Command="{x:Bind Common.OpenArtistCommand}"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"

--- a/Screenbox/Pages/Search/SearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SearchResultPage.xaml
@@ -39,8 +39,11 @@
             Padding="{StaticResource PageContentMargin}"
             MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind strings:Resources.SearchResultHeader(ViewModel.SearchQuery)}"
-            TextTrimming="CharacterEllipsis" />
+            Text="{x:Bind strings:Resources.SearchResultHeader(ViewModel.SearchQuery)}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <ScrollViewer
             Grid.Row="1"

--- a/Screenbox/Pages/Search/SearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SearchResultPage.xaml
@@ -52,11 +52,13 @@
             <StackPanel
                 Orientation="Vertical"
                 SizeChanged="GridView_OnSizeChanged"
-                Spacing="24"
                 XYFocusDownNavigationStrategy="RectilinearDistance"
                 XYFocusKeyboardNavigation="Enabled">
                 <!--  Artists Section  -->
-                <StackPanel Orientation="Vertical" Visibility="{x:Bind ViewModel.ShowArtists}">
+                <StackPanel
+                    Margin="0,0,0,24"
+                    Orientation="Vertical"
+                    Visibility="{x:Bind ViewModel.ShowArtists}">
                     <Grid
                         x:Name="ArtistsResultHeader"
                         Height="32"
@@ -82,7 +84,10 @@
                         SelectionMode="None" />
                 </StackPanel>
                 <!--  Albums Section  -->
-                <StackPanel Orientation="Vertical" Visibility="{x:Bind ViewModel.ShowAlbums}">
+                <StackPanel
+                    Margin="0,0,0,24"
+                    Orientation="Vertical"
+                    Visibility="{x:Bind ViewModel.ShowAlbums}">
                     <Grid
                         x:Name="AlbumsResultHeader"
                         Height="32"
@@ -112,7 +117,10 @@
                     </GridView>
                 </StackPanel>
                 <!--  Songs Section  -->
-                <StackPanel Orientation="Vertical" Visibility="{x:Bind ViewModel.ShowSongs}">
+                <StackPanel
+                    Margin="0,0,0,24"
+                    Orientation="Vertical"
+                    Visibility="{x:Bind ViewModel.ShowSongs}">
                     <Grid
                         x:Name="SongsResultHeader"
                         Height="32"

--- a/Screenbox/Pages/Search/SongSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SongSearchResultPage.xaml
@@ -37,7 +37,7 @@
         <ListView
             x:Name="SongListView"
             Grid.Row="1"
-            Margin="0,12,0,0"
+            Margin="{StaticResource TopLargeMargin}"
             Padding="{StaticResource PageContentMargin}"
             extensions:ListViewExtensions.ItemCornerRadius="8"
             extensions:ListViewExtensions.ItemMargin="0,2,0,2"

--- a/Screenbox/Pages/Search/SongSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SongSearchResultPage.xaml
@@ -28,7 +28,11 @@
             Padding="{StaticResource PageContentMargin}"
             MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind strings:Resources.SearchResultSongHeader(ViewModel.SearchQuery), FallbackValue={}}" />
+            Text="{x:Bind strings:Resources.SearchResultSongHeader(ViewModel.SearchQuery), FallbackValue={}}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <ListView
             x:Name="SongListView"

--- a/Screenbox/Pages/Search/VideoSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/VideoSearchResultPage.xaml
@@ -39,7 +39,11 @@
             Padding="{StaticResource PageContentMargin}"
             MaxLines="2"
             Style="{StaticResource PageHeaderTextBlockStyle}"
-            Text="{x:Bind strings:Resources.SearchResultVideoHeader(ViewModel.SearchQuery), FallbackValue={}}" />
+            Text="{x:Bind strings:Resources.SearchResultVideoHeader(ViewModel.SearchQuery), FallbackValue={}}">
+            <interactivity:Interaction.Behaviors>
+                <interactions:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
 
         <GridView
             x:Name="VideosGridView"

--- a/Screenbox/Pages/Search/VideoSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/VideoSearchResultPage.xaml
@@ -48,7 +48,7 @@
         <GridView
             x:Name="VideosGridView"
             Grid.Row="1"
-            Margin="0,12,0,0"
+            Margin="{StaticResource TopLargeMargin}"
             Padding="{StaticResource PageThumbnailMargin}"
             ui:ListViewExtensions.Command="{x:Bind ViewModel.PlayCommand, FallbackValue={x:Null}}"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"


### PR DESCRIPTION
![Example of overflow text on a GridView Item](https://github.com/huynhsontung/Screenbox/assets/698155/615a5179-150e-4866-ab9e-36fb7a2aa369)
![Example of overflow text on a ListView Item](https://github.com/huynhsontung/Screenbox/assets/698155/c6338843-5884-4e4c-9cb9-7c74d9a6484b)
![Example of overflow text on a ListView Item #2](https://github.com/huynhsontung/Screenbox/assets/698155/94681e13-994a-4688-9aa7-8a6be37442f7)
