### PR TITLE
fix: cache pages to avoid system memory leak

### DIFF
--- a/Screenbox.Core/ViewModels/BaseMusicContentViewModel.cs
+++ b/Screenbox.Core/ViewModels/BaseMusicContentViewModel.cs
@@ -4,14 +4,22 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Messages;
+using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.System;
 
 namespace Screenbox.Core.ViewModels;
 public abstract partial class BaseMusicContentViewModel : ObservableRecipient
 {
     private bool HasSongs => Songs.Count > 0;
+
+    private DispatcherQueue DispatcherQueue { get; }
+
+    protected DispatcherQueueTimer RefreshTimer { get; }
+
+    protected ILibraryService LibraryService { get; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ShuffleAndPlayCommand))]
@@ -21,6 +29,31 @@ public abstract partial class BaseMusicContentViewModel : ObservableRecipient
     private string _sortBy = string.Empty;
 
     [ObservableProperty] private bool _isLoading;
+
+    protected BaseMusicContentViewModel(ILibraryService libraryService)
+    {
+        LibraryService = libraryService;
+        DispatcherQueue = DispatcherQueue.GetForCurrentThread();
+        RefreshTimer = DispatcherQueue.CreateTimer();
+    }
+
+    public abstract void FetchContent();
+
+    public void OnNavigatedTo()
+    {
+        LibraryService.MusicLibraryContentChanged += OnMusicLibraryContentChanged;
+    }
+
+    public void OnNavigatedFrom()
+    {
+        LibraryService.MusicLibraryContentChanged -= OnMusicLibraryContentChanged;
+        RefreshTimer.Stop();
+    }
+
+    private void OnMusicLibraryContentChanged(ILibraryService sender, object args)
+    {
+        DispatcherQueue.TryEnqueue(FetchContent);
+    }
 
     [RelayCommand(CanExecute = nameof(HasSongs))]
     private void ShuffleAndPlay()

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -27,9 +27,18 @@ namespace Screenbox.Core.ViewModels
         {
             _libraryService = libraryService;
             _resourceService = resourceService;
-            _libraryService.MusicLibraryContentChanged += OnMusicLibraryContentChanged;
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             _hasContent = true;
+        }
+
+        public void OnNavigatedTo()
+        {
+            _libraryService.MusicLibraryContentChanged += OnMusicLibraryContentChanged;
+        }
+
+        public void OnNavigatedFrom()
+        {
+            _libraryService.MusicLibraryContentChanged -= OnMusicLibraryContentChanged;
         }
 
         public void UpdateSongs()

--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -94,7 +94,7 @@
                     <Thickness x:Key="ContentPageBottomMargin">0,0,0,106</Thickness>
                     <x:Double x:Key="ContentPageBottomPaddingHeight">106</x:Double>
 
-                    <x:String x:Key="EntranceTranslateAnimationOffset">0,50,0</x:String>
+                    <x:String x:Key="EntranceTranslateAnimationOffset">0,40,0</x:String>
                     <x:String x:Key="EntranceTranslateAnimationDuration">0:0:0.4</x:String>
 
                     <CornerRadius x:Key="CircularCornerRadius">99</CornerRadius>

--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -94,6 +94,9 @@
                     <Thickness x:Key="ContentPageBottomMargin">0,0,0,106</Thickness>
                     <x:Double x:Key="ContentPageBottomPaddingHeight">106</x:Double>
 
+                    <x:String x:Key="EntranceTranslateAnimationOffset">0,50,0</x:String>
+                    <x:String x:Key="EntranceTranslateAnimationDuration">0:0:0.4</x:String>
+
                     <CornerRadius x:Key="CircularCornerRadius">99</CornerRadius>
 
                     <Style TargetType="FontIcon">

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -11,7 +11,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
-    xmlns:toolkitConverters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewModels="using:Screenbox.Core.ViewModels"
     d:DataContext="{d:DesignInstance Type=viewModels:MediaViewModel}"
     d:DesignHeight="300"
