### PR TITLE
feat: lazily initialize PlaybackItem

### DIFF
--- a/Screenbox.Core/Factories/MediaViewModelFactory.cs
+++ b/Screenbox.Core/Factories/MediaViewModelFactory.cs
@@ -38,7 +38,7 @@ namespace Screenbox.Core.Factories
             // Prefer URI source for easier clean up
             MediaViewModel vm = new(_libVlcService, uri)
             {
-                Item = new PlaybackItem(media, media)
+                Item = new Lazy<PlaybackItem>(new PlaybackItem(media, media))
             };
 
             if (media.Meta(MetadataType.Title) is { } name)

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -61,7 +61,7 @@ namespace Screenbox.Core.ViewModels
         public async void Receive(PlaylistCurrentItemChangedMessage message)
         {
             if (_mediaPlayer is not VlcMediaPlayer player) return;
-            if (message.Value is not { Source: StorageFile file, Item: { } item, MediaType: MediaPlaybackType.Video })
+            if (message.Value is not { Source: StorageFile file, MediaType: MediaPlaybackType.Video } media)
                 return;
 
             IReadOnlyList<StorageFile> subtitles = await GetSubtitlesForFile(file);
@@ -70,7 +70,7 @@ namespace Screenbox.Core.ViewModels
             foreach (StorageFile subtitleFile in subtitles)
             {
                 // Preload subtitle but don't select it
-                item.SubtitleTracks.AddExternalSubtitle(player, subtitleFile, false);
+                media.Item.Value?.SubtitleTracks.AddExternalSubtitle(player, subtitleFile, false);
             }
         }
 

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -229,7 +229,7 @@ namespace Screenbox.Core.ViewModels
         {
             if (_mediaPlayer != null)
             {
-                _mediaPlayer.PlaybackItem = value?.Item;
+                _mediaPlayer.PlaybackItem = value?.Item.Value;
             }
 
             if (CurrentItem != null)
@@ -371,9 +371,9 @@ namespace Screenbox.Core.ViewModels
 
             _mediaBuffer = newBuffer;
             await Task.WhenAll(toLoad.Select(x =>
-                x.Item?.Media.IsParsed ?? true
+                x.Item.Value?.Media.IsParsed ?? true
                     ? x.LoadThumbnailAsync(_filesService)
-                    : Task.WhenAll(x.Item?.Media.Parse(), x.LoadThumbnailAsync(_filesService))));
+                    : Task.WhenAll(x.Item.Value?.Media.Parse(), x.LoadThumbnailAsync(_filesService))));
         }
 
         private void TransportControlsOnButtonPressed(SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args)
@@ -497,7 +497,7 @@ namespace Screenbox.Core.ViewModels
             // Delay check Item as much as possible. Item is lazy init.
             if ((media.Source is StorageFile file && !file.IsSupportedPlaylist())
                 || media.Source is Uri uri && !IsUriLocalPlaylistFile(uri)
-                || media.Item?.Media is { ParsedStatus: MediaParsedStatus.Done or MediaParsedStatus.Failed, SubItems.Count: 0 }
+                || media.Item.Value?.Media is { ParsedStatus: MediaParsedStatus.Done or MediaParsedStatus.Failed, SubItems.Count: 0 }
                 || await ParseSubMediaRecursiveAsync(media) is not { Count: > 0 } playlist)
             {
                 return new PlaylistCreateResult(media);
@@ -739,7 +739,7 @@ namespace Screenbox.Core.ViewModels
 
         private async Task<IList<MediaViewModel>> ParseSubMediaAsync(MediaViewModel source)
         {
-            if (source.Item == null) return Array.Empty<MediaViewModel>();
+            if (source.Item.Value == null) return Array.Empty<MediaViewModel>();
 
             // Parsing sub items is atomic
             _cts?.Cancel();
@@ -748,7 +748,7 @@ namespace Screenbox.Core.ViewModels
             try
             {
                 _cts = cts;
-                Media media = source.Item.Media;
+                Media media = source.Item.Value.Media;
                 if (!media.IsParsed || media.ParsedStatus is MediaParsedStatus.Skipped)    // Not yet parsed
                 {
                     await media.ParseAsync(TimeSpan.FromSeconds(10), cts.Token);

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -194,9 +194,9 @@ namespace Screenbox.Core.ViewModels
                     if (items.Count > 0)
                     {
                         if (items.Count == 1 && items[0] is StorageFile file && file.IsSupportedSubtitle() &&
-                            _mediaPlayer is VlcMediaPlayer player && Media?.Item != null)
+                            _mediaPlayer is VlcMediaPlayer player && Media?.Item.Value != null)
                         {
-                            Media.Item.SubtitleTracks.AddExternalSubtitle(player, file, true);
+                            Media.Item.Value.SubtitleTracks.AddExternalSubtitle(player, file, true);
                             Messenger.Send(new SubtitleAddedNotificationMessage(file));
                         }
                         else


### PR DESCRIPTION
Use Lazy<T> to initialize PlaybackItem instead of getter-based initialization.