### PR TITLE
fix: Lively visual is always selected

### DIFF
--- a/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -39,13 +39,7 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
 
         var selectedVisualizer =
             allVisualizers.FirstOrDefault(visualizer =>
-                visualizer.Path.Equals(activeVisualizerPath, StringComparison.OrdinalIgnoreCase)) ??
-            allVisualizers.FirstOrDefault();
-
-        if (selectedVisualizer != null)
-        {
-            _settingsService.LivelyActivePath = selectedVisualizer.Path;
-        }
+                visualizer.Path.Equals(activeVisualizerPath, StringComparison.OrdinalIgnoreCase));
 
         Source = selectedVisualizer;
     }

--- a/Screenbox.Core/ViewModels/LivelyWallpaperSelectorViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperSelectorViewModel.cs
@@ -55,8 +55,6 @@ public sealed partial class LivelyWallpaperSelectorViewModel : ObservableRecipie
         _wallpaperService = wallpaperService;
         _filesService = filesService;
         _settingsService = settingsService;
-
-        _selectedVisualizer = _default;
     }
 
     public async Task InitializeVisualizers()

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -326,7 +326,8 @@
             Grid.Column="0"
             Grid.ColumnSpan="2"
             x:Load="False"
-            Media="{x:Bind ViewModel.Media, Mode=OneWay}" />
+            Media="{x:Bind ViewModel.Media, Mode=OneWay}"
+            Visibility="Collapsed" />
 
         <Button
             x:Name="LivelyOptionsButton"
@@ -586,7 +587,6 @@
                         <Setter Target="HeaderBackground.Opacity" Value="1" />
                         <Setter Target="PlayerControlsBackground.Opacity" Value="1" />
                         <Setter Target="VideoView.Opacity" Value="1" />
-                        <Setter Target="LivelyWallpaperPlayer.Visibility" Value="Collapsed" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="AudioOnly">
@@ -597,7 +597,6 @@
                         <Setter Target="HeaderBackground.Opacity" Value="0" />
                         <Setter Target="PlayerControlsBackground.Opacity" Value="0" />
                         <Setter Target="VideoView.Opacity" Value="0" />
-                        <Setter Target="LivelyWallpaperPlayer.Visibility" Value="Collapsed" />
                     </VisualState.Setters>
                     <Storyboard x:Name="BackgroundArtAnimation">
                         <DoubleAnimationUsingKeyFrames

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -367,7 +367,8 @@ namespace Screenbox.Pages
             // Update lively options button visibility
             // TODO: Use XAML visual state to encode this logic
             LivelyOptionsButton.Visibility = ViewModel.PlayerVisibility == PlayerVisibilityState.Visible &&
-                                             ViewModel.ViewMode != WindowViewMode.Compact
+                                             ViewModel.ViewMode != WindowViewMode.Compact &&
+                                             ViewModel.AudioOnly
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }


### PR DESCRIPTION
Fix an issue where a lively visual is always selected by default and the lively player is always loaded.