### PR TITLE
feat: Add option to not display controls on pause

### DIFF
--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -10,6 +10,7 @@ namespace Screenbox.Core.Services
         bool PlayerVolumeGesture { get; set; }
         bool PlayerSeekGesture { get; set; }
         bool PlayerTapGesture { get; set; }
+        bool PlayerShowControls { get; set; }
         int PersistentVolume { get; set; }
         bool ShowRecent { get; set; }
         bool SearchRemovableStorage { get; set; }

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -18,6 +18,7 @@ namespace Screenbox.Core.Services
         private const string PlayerVolumeGestureKey = "Player/Gesture/Volume";
         private const string PlayerSeekGestureKey = "Player/Gesture/Seek";
         private const string PlayerTapGestureKey = "Player/Gesture/Tap";
+        private const string PlayerShowControlsKey = "Player/ShowControls";
         private const string PlayerLivelyPathKey = "Player/Lively/Path";
         private const string LibrariesUseIndexerKey = "Libraries/UseIndexer";
         private const string LibrariesSearchRemovableStorageKey = "Libraries/SearchRemovableStorage";
@@ -77,6 +78,12 @@ namespace Screenbox.Core.Services
             set => SetValue(GeneralShowRecent, value);
         }
 
+        public bool PlayerShowControls
+        {
+            get => GetValue<bool>(PlayerShowControlsKey);
+            set => SetValue(PlayerShowControlsKey, value);
+        }
+
         public bool SearchRemovableStorage
         {
             get => GetValue<bool>(LibrariesSearchRemovableStorageKey);
@@ -119,6 +126,7 @@ namespace Screenbox.Core.Services
             SetDefault(PlayerVolumeGestureKey, true);
             SetDefault(PlayerSeekGestureKey, true);
             SetDefault(PlayerTapGestureKey, true);
+            SetDefault(PlayerShowControlsKey, true);
             SetDefault(PersistentVolumeKey, 100);
             SetDefault(MaxVolumeKey, 100);
             SetDefault(LibrariesUseIndexerKey, true);
@@ -136,6 +144,7 @@ namespace Screenbox.Core.Services
                 SetValue(PlayerSeekGestureKey, false);
                 SetValue(PlayerVolumeGestureKey, false);
                 SetValue(PlayerAutoResizeKey, (int)PlayerAutoResizeOption.Never);
+                SetValue(PlayerShowControlsKey, true);
             }
         }
 

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -542,7 +542,8 @@ namespace Screenbox.Core.ViewModels
 
         public bool TryHideControls(bool skipFocusCheck = false)
         {
-            if (PlayerVisibility != PlayerVisibilityState.Visible || !IsPlaying ||
+            bool shouldCheckPlaying = _settingsService.PlayerShowControls ? !IsPlaying : false;
+            if (PlayerVisibility != PlayerVisibilityState.Visible || shouldCheckPlaying ||
                 SeekBarPointerInteracting || AudioOnly || ControlsHidden) return false;
 
             if (!skipFocusCheck)
@@ -627,9 +628,14 @@ namespace Screenbox.Core.ViewModels
                 IsPlaying = state == MediaPlaybackState.Playing;
                 IsOpening = false;
 
-                if (!IsPlaying)
+                if (!IsPlaying && _settingsService.PlayerShowControls)
                 {
                     ControlsHidden = false;
+                }
+
+                if (!IsPlaying && !_settingsService.PlayerShowControls)
+                {
+                    DelayHideControls();
                 }
 
                 if (!ControlsHidden && IsPlaying)

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -24,6 +24,7 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private bool _playerVolumeGesture;
         [ObservableProperty] private bool _playerSeekGesture;
         [ObservableProperty] private bool _playerTapGesture;
+        [ObservableProperty] private bool _playerShowControls;
         [ObservableProperty] private int _volumeBoost;
         [ObservableProperty] private bool _useIndexer;
         [ObservableProperty] private bool _showRecent;
@@ -72,6 +73,7 @@ namespace Screenbox.Core.ViewModels
             _playerVolumeGesture = _settingsService.PlayerVolumeGesture;
             _playerSeekGesture = _settingsService.PlayerSeekGesture;
             _playerTapGesture = _settingsService.PlayerTapGesture;
+            _playerShowControls = _settingsService.PlayerShowControls;
             _useIndexer = _settingsService.UseIndexer;
             _showRecent = _settingsService.ShowRecent;
             _searchRemovableStorage = _settingsService.SearchRemovableStorage;
@@ -114,6 +116,12 @@ namespace Screenbox.Core.ViewModels
         {
             _settingsService.PlayerTapGesture = value;
             Messenger.Send(new SettingsChangedMessage(nameof(PlayerTapGesture), typeof(SettingsPageViewModel)));
+        }
+
+        partial void OnPlayerShowControlsChanged(bool value)
+        {
+            _settingsService.PlayerShowControls = value;
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerShowControls)));
         }
 
         partial void OnUseIndexerChanged(bool value)

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -121,7 +121,7 @@ namespace Screenbox.Core.ViewModels
         partial void OnPlayerShowControlsChanged(bool value)
         {
             _settingsService.PlayerShowControls = value;
-            Messenger.Send(new SettingsChangedMessage(nameof(PlayerShowControls)));
+            Messenger.Send(new SettingsChangedMessage(nameof(PlayerShowControls), typeof(SettingsPageViewModel)));
         }
 
         partial void OnUseIndexerChanged(bool value)

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -293,6 +293,12 @@
                         </ctc:SettingsCard>
                     </ctc:SettingsExpander.Items>
                 </ctc:SettingsExpander>
