### PR TITLE
chore: bump LibVLC version

### DIFF
--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -3,13 +3,13 @@
 using LibVLCSharp.Shared;
 using Screenbox.Core.Events;
 using System;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.Devices.Enumeration;
 using Windows.Foundation;
 using Windows.Media.Core;
 using Windows.Media.Devices;
 using Windows.Media.Playback;
 using Windows.Storage;
-using Windows.Storage.AccessCache;
 using MediaPlayer = LibVLCSharp.Shared.MediaPlayer;
 
 namespace Screenbox.Core.Playback
@@ -423,7 +423,7 @@ namespace Screenbox.Core.Playback
         public void AddSubtitle(IStorageFile file, bool select = true)
         {
             if (PlaybackItem == null) return;
-            string mrl = "winrt://" + StorageApplicationPermissions.FutureAccessList.Add(file, "subtitle");
+            string mrl = "winrt://" + SharedStorageAccessManager.AddFile(file);
             VlcPlayer.AddSlave(MediaSlaveType.Subtitle, mrl, select);
         }
 

--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -3,13 +3,13 @@
 using LibVLCSharp.Shared;
 using Screenbox.Core.Events;
 using System;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.Devices.Enumeration;
 using Windows.Foundation;
 using Windows.Media.Core;
 using Windows.Media.Devices;
 using Windows.Media.Playback;
 using Windows.Storage;
+using Windows.Storage.AccessCache;
 using MediaPlayer = LibVLCSharp.Shared.MediaPlayer;
 
 namespace Screenbox.Core.Playback
@@ -423,7 +423,7 @@ namespace Screenbox.Core.Playback
         public void AddSubtitle(IStorageFile file, bool select = true)
         {
             if (PlaybackItem == null) return;
-            string mrl = "winrt://" + SharedStorageAccessManager.AddFile(file);
+            string mrl = "winrt://" + StorageApplicationPermissions.FutureAccessList.Add(file, "subtitle");
             VlcPlayer.AddSlave(MediaSlaveType.Subtitle, mrl, select);
         }
 

--- a/Screenbox.Core/Services/LibVlcService.cs
+++ b/Screenbox.Core/Services/LibVlcService.cs
@@ -38,7 +38,7 @@ namespace Screenbox.Core.Services
         {
             return source switch
             {
-                StorageFile file => CreateMedia(file, options),
+                IStorageFile file => CreateMedia(file, options),
                 string str => CreateMedia(str, options),
                 Uri uri => CreateMedia(uri, options),
                 _ => throw new ArgumentOutOfRangeException(nameof(source))
@@ -57,7 +57,7 @@ namespace Screenbox.Core.Services
             return new Media(libVlc, str, FromType.FromPath, options);
         }
 
-        private Media CreateMedia(IStorageItem file, params string[] options)
+        private Media CreateMedia(IStorageFile file, params string[] options)
         {
             Guard.IsNotNull(LibVlc, nameof(LibVlc));
             LibVLC libVlc = LibVlc;

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -191,7 +191,7 @@ namespace Screenbox.Core.ViewModels
             PlaybackItem? item = _item;
             _item = null;
             if (item == null) return;
-            _libVlcService.DisposeMedia(item.Media);
+            LibVlcService.DisposeMedia(item.Media);
         }
 
         public void UpdateSource(StorageFile file)
@@ -241,11 +241,6 @@ namespace Screenbox.Core.ViewModels
 
             if (_item?.Media is { IsParsed: true } media)
             {
-                if (media.Meta(MetadataType.Title) is { } title && !title.StartsWith('{'))
-                {
-                    Name = title;
-                }
-
                 VideoInfo videoProperties = MediaInfo.VideoProperties;
                 videoProperties.ShowName = media.Meta(MetadataType.ShowName) ?? videoProperties.ShowName;
                 videoProperties.Season = media.Meta(MetadataType.Season) ?? videoProperties.Season;

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -241,6 +241,13 @@ namespace Screenbox.Core.ViewModels
 
             if (_item?.Media is { IsParsed: true } media)
             {
+                if (Source is not IStorageItem &&
+                    media.Meta(MetadataType.Title) is { } title &&
+                    !Guid.TryParse(title, out Guid _))
+                {
+                    Name = title;
+                }
+
                 VideoInfo videoProperties = MediaInfo.VideoProperties;
                 videoProperties.ShowName = media.Meta(MetadataType.ShowName) ?? videoProperties.ShowName;
                 videoProperties.Season = media.Meta(MetadataType.Season) ?? videoProperties.Season;

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1094,7 +1094,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="LibVLC.UWP">
-      <Version>3.0.20-2405070026</Version>
+      <Version>3.0.20-2405070635</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -1094,7 +1094,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="LibVLC.UWP">
-      <Version>3.0.20-2404030615</Version>
+      <Version>3.0.20-2405070026</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -66,9 +66,9 @@
       },
       "LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.0.20-2405070026, )",
-        "resolved": "3.0.20-2405070026",
-        "contentHash": "uTnaEWjjdh2VJzyE+M1Ie589URJJDHikxus22tC34M8w1kHqtTcB9j5DA83QzI1UbbBkgdxGialhXiQoy2xxBA=="
+        "requested": "[3.0.20-2405070635, )",
+        "resolved": "3.0.20-2405070635",
+        "contentHash": "h3mBtHTXgahhNAPpQIwBlHUBE2AmRIbXHX8+2c3WLXhLD/V/w/bFau3aurbbLlcaK8fcpiVoHOOyFd5gOomyNQ=="
       },
       "Microsoft.AppCenter.Analytics": {
         "type": "Direct",

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -66,9 +66,9 @@
       },
       "LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.0.20-2404030615, )",
-        "resolved": "3.0.20-2404030615",
-        "contentHash": "J7sFZMPGWC6tCRDXcZdZ/usoGZCxsjM6c0M3di+k+UjaW1oPlqoC4jVSgMvzdvahoIHVG09+BWVdzeXer7BXOQ=="
+        "requested": "[3.0.20-2405070026, )",
+        "resolved": "3.0.20-2405070026",
+        "contentHash": "uTnaEWjjdh2VJzyE+M1Ie589URJJDHikxus22tC34M8w1kHqtTcB9j5DA83QzI1UbbBkgdxGialhXiQoy2xxBA=="
       },
       "Microsoft.AppCenter.Analytics": {
         "type": "Direct",


### PR DESCRIPTION
This LibVLC version adds support for opening StorageFile using SharedStorageAccessManager tokens. Too bad they are too restrictive compared to FutureAccessList.

The plugin source code is located in https://github.com/huynhsontung/libvlc-winrt-plugins