### PR TITLE
feat: use AudioGraph to output and process audio

### DIFF
--- a/Screenbox.Core/Helpers/CircularBuffer.cs
+++ b/Screenbox.Core/Helpers/CircularBuffer.cs
@@ -1,0 +1,417 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Screenbox.Core.Helpers
+{
+    /// <inheritdoc/>
+    /// <summary>
+    /// Circular buffer.
+    /// 
+    /// When writing to a full buffer:
+    /// PushBack -> removes this[0] / Front()
+    /// PushFront -> removes this[Size-1] / Back()
+    /// 
+    /// this implementation is inspired by
+    /// http://www.boost.org/doc/libs/1_53_0/libs/circular_buffer/doc/circular_buffer.html
+    /// because I liked their interface.
+    /// </summary>
+    public class CircularBuffer<T> : IEnumerable<T>
+    {
+        private readonly T[] _buffer;
+
+        /// <summary>
+        /// The _start. Index of the first element in buffer.
+        /// </summary>
+        private int _start;
+
+        /// <summary>
+        /// The _end. Index after the last element in the buffer.
+        /// </summary>
+        private int _end;
+
+        /// <summary>
+        /// The _size. Buffer size.
+        /// </summary>
+        private int _size;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularBuffer{T}"/> class.
+        /// 
+        /// </summary>
+        /// <param name='capacity'>
+        /// Buffer capacity. Must be positive.
+        /// </param>
+        public CircularBuffer(int capacity)
+            : this(capacity, new T[] { })
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularBuffer{T}"/> class.
+        /// 
+        /// </summary>
+        /// <param name='capacity'>
+        /// Buffer capacity. Must be positive.
+        /// </param>
+        /// <param name='items'>
+        /// Items to fill buffer with. Items length must be less than capacity.
+        /// Suggestion: use Skip(x).Take(y).ToArray() to build this argument from
+        /// any enumerable.
+        /// </param>
+        public CircularBuffer(int capacity, T[] items)
+        {
+            if (capacity < 1)
+            {
+                throw new ArgumentException(
+                    "Circular buffer cannot have negative or zero capacity.", nameof(capacity));
+            }
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+            if (items.Length > capacity)
+            {
+                throw new ArgumentException(
+                    "Too many items to fit circular buffer", nameof(items));
+            }
+
+            _buffer = new T[capacity];
+
+            Array.Copy(items, _buffer, items.Length);
+            _size = items.Length;
+
+            _start = 0;
+            _end = _size == capacity ? 0 : _size;
+        }
+
+        /// <summary>
+        /// Maximum capacity of the buffer. Elements pushed into the buffer after
+        /// maximum capacity is reached (IsFull = true), will remove an element.
+        /// </summary>
+        public int Capacity { get { return _buffer.Length; } }
+
+        /// <summary>
+        /// Boolean indicating if Circular is at full capacity.
+        /// Adding more elements when the buffer is full will
+        /// cause elements to be removed from the other end
+        /// of the buffer.
+        /// </summary>
+        public bool IsFull
+        {
+            get
+            {
+                return Size == Capacity;
+            }
+        }
+
+        /// <summary>
+        /// True if has no elements.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get
+            {
+                return Size == 0;
+            }
+        }
+
+        /// <summary>
+        /// Current buffer size (the number of elements that the buffer has).
+        /// </summary>
+        public int Size { get { return _size; } }
+
+        /// <summary>
+        /// Element at the front of the buffer - this[0].
+        /// </summary>
+        /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        public T Front()
+        {
+            ThrowIfEmpty();
+            return _buffer[_start];
+        }
+
+        /// <summary>
+        /// Element at the back of the buffer - this[Size - 1].
+        /// </summary>
+        /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        public T Back()
+        {
+            ThrowIfEmpty();
+            return _buffer[(_end != 0 ? _end : Capacity) - 1];
+        }
+
+        /// <summary>
+        /// Index access to elements in buffer.
+        /// Index does not loop around like when adding elements,
+        /// valid interval is [0;Size[
+        /// </summary>
+        /// <param name="index">Index of element to access.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown when index is outside of [; Size[ interval.</exception>
+        public T this[int index]
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer is empty", index));
+                }
+                if (index >= _size)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer size is {1}", index, _size));
+                }
+                int actualIndex = InternalIndex(index);
+                return _buffer[actualIndex];
+            }
+            set
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer is empty", index));
+                }
+                if (index >= _size)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer size is {1}", index, _size));
+                }
+                int actualIndex = InternalIndex(index);
+                _buffer[actualIndex] = value;
+            }
+        }
+
+        /// <summary>
+        /// Pushes a new element to the back of the buffer. Back()/this[Size-1]
+        /// will now return this element.
+        /// 
+        /// When the buffer is full, the element at Front()/this[0] will be 
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the back of the buffer</param>
+        public void PushBack(T item)
+        {
+            if (IsFull)
+            {
+                _buffer[_end] = item;
+                Increment(ref _end);
+                _start = _end;
+            }
+            else
+            {
+                _buffer[_end] = item;
+                Increment(ref _end);
+                ++_size;
+            }
+        }
+
+        /// <summary>
+        /// Pushes a new element to the front of the buffer. Front()/this[0]
+        /// will now return this element.
+        /// 
+        /// When the buffer is full, the element at Back()/this[Size-1] will be 
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the front of the buffer</param>
+        public void PushFront(T item)
+        {
+            if (IsFull)
+            {
+                Decrement(ref _start);
+                _end = _start;
+                _buffer[_start] = item;
+            }
+            else
+            {
+                Decrement(ref _start);
+                _buffer[_start] = item;
+                ++_size;
+            }
+        }
+
+        /// <summary>
+        /// Removes the element at the back of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        public void PopBack()
+        {
+            ThrowIfEmpty("Cannot take elements from an empty buffer.");
+            Decrement(ref _end);
+            _buffer[_end] = default(T);
+            --_size;
+        }
+
+        /// <summary>
+        /// Removes the element at the front of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        public void PopFront()
+        {
+            ThrowIfEmpty("Cannot take elements from an empty buffer.");
+            _buffer[_start] = default(T);
+            Increment(ref _start);
+            --_size;
+        }
+
+        /// <summary>
+        /// Clears the contents of the array. Size = 0, Capacity is unchanged.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        public void Clear()
+        {
+            // to clear we just reset everything.
+            _start = 0;
+            _end = 0;
+            _size = 0;
+            Array.Clear(_buffer, 0, _buffer.Length);
+        }
+
+        /// <summary>
+        /// Copies the buffer contents to an array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal 
+        /// order/contents)
+        /// </summary>
+        /// <returns>A new array with a copy of the buffer contents.</returns>
+        public T[] ToArray()
+        {
+            T[] newArray = new T[Size];
+            int newArrayOffset = 0;
+            var segments = ToArraySegments();
+            foreach (ArraySegment<T> segment in segments)
+            {
+                Array.Copy(segment.Array, segment.Offset, newArray, newArrayOffset, segment.Count);
+                newArrayOffset += segment.Count;
+            }
+            return newArray;
+        }
+
+        /// <summary>
+        /// Get the contents of the buffer as 2 ArraySegments.
+        /// Respects the logical contents of the buffer, where
+        /// each segment and items in each segment are ordered
+        /// according to insertion.
+        ///
+        /// Fast: does not copy the array elements.
+        /// Useful for methods like <c>Send(IList&lt;ArraySegment&lt;Byte&gt;&gt;)</c>.
+        /// 
+        /// <remarks>Segments may be empty.</remarks>
+        /// </summary>
+        /// <returns>An IList with 2 segments corresponding to the buffer content.</returns>
+        public IList<ArraySegment<T>> ToArraySegments()
+        {
+            return new[] { ArrayOne(), ArrayTwo() };
+        }
+
+        #region IEnumerable<T> implementation
+        /// <summary>
+        /// Returns an enumerator that iterates through this buffer.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate this collection.</returns>
+        public IEnumerator<T> GetEnumerator()
+        {
+            var segments = ToArraySegments();
+            foreach (ArraySegment<T> segment in segments)
+            {
+                for (int i = 0; i < segment.Count; i++)
+                {
+                    yield return segment.Array[segment.Offset + i];
+                }
+            }
+        }
+        #endregion
+        #region IEnumerable implementation
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+        #endregion
+
+        private void ThrowIfEmpty(string message = "Cannot access an empty buffer.")
+        {
+            if (IsEmpty)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        /// <summary>
+        /// Increments the provided index variable by one, wrapping
+        /// around if necessary.
+        /// </summary>
+        /// <param name="index"></param>
+        private void Increment(ref int index)
+        {
+            if (++index == Capacity)
+            {
+                index = 0;
+            }
+        }
+
+        /// <summary>
+        /// Decrements the provided index variable by one, wrapping
+        /// around if necessary.
+        /// </summary>
+        /// <param name="index"></param>
+        private void Decrement(ref int index)
+        {
+            if (index == 0)
+            {
+                index = Capacity;
+            }
+            index--;
+        }
+
+        /// <summary>
+        /// Converts the index in the argument to an index in <code>_buffer</code>
+        /// </summary>
+        /// <returns>
+        /// The transformed index.
+        /// </returns>
+        /// <param name='index'>
+        /// External index.
+        /// </param>
+        private int InternalIndex(int index)
+        {
+            return _start + (index < (Capacity - _start) ? index : index - Capacity);
+        }
+
+        // doing ArrayOne and ArrayTwo methods returning ArraySegment<T> as seen here: 
+        // http://www.boost.org/doc/libs/1_37_0/libs/circular_buffer/doc/circular_buffer.html#classboost_1_1circular__buffer_1957cccdcb0c4ef7d80a34a990065818d
+        // http://www.boost.org/doc/libs/1_37_0/libs/circular_buffer/doc/circular_buffer.html#classboost_1_1circular__buffer_1f5081a54afbc2dfc1a7fb20329df7d5b
+        // should help a lot with the code.
+
+        #region Array items easy access.
+        // The array is composed by at most two non-contiguous segments, 
+        // the next two methods allow easy access to those.
+
+        private ArraySegment<T> ArrayOne()
+        {
+            if (IsEmpty)
+            {
+                return new ArraySegment<T>(new T[0]);
+            }
+            else if (_start < _end)
+            {
+                return new ArraySegment<T>(_buffer, _start, _end - _start);
+            }
+            else
+            {
+                return new ArraySegment<T>(_buffer, _start, _buffer.Length - _start);
+            }
+        }
+
+        private ArraySegment<T> ArrayTwo()
+        {
+            if (IsEmpty)
+            {
+                return new ArraySegment<T>(Array.Empty<T>());
+            }
+            else if (_start < _end)
+            {
+                return new ArraySegment<T>(_buffer, _end, 0);
+            }
+            else
+            {
+                return new ArraySegment<T>(_buffer, 0, _end);
+            }
+        }
+        #endregion
+    }
+}

