### PR TITLE
fix: handle permission request for removable devices on Xbox

### DIFF
--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -301,6 +301,7 @@ namespace Screenbox.Core.Services
             var changeReader = libraryChangeTracker.GetChangeReader();
             try
             {
+                await KnownFolders.RequestAccessAsync(KnownFolderId.MusicLibrary);
                 var libraryQuery = GetMusicLibraryQuery();
                 List<MediaViewModel> songs = new();
                 if (useCache)
@@ -331,9 +332,13 @@ namespace Screenbox.Core.Services
                     // Search removable storage if the system is Xbox
                     if (SearchRemovableStorage)
                     {
-                        libraryQuery = CreateRemovableStorageMusicQuery();
-                        await BatchFetchMediaAsync(libraryQuery, songs, cancellationToken);
-                        StartPortableStorageDeviceWatcher();
+                        var accessStatus = await KnownFolders.RequestAccessAsync(KnownFolderId.RemovableDevices);
+                        if (accessStatus is KnownFoldersAccessStatus.Allowed or KnownFoldersAccessStatus.AllowedPerAppFolder)
+                        {
+                            libraryQuery = CreateRemovableStorageMusicQuery();
+                            await BatchFetchMediaAsync(libraryQuery, songs, cancellationToken);
+                            StartPortableStorageDeviceWatcher();
+                        }
                     }
                 }
 
@@ -397,6 +402,7 @@ namespace Screenbox.Core.Services
             var changeReader = libraryChangeTracker.GetChangeReader();
             try
             {
+                await KnownFolders.RequestAccessAsync(KnownFolderId.VideosLibrary);
                 StorageFileQueryResult libraryQuery = GetVideosLibraryQuery();
                 List<MediaViewModel> videos = new();
                 if (useCache)
@@ -425,9 +431,13 @@ namespace Screenbox.Core.Services
                     // Search removable storage if the system is Xbox
                     if (SearchRemovableStorage)
                     {
-                        libraryQuery = CreateRemovableStorageVideosQuery();
-                        await BatchFetchMediaAsync(libraryQuery, videos, cancellationToken);
-                        StartPortableStorageDeviceWatcher();
+                        var accessStatus = await KnownFolders.RequestAccessAsync(KnownFolderId.RemovableDevices);
+                        if (accessStatus is KnownFoldersAccessStatus.Allowed or KnownFoldersAccessStatus.AllowedPerAppFolder)
+                        {
+                            libraryQuery = CreateRemovableStorageVideosQuery();
+                            await BatchFetchMediaAsync(libraryQuery, videos, cancellationToken);
+                            StartPortableStorageDeviceWatcher();
+                        }
                     }
                 }
 

--- a/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
@@ -109,9 +109,16 @@ namespace Screenbox.Core.ViewModels
                     break;
                 case "VideosLibrary":   // Special case for VideosPage
                     // VideosPage needs to serialize navigation state so it cannot set nav data
-                    Breadcrumbs = new[] { SystemInformation.IsXbox ? KnownFolders.RemovableDevices : KnownFolders.VideosLibrary };
-                    NavData = new NavigationMetadata(typeof(VideosPageViewModel), Breadcrumbs);
-                    await FetchFolderContentAsync(Breadcrumbs[0]);
+                    try
+                    {
+                        Breadcrumbs = new[] { SystemInformation.IsXbox ? KnownFolders.RemovableDevices : KnownFolders.VideosLibrary };
+                        NavData = new NavigationMetadata(typeof(VideosPageViewModel), Breadcrumbs);
+                        await FetchFolderContentAsync(Breadcrumbs[0]);
+                    }
+                    catch (Exception)
+                    {
+                        // pass
+                    }
                     break;
             }
         }

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -317,6 +317,10 @@ namespace Screenbox.Core.ViewModels
             if (SystemInformation.IsXbox)
             {
                 RemovableStorageFolders.Clear();
+                var accessStatus = await KnownFolders.RequestAccessAsync(KnownFolderId.RemovableDevices);
+                if (accessStatus != KnownFoldersAccessStatus.Allowed)
+                    return;
+
                 foreach (StorageFolder folder in await KnownFolders.RemovableDevices.GetFoldersAsync())
                 {
                     RemovableStorageFolders.Add(folder);


### PR DESCRIPTION
Check and request access to library and removable device folders before accessing them.