@@ -228,7 +227,7 @@
                 </VisualState>
             </VisualStateGroup>
 
-            <VisualStateGroup x:Name="PlayingStates">
+            <VisualStateGroup x:Name="PlayingStates" CurrentStateChanged="PlayingStatesOnCurrentStateChanged">
                 <VisualState x:Name="Playing">
                     <VisualState.Setters>
                         <Setter Target="PlayingIndicator.PlaybackRate" Value="1" />

--- a/Screenbox/Controls/MediaListViewItem.xaml.cs
+++ b/Screenbox/Controls/MediaListViewItem.xaml.cs
@@ -36,7 +36,6 @@ public sealed partial class MediaListViewItem : UserControl
     {
         this.InitializeComponent();
         Common = Ioc.Default.GetRequiredService<CommonViewModel>();
-        PlayingStates.CurrentStateChanged += PlayingStatesOnCurrentStateChanged;
     }
 
     private GridLength BoolToGridLength(bool visibility) =>

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.AlbumsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -111,7 +112,10 @@
             IsIndeterminate="True"
             Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
 
-        <SemanticZoom Grid.Row="1" Margin="{StaticResource TopLargeMargin}">
+        <SemanticZoom
+            x:Name="SemanticZoom"
+            Grid.Row="1"
+            Margin="{StaticResource TopLargeMargin}">
             <SemanticZoom.ZoomedInView>
                 <GridView
                     x:Name="AlbumGridView"
@@ -166,6 +170,19 @@
                     </interactivity:Interaction.Behaviors>
                 </GridView>
             </SemanticZoom.ZoomedOutView>
+
+            <animations:Implicit.ShowAnimations>
+                <animations:TranslationAnimation
+                    EasingMode="EaseOut"
+                    EasingType="Default"
+                    From="{StaticResource EntranceTranslateAnimationOffset}"
+                    To="0"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+                <animations:OpacityAnimation
+                    From="0"
+                    To="1"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+            </animations:Implicit.ShowAnimations>
         </SemanticZoom>
 
         <VisualStateManager.VisualStateGroups>

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -2,7 +2,6 @@
     x:Class="Screenbox.Pages.AlbumsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -11,7 +10,7 @@
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
-    xmlns:viewModels="using:Screenbox.Core.ViewModels"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -54,6 +54,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
+            ViewModel.OnNavigatedTo();
             if (e.NavigationMode == NavigationMode.Back
                 && Common.TryGetPageState(nameof(AlbumsPage), Frame.BackStackDepth, out var state)
                 && state is KeyValuePair<string, double> pair)
@@ -62,8 +63,8 @@ namespace Screenbox.Pages
                 _contentVerticalOffset = pair.Value;
             }
 
-            if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchAlbums))
-                ViewModel.FetchAlbums();
+            if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchContent))
+                ViewModel.FetchContent();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/AllVideosPage.xaml
+++ b/Screenbox/Pages/AllVideosPage.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commands="using:Screenbox.Commands"
-    xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -12,7 +11,7 @@
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
-    xmlns:viewModels="using:Screenbox.Core.ViewModels"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -10,6 +10,7 @@
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.ArtistsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -119,6 +120,19 @@
                     </GridView.ItemsPanel>
                 </GridView>
             </SemanticZoom.ZoomedOutView>
+
+            <animations:Implicit.ShowAnimations>
+                <animations:TranslationAnimation
+                    EasingMode="EaseOut"
+                    EasingType="Default"
+                    From="{StaticResource EntranceTranslateAnimationOffset}"
+                    To="0"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+                <animations:OpacityAnimation
+                    From="0"
+                    To="1"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+            </animations:Implicit.ShowAnimations>
         </SemanticZoom>
 
         <VisualStateManager.VisualStateGroups>

--- a/Screenbox/Pages/ArtistsPage.xaml.cs
+++ b/Screenbox/Pages/ArtistsPage.xaml.cs
@@ -30,6 +30,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
+            ViewModel.OnNavigatedTo();
             if (e.NavigationMode == NavigationMode.Back
                 && Common.TryGetPageState(nameof(ArtistsPage), Frame.BackStackDepth, out var state)
                 && state is double verticalOffset)