--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -98,26 +98,32 @@ namespace Screenbox.Core.Playback
 
         public bool IsMuted
         {
-            get => VlcPlayer.Mute;
+            get => _isMuted;
             set
             {
+                _isMuted = value;
                 if (VlcPlayer.Mute != value)
                 {
                     VlcPlayer.Mute = value;
                 }
+
+                UpdateOutputNodeGain();
             }
         }
 
         public double Volume
         {
-            get => VlcPlayer.Volume / 100d;
+            get => _volume;
             set
             {
+                _volume = value;
                 int iVal = (int)(value * 100);
                 if (VlcPlayer.Volume != iVal && VlcPlayer.Volume >= 0)
                 {
                     VlcPlayer.Volume = iVal;
                 }
+
+                UpdateOutputNodeGain();
             }
         }
 
@@ -248,6 +254,8 @@ namespace Screenbox.Core.Playback
         private readonly Rect _defaultSourceRect;
         private ChapterCue? _chapter;
         private Rect _normalizedSourceRect;
+        private bool _isMuted;
+        private double _volume;
         private bool _readyToPlay;
         private bool _updateMediaProperties;
         private TimeSpan _naturalDuration;
@@ -258,6 +266,7 @@ namespace Screenbox.Core.Playback
         private AudioFrameInputNode? _inputNode;
         private AudioDeviceOutputNode? _outputNode;
         private CircularBuffer<short>? _audioBuffer;
