### PR TITLE
fix: library cache using a method that is unavailable in older versions of Windows

### DIFF
--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -361,9 +361,8 @@ namespace Screenbox.Core.Services
                 // Populate Album and Artists for each song
                 foreach (MediaViewModel song in songs)
                 {
-                    // If cache is available but IsFromLibrary = false then it may have been added
-                    // by a background library change. Load details first in this case.
-                    if (hasCache && song.IsFromLibrary)
+                    // A cached song always has a URI as source
+                    if (hasCache && song.Source is Uri)
                     {
                         song.UpdateAlbum(_albumFactory);
                         song.UpdateArtists(_artistFactory);

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -566,7 +566,7 @@ namespace Screenbox.Core.Services
             return mediaBatch;
         }
 
-        private async Task<bool> TryResolveLibraryChangeAsync(List<MediaViewModel> mediaList, StorageLibraryChangeReader changeReader)
+        private Task<bool> TryResolveLibraryChangeAsync(List<MediaViewModel> mediaList, StorageLibraryChangeReader changeReader)
         {
             if (ApiInformation.IsMethodPresent("Windows.Storage.StorageLibraryChangeReader",
                     "GetLastChangeId"))
@@ -574,20 +574,20 @@ namespace Screenbox.Core.Services
                 var changeId = changeReader.GetLastChangeId();
                 if (changeId == StorageLibraryLastChangeId.Unknown)
                 {
-                    return false;
+                    return Task.FromResult(false);
                 }
 
                 if (changeId > 0)
                 {
-                    return await TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
+                    return TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
                 }
             }
             else
             {
-                return await TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
+                return TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
             }
 
-            return true;
+            return Task.FromResult(true);
         }
 
         private async Task<bool> TryResolveLibraryBatchChangeAsync(List<MediaViewModel> mediaList, StorageLibraryChangeReader changeReader)

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -582,8 +582,12 @@ namespace Screenbox.Core.Services
                     return await TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
                 }
             }
+            else
+            {
+                return await TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
+            }
 
-            return await TryResolveLibraryBatchChangeAsync(mediaList, changeReader);
+            return true;
         }
 
         private async Task<bool> TryResolveLibraryBatchChangeAsync(List<MediaViewModel> mediaList, StorageLibraryChangeReader changeReader)

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -635,6 +635,12 @@ namespace Screenbox.Core.Services
 
                     case StorageLibraryChangeType.ContentsChanged:
                     case StorageLibraryChangeType.ContentsReplaced:
+                        file = (StorageFile)await change.GetStorageItemAsync();
+                        existing = mediaList.Find(s =>
+                            s.Location.Equals(file.Path, StringComparison.OrdinalIgnoreCase));
+                        existing?.UpdateSource(file);
+                        break;
+
                     case StorageLibraryChangeType.EncryptionChanged:
                     case StorageLibraryChangeType.IndexingStatusChanged:
                         break;


### PR DESCRIPTION
`Windows.Storage.StorageLibraryChangeReader.GetLastChangeId()` is not available in older versions of Windows. Fixed bug introduced in #373 