+                <ctc:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
+                    Header="{strings:Resources Key=SettingsShowControlsHeader}"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}">
+                    <ToggleSwitch x:Name="ShowControlsToggleSwitch" IsOn="{x:Bind ViewModel.PlayerShowControls, Mode=TwoWay}" />
+                </ctc:SettingsCard>
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsAudioVisualDescription}"

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -1767,6 +1767,19 @@ namespace Screenbox.Strings{
         }
         #endregion
 
+        #region SettingsShowControlsHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: Show controls
+        /// </summary>
+        public static string SettingsControlsHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsShowControlsHeader");
+            }
+        }
+        #endregion
+
         #region SettingsVideoLibraryLocationsHeader
         /// <summary>
         ///   Looks up a localized string similar to: Video library locations
@@ -2886,6 +2899,7 @@ namespace Screenbox.Strings{
             SettingsCategoryPlayer,
             SettingsMusicLibraryLocationsHeader,
             SettingsShowRecentHeader,
+            SettingsShowControlsHeader,
             SettingsVideoLibraryLocationsHeader,
             Subtitles,
             SettingsShowRecentDescription,

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -1769,9 +1769,9 @@ namespace Screenbox.Strings{
 
         #region SettingsShowControlsHeader
         /// <summary>
-        ///   Looks up a localized string similar to: Show controls
+        ///   Looks up a localized string similar to: Display controls on pause
         /// </summary>
-        public static string SettingsControlsHeader
+        public static string SettingsShowControlsHeader
         {
             get
             {

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -585,6 +585,9 @@
   <data name="SettingsShowRecentHeader" xml:space="preserve">
     <value>Show recent</value>
   </data>
+  <data name="SettingsShowControlsHeader" xml:space="preserve">
+    <value>Display controls on pause</value>
+  </data>
   <data name="SettingsVideoLibraryLocationsHeader" xml:space="preserve">
     <value>Video library locations</value>
   </data>

--- a/Screenbox/Strings/zh-Hans/Resources.resw
+++ b/Screenbox/Strings/zh-Hans/Resources.resw
@@ -585,6 +585,9 @@
   <data name="SettingsShowRecentHeader" xml:space="preserve">
     <value>显示最近播放</value>
   </data>
+  <data name="SettingsShowControlsHeader" xml:space="preserve">
+    <value>暂停时显示控制界面</value>
+  </data>
   <data name="SettingsVideoLibraryLocationsHeader" xml:space="preserve">
     <value>视频资料库位置</value>
   </data>


### PR DESCRIPTION
I often use screenshot software (e.g. pixpin, snipaste) to take a screenshot of the video directly and copy it to the clipboard, which is very easy to share. Therefore I seldom need to save the frame as a file. However, the controls keep displaying when paused, which is not convenient for taking screenshots directly. So I added a setting to control whether the controls will be displayed when paused. The controls will disappear after a while when paused. When pause with spacebar, it will not show the controls.