### PR TITLE
fix: better handle sub media parsing

### DIFF
--- a/Screenbox.Core/Helpers/VlcMediaExtensions.cs
+++ b/Screenbox.Core/Helpers/VlcMediaExtensions.cs
@@ -1,0 +1,41 @@
+﻿using LibVLCSharp.Shared;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Screenbox.Core.Helpers;
+internal static class VlcMediaExtensions
+{
+    public static async Task ParseAsync(this Media media, TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        // Check if media is already parsed
+        if (media.IsParsed && media.ParsedStatus is MediaParsedStatus.Done or MediaParsedStatus.Failed)
+            return;
+
+        await media.Parse(MediaParseOptions.ParseNetwork, (int)timeout.TotalMilliseconds, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Media may not be parsed even after calling Parse()
+        // This can happen if the media is being open at the same time.
+        if (media.IsParsed && media.ParsedStatus != MediaParsedStatus.Skipped)
+            return;
+
+        // Wait for the ParsedStatus to change again.
+        TaskCompletionSource<MediaParsedStatus> tsc = new();
+        Task task = tsc.Task;
+
+        media.ParsedChanged += MediaOnParsedChanged;
+
+        if (await Task.WhenAny(tsc.Task, Task.Delay(timeout, cancellationToken)) != task)
+        {
+            tsc.SetCanceled();
+        }
+
+        return;
+
+        void MediaOnParsedChanged(object sender, MediaParsedChangedEventArgs e)
+        {
+            tsc.TrySetResult(e.ParsedStatus);
+        }
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Helpers\MediaGroupingHelpers.cs" />
     <Compile Include="Helpers\MessengerExtensions.cs" />
     <Compile Include="Helpers\SystemInformation.cs" />
+    <Compile Include="Helpers\VlcMediaExtensions.cs" />
     <Compile Include="Messages\ChangeAspectRatioMessage.cs" />
     <Compile Include="Messages\ChangeTimeRequestMessage.cs" />
     <Compile Include="Messages\ChangeVolumeRequestMessage.cs" />

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -708,7 +708,7 @@ namespace Screenbox.Core.ViewModels
                 MediaParsedStatus parsedStatus = media.ParsedStatus;
                 if (!media.IsParsed)
                 {
-                    parsedStatus = await media.Parse(MediaParseOptions.ParseNetwork, 5000, cts.Token);
+                    parsedStatus = await media.Parse(MediaParseOptions.ParseNetwork, 10000, cts.Token);
                 }
 
                 if (parsedStatus != MediaParsedStatus.Done) return Array.Empty<MediaViewModel>();

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using LibVLCSharp.Shared;
@@ -116,6 +117,7 @@ namespace Screenbox.Core.ViewModels
         public MediaViewModel(LibVlcService libVlcService, Uri uri)
             : this(uri, new MediaInfo(MediaPlaybackType.Unknown), libVlcService)
         {
+            Guard.IsTrue(uri.IsAbsoluteUri);
             Location = uri.OriginalString;
             _name = uri.Segments.Length > 0 ? Uri.UnescapeDataString(uri.Segments.Last()) : string.Empty;
         }

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -224,7 +224,7 @@ namespace Screenbox.Core.ViewModels
 
             switch (MediaType)
             {
-                case MediaPlaybackType.Unknown when _item is { VideoTracks.Count: 0, Media.IsParsed: true }:
+                case MediaPlaybackType.Unknown when _item is { VideoTracks.Count: 0, Media.ParsedStatus: MediaParsedStatus.Done }:
                     // Update media type when it was previously set Unknown. Usually when source is a URI.
                     // We don't want to init PlaybackItem just for this.
                     MediaInfo.MediaType = MediaPlaybackType.Music;

--- a/Screenbox/Controls/OpenUrlDialog.xaml.cs
+++ b/Screenbox/Controls/OpenUrlDialog.xaml.cs
@@ -21,14 +21,14 @@ namespace Screenbox.Controls
             OpenUrlDialog dialog = new();
             ContentDialogResult result = await dialog.ShowAsync();
             string url = dialog.UrlBox.Text;
-            return result == ContentDialogResult.Primary && Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri uri)
+            return result == ContentDialogResult.Primary && Uri.TryCreate(url, UriKind.Absolute, out Uri uri)
                 ? uri
                 : null;
         }
 
         private bool CanOpen(string url)
         {
-            return Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri _);
+            return Uri.TryCreate(url, UriKind.Absolute, out Uri _);
         }
     }
 }


### PR DESCRIPTION
- Handle playlist parse timeout. Closes #364 
- Fix URL media is not parsed when adding directly to the play queue without playing first.
- Enforce all media URLs to be absolute URLs.
- Remove wait time when opening a URL. Provide instant UI feedback while media is being parsed in the background.