@@ -37,7 +38,7 @@ namespace Screenbox.Pages
                 _contentVerticalOffset = verticalOffset;
             }
 
-            ViewModel.FetchArtists();
+            ViewModel.FetchContent();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -2,8 +2,6 @@
     x:Class="Screenbox.Pages.MusicPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
-    xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Screenbox.Core.Helpers"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
@@ -12,6 +10,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/MusicPage.xaml.cs
+++ b/Screenbox/Pages/MusicPage.xaml.cs
@@ -48,6 +48,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
+            ViewModel.OnNavigatedTo();
             if (Common.NavigationStates.TryGetValue(typeof(MusicPage), out string navigationState))
             {
                 ContentFrame.SetNavigationState(navigationState);
@@ -64,6 +65,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             base.OnNavigatedFrom(e);
+            ViewModel.OnNavigatedFrom();
             Common.NavigationStates[typeof(MusicPage)] = ContentFrame.GetNavigationState();
         }
 

--- a/Screenbox/Pages/NetworkPage.xaml
+++ b/Screenbox/Pages/NetworkPage.xaml
@@ -8,6 +8,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Pages.SongsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -138,7 +139,10 @@
             IsIndeterminate="True"
             Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
 
-        <SemanticZoom Grid.Row="1" Margin="{StaticResource TopLargeMargin}">
+        <SemanticZoom
+            x:Name="SemanticZoom"
+            Grid.Row="1"
+            Margin="{StaticResource TopLargeMargin}">
             <SemanticZoom.ZoomedInView>
                 <ListView
                     x:Name="SongListView"
@@ -203,6 +207,19 @@
                     </interactivity:Interaction.Behaviors>
                 </GridView>
             </SemanticZoom.ZoomedOutView>
+
+            <animations:Implicit.ShowAnimations>
+                <animations:TranslationAnimation
+                    EasingMode="EaseOut"
+                    EasingType="Default"
+                    From="{StaticResource EntranceTranslateAnimationOffset}"
+                    To="0"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+                <animations:OpacityAnimation
+                    From="0"
+                    To="1"
+                    Duration="{StaticResource EntranceTranslateAnimationDuration}" />
+            </animations:Implicit.ShowAnimations>
         </SemanticZoom>
 
         <VisualStateManager.VisualStateGroups>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -13,6 +13,7 @@
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -55,6 +55,7 @@ namespace Screenbox.Pages
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
+            ViewModel.OnNavigatedTo();
             if (e.NavigationMode == NavigationMode.Back
                 && Common.TryGetPageState(nameof(SongsPage), Frame.BackStackDepth, out var state)
                 && state is KeyValuePair<string, double> pair)
@@ -63,8 +64,8 @@ namespace Screenbox.Pages
                 _contentVerticalOffset = pair.Value;
             }
 
-            if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchSongs))
-                ViewModel.FetchSongs();
+            if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchContent))
+                ViewModel.FetchContent();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -12,6 +12,7 @@
     xmlns:storage="using:Windows.Storage"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
+    NavigationCacheMode="Enabled"
     mc:Ignorable="d">
 
     <Page.Resources>


### PR DESCRIPTION
**Update**: Memory leak is due to pages not unregistering the handler for view model's PropertyChanged events when navigating away. The ViewModel keeps a hard reference to the Page, so somehow both cannot be GC.

Looks like Pages don't get efficiently cleaned up when they are navigated away from. New Page instances are created on every navigation and never get properly released. It's confirmed to be a system-level memory leak. 🤦 Set `NavigationCacheMode` to `Enabled` can fix that. 

https://learn.microsoft.com/en-us/answers/questions/111194/memory-leak-on-uwp-with-target-versions-10-0-17763
https://github.com/microsoft/microsoft-ui-xaml/issues/934
https://github.com/microsoft/microsoft-ui-xaml/issues/3597