+        private readonly object _audioBufferLock;
 
         [ComImport]
         [Guid("5B0D3235-4DBA-4D44-865E-8F1D0E4FD04D")]
@@ -271,6 +280,8 @@ namespace Screenbox.Core.Playback
         {
             LibVlc = libVlc;
             VlcPlayer = new MediaPlayer(libVlc);
+            _volume = VlcPlayer.Volume / 100d;
+            _audioBufferLock = new object();
             _defaultSourceRect = new Rect(0, 0, 1, 1);
             _normalizedSourceRect = _defaultSourceRect;
 
@@ -298,29 +309,20 @@ namespace Screenbox.Core.Playback
         public async Task InitAudioGraphAsync()
         {
             AudioGraphSettings settings = new(Windows.Media.Render.AudioRenderCategory.Media);
-            // settings.QuantumSizeSelectionMode = QuantumSizeSelectionMode.LowestLatency;
-            // settings.MaxPlaybackSpeedFactor = 3;
-            // settings.EncodingProperties = AudioEncodingProperties.CreatePcm(48000, 2, 16);
             CreateAudioGraphResult result = await AudioGraph.CreateAsync(settings);
             if (result.Status != AudioGraphCreationStatus.Success) return;
             AudioGraph audioGraph = _audioGraph = result.Graph;
             var outputNodeResult = await audioGraph.CreateDeviceOutputNodeAsync();
             if (outputNodeResult.Status != AudioDeviceNodeCreationStatus.Success) return;
-            var outputNode = _outputNode = outputNodeResult.DeviceOutputNode;
-
-            // AudioEncodingProperties inputEncoding = AudioEncodingProperties.CreatePcm(
-            //     audioGraph.EncodingProperties.SampleRate, audioGraph.EncodingProperties.ChannelCount, 16);
-            // var inputNode = _inputNode = audioGraph.CreateFrameInputNode(inputEncoding);
-            // inputNode.AddOutgoingConnection(outputNode);
-            // inputNode.QuantumStarted += InputNodeOnQuantumStarted;
+            _outputNode = outputNodeResult.DeviceOutputNode;
 
             // VLC callbacks
             VlcPlayer.SetAudioFormatCallback(SetupCb, CleanupCb);
-            // VlcPlayer.SetAudioFormat("S16N", inputEncoding.SampleRate, inputEncoding.ChannelCount);
             VlcPlayer.SetAudioCallbacks(PlayCb, PauseCb, ResumeCb, FlushCb, DrainCb);
             VlcPlayer.SetVolumeCallback(VolumeCb);
 
-            audioGraph.Start();
+            // VLC setup callback starts the audio graph
+            audioGraph.Stop();
         }
 
         private void CleanupCb(IntPtr opaque)
@@ -338,118 +340,72 @@ namespace Screenbox.Core.Playback
             // Format is always "S16N"
             if (_audioGraph == null) return 0;
 
-            // Create an audio buffer for 1s of audio
-            _audioBuffer = new CircularBuffer<short>((int)(rate * channels));
+            lock (_audioBufferLock)
+            {
+                // Create an audio buffer for 500ms of audio
+                _audioBuffer = new CircularBuffer<short>((int)(rate * channels / 2));
+            }
 
             // Create input node that has 16-bit integer PCM encoding to match VLC
             var inputEncoding = AudioEncodingProperties.CreatePcm(rate, channels, 16);
             var inputNode = _inputNode = _audioGraph.CreateFrameInputNode(inputEncoding);
             inputNode.AddOutgoingConnection(_outputNode);
             inputNode.QuantumStarted += InputNodeOnQuantumStarted;
+
+            UpdateOutputNodeGain();
+
             _audioGraph.Start();
 
-            // rate = _inputNode.EncodingProperties.SampleRate;
-            // channels = _inputNode.EncodingProperties.ChannelCount;
-            // var span = new ReadOnlySpan<byte>((void*)format, 4);
-            // _format = System.Text.Encoding.ASCII.GetString(span.ToArray());
             return 0;
+        }
+
+        private void UpdateOutputNodeGain()
+        {
+            if (_outputNode == null) return;
+            _outputNode.OutgoingGain = IsMuted ? 0 : Volume;
         }
 
         private void VolumeCb(IntPtr data, float volume, bool mute)
         {
-            if (_inputNode == null) return;
-            _inputNode.OutgoingGain = volume;
+            UpdateOutputNodeGain();
         }
 
         private void InputNodeOnQuantumStarted(AudioFrameInputNode sender, FrameInputNodeQuantumStartedEventArgs args)
         {
+            if (_audioBuffer == null) return;
             AudioFrame frame;
-            lock (_audioBuffer)
+            lock (_audioBufferLock)
             {
                 if (_audioBuffer.Size < args.RequiredSamples * sender.EncodingProperties.ChannelCount) return;
-                frame = GenerateAudioFrame((uint)args.RequiredSamples, sender.EncodingProperties.ChannelCount, sender.EncodingProperties.SampleRate);
+                frame = GenerateAudioFrame(_audioBuffer, (uint)args.RequiredSamples,
+                    sender.EncodingProperties.ChannelCount, sender.EncodingProperties.SampleRate);
             }
 
             sender.AddFrame(frame);
-
-            // if (_frameBuffer.TryDequeue(out AudioFrame frame))
-            // {
-            //     sender.AddFrame(frame);
-            // }
-
-            // if (_inputNode == null) return;
-            // uint numSamplesNeeded = (uint)args.RequiredSamples;
-            //
-            // if (numSamplesNeeded != 0)
-            // {
-            //     AudioFrame audioData = GenerateAudioData(numSamplesNeeded, _inputNode.EncodingProperties.ChannelCount);
-            //     _inputNode.AddFrame(audioData);
-            // }
         }
 
-        private double audioWaveTheta = 0;
-
-        private unsafe AudioFrame GenerateAudioData(uint samples, uint numChannels)
-        {
-            // Buffer size is (number of samples) * (size of each sample)
-            // We choose to generate single channel (mono) audio. For multi-channel, multiply by number of channels
-            uint bufferSize = samples * numChannels * sizeof(float);
-            AudioFrame frame = new(bufferSize);
-
-            using (AudioBuffer buffer = frame.LockBuffer(AudioBufferAccessMode.Write))
-            using (IMemoryBufferReference reference = buffer.CreateReference())
-            {
-                byte* dataInBytes;
-                uint capacityInBytes;
-                float* dataInFloat;
-
-                // Get the buffer from the AudioFrame
-                ((IMemoryBufferByteAccess)reference).GetBuffer(out dataInBytes, out capacityInBytes);
-
-                // Cast to float since the data we are generating is float
-                dataInFloat = (float*)dataInBytes;
-
-                float freq = 1000; // choosing to generate frequency of 1kHz
-                float amplitude = 0.3f;
-                int sampleRate = (int)_audioGraph.EncodingProperties.SampleRate;
-                double sampleIncrement = (freq * (Math.PI * 2)) / sampleRate;
-
-                // Generate a 1kHz sine wave and populate the values in the memory buffer
-                for (uint i = 0; i < samples; i++)
-                {
-                    double sinValue = amplitude * Math.Sin(audioWaveTheta);
-                    dataInFloat[i] = (float)sinValue;
-                    dataInFloat[i + samples] = (float)sinValue;
-
-                    audioWaveTheta += sampleIncrement;
-                }
-            }
-
-            return frame;
-        }
-
-        private unsafe AudioFrame GenerateAudioFrame(uint sampleCountPerChannel, uint channelCount, uint sampleRate)
+        private unsafe AudioFrame GenerateAudioFrame(CircularBuffer<short> audioBuffer, uint sampleCountPerChannel, uint channelCount, uint sampleRate)
         {
             uint totalSampleCount = sampleCountPerChannel * channelCount;
             uint bufferSize = totalSampleCount * sizeof(short);
-            AudioFrame frame = new(bufferSize);
-            frame.Duration = TimeSpan.FromSeconds((double)sampleCountPerChannel / sampleRate);
-
-            using (AudioBuffer buffer = frame.LockBuffer(AudioBufferAccessMode.Write))
-            using (IMemoryBufferReference reference = buffer.CreateReference())
+            AudioFrame frame = new(bufferSize)
             {
-                // Get the buffer from the AudioFrame
-                ((IMemoryBufferByteAccess)reference).GetBuffer(out byte* dataInBytes, out _);
+                Duration = TimeSpan.FromSeconds((double)sampleCountPerChannel / sampleRate)
+            };
 
-                // Float span since audio graph only supports float
-                Span<short> dest = new(dataInBytes, (int)totalSampleCount);
+            using AudioBuffer buffer = frame.LockBuffer(AudioBufferAccessMode.Write);
+            using IMemoryBufferReference reference = buffer.CreateReference();
 
-                // VLC samples are interleaved, Windows expects data for each channel to be contiguous
-                for (int i = 0; i < totalSampleCount; i++)
-                {
-                    dest[i] = _audioBuffer.Front();
-                    _audioBuffer.PopFront();
-                }
+            // Get the buffer from the AudioFrame
+            ((IMemoryBufferByteAccess)reference).GetBuffer(out byte* dataInBytes, out _);
+
+            // Then create a span for easy access
+            Span<short> dest = new(dataInBytes, (int)totalSampleCount);
+
+            for (int i = 0; i < totalSampleCount; i++)
+            {
+                dest[i] = audioBuffer.Front();
+                audioBuffer.PopFront();
             }
 
             return frame;
@@ -463,7 +419,8 @@ namespace Screenbox.Core.Playback
         private void FlushCb(IntPtr data, long pts)
         {
             _inputNode?.DiscardQueuedFrames();
-            lock (_audioBuffer)
+            if (_audioBuffer == null) return;
+            lock (_audioBufferLock)
             {
                 _audioBuffer.Clear();
             }
@@ -481,66 +438,19 @@ namespace Screenbox.Core.Playback
 
         private unsafe void PlayCb(IntPtr data, IntPtr samplesPtr, uint countPerChannel, long pts)
         {
-            if (_audioGraph == null || _inputNode == null) return;
-            // Assume VLC has the same number of channels as the audio graph
+            if (_audioGraph == null || _inputNode == null || _audioBuffer == null) return;
+            // Assume VLC has the same number of channels as the audio graph input node
+            // as the input node is created by VLC set up callback
             uint channelCount = _inputNode.EncodingProperties.ChannelCount;
-            uint sampleRate = _inputNode.EncodingProperties.SampleRate;
-
-            // if (_inputNode.QueuedSampleCount > sampleRate * 3)
-            //     return;
-
             uint sampleCount = countPerChannel * channelCount;
-            uint bufferSize = sampleCount * sizeof(short);
 
             ReadOnlySpan<short> src = new((void*)samplesPtr, (int)sampleCount);
-            lock (_audioBuffer)
+            lock (_audioBufferLock)
             {
                 for (int i = 0; i < sampleCount; i++)
                 {
                     _audioBuffer.PushBack(src[i]);
                 }
-
-                return;
-            }
-
-            AudioFrame frame = new(bufferSize);
-            frame.Duration = TimeSpan.FromSeconds((double)countPerChannel / sampleRate);
-
-            using (AudioBuffer buffer = frame.LockBuffer(AudioBufferAccessMode.Write))
-            using (IMemoryBufferReference reference = buffer.CreateReference())
-            {
-                // Get the buffer from the AudioFrame
-                ((IMemoryBufferByteAccess)reference).GetBuffer(out byte* dataInBytes, out _);
-
-                // Float span since audio graph only supports float
-                Span<short> dest = new(dataInBytes, (int)sampleCount);
-
-                // Assume sample format is fixed to floating point with VlcPlayer.SetAudioFormat("FL32",...)
-                // ReadOnlySpan<short> src = new((void*)samplesPtr, (int)sampleCount);
-
-                // VLC samples are interleaved, Windows expects data for each channel to be contiguous
-                // for (int i = 0; i < sampleCount; i++)
-                // {
-                //     // uint channel = i % channelCount;
-                //     // uint offset = (i / channelCount) + (channel * countPerChannel);
-                //     // dest[(int)offset] = (float)src[(int)i] / short.MaxValue;
-                //     dest[i] = (float)src[i] / short.MaxValue;
-                // }
-
-                src.CopyTo(dest);
-            }
-
-            // _frameQueue.Enqueue(frame);
-            // _audioGraph.Start();
-            _inputNode.AddFrame(frame);
-            try
-            {
-            }
-            catch (InvalidOperationException)
-            {
-                // _inputNode.DiscardQueuedFrames();
-                // _inputNode.AddFrame(frame);
-                // _frameBuffer.Enqueue(frame);
             }
         }
 

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -106,6 +106,7 @@
     <DebugType>full</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -116,6 +117,7 @@
     <DebugType>pdbonly</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -144,6 +146,7 @@
     <Compile Include="Factories\ArtistViewModelFactory.cs" />
     <Compile Include="Factories\MediaViewModelFactory.cs" />
     <Compile Include="Factories\StorageItemViewModelFactory.cs" />
+    <Compile Include="Helpers\CircularBuffer.cs" />
     <Compile Include="Helpers\CollectionExtensions.cs" />
     <Compile Include="Helpers\FilesHelpers.cs" />
     <Compile Include="Helpers\LanguageHelper.cs" />

--- a/Screenbox/Controls/VolumeControl.xaml
+++ b/Screenbox/Controls/VolumeControl.xaml
@@ -66,6 +66,7 @@
             VerticalAlignment="Center"
             IsThumbToolTipEnabled="{x:Bind ShowValueText, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             Maximum="{x:Bind ViewModel.MaxVolume, Mode=OneWay}"
+            Minimum="0"
             PointerWheelChanged="{x:Bind ViewModel.OnPointerWheelChanged}"
             Value="{x:Bind ViewModel.Volume, Mode=TwoWay}" />
         <TextBlock


### PR DESCRIPTION
Use AudioGraph to handle audio output from VLC using [audio callbacks](https://videolan.videolan.me/vlc/group__libvlc__media__player.html#gaac7abb1d8be3f60bb9da20c000703790). This change allows us to potentially extract audio data for additional post processing and filtering, or external use cases such as audio visualizations.

Due to the AudioFrameInputNode having a limited buffer, a circular buffer is employed to transport and package audio data from VLC into audio frames.