### PR TITLE
feat: use TaglibSharp for album art extraction

### DIFF
--- a/Screenbox.Core/Helpers/StreamAbstraction.cs
+++ b/Screenbox.Core/Helpers/StreamAbstraction.cs
@@ -19,7 +19,7 @@ internal class StreamAbstraction : TagLib.File.IFileAbstraction
 
     public void CloseStream(Stream stream)
     {
-        stream.Close();
+        // stream.Close();
     }
 
     public string Name { get; }

--- a/Screenbox.Core/Helpers/StreamAbstraction.cs
+++ b/Screenbox.Core/Helpers/StreamAbstraction.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace Screenbox.Core.Helpers;
+internal class StreamAbstraction : TagLib.File.IFileAbstraction
+{
+    public StreamAbstraction(string name, Stream readStream)
+    {
+        Name = name;
+        ReadStream = readStream;
+        WriteStream = Stream.Null;
+    }
+
+    public StreamAbstraction(string name, Stream readStream, Stream writeStream)
+    {
+        Name = name;
+        ReadStream = readStream;
+        WriteStream = writeStream;
+    }
+
+    public void CloseStream(Stream stream)
+    {
+        stream.Close();
+    }
+
+    public string Name { get; }
+    public Stream ReadStream { get; }
+    public Stream WriteStream { get; }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Helpers\LivelyWallpaperUtil.cs" />
     <Compile Include="Helpers\MediaGroupingHelpers.cs" />
     <Compile Include="Helpers\MessengerExtensions.cs" />
+    <Compile Include="Helpers\StreamAbstraction.cs" />
     <Compile Include="Helpers\SystemInformation.cs" />
     <Compile Include="Helpers\VlcMediaExtensions.cs" />
     <Compile Include="Helpers\WebView2Util.cs" />
@@ -318,6 +319,9 @@
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>4.10.2</Version>
+    </PackageReference>
+    <PackageReference Include="TagLibSharp">
+      <Version>2.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -63,29 +63,6 @@ namespace Screenbox.Core.Services
             return files.LastOrDefault(x => x.IsSupported());
         }
 
-        public async Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFile file, bool allowIcon = false)
-        {
-            if (!file.IsAvailable) return null;
-            try
-            {
-                StorageItemThumbnail? source = await file.GetThumbnailAsync(ThumbnailMode.SingleItem);
-                if (source != null && (source.Type == ThumbnailType.Image || allowIcon))
-                {
-                    return source;
-                }
-            }
-            catch (Exception e)
-            {
-                // System.Exception: The data necessary to complete this operation is not yet available.
-                if (e.HResult != unchecked((int)0x8000000A) &&
-                    // System.Exception: The RPC server is unavailable.
-                    e.HResult != unchecked((int)0x800706BA))
-                    LogService.Log(e);
-            }
-
-            return null;
-        }
-
         public StorageItemQueryResult GetSupportedItems(StorageFolder folder)
         {
             // Don't use indexer when querying. Potential incomplete result.

--- a/Screenbox.Core/Services/IFilesService.cs
+++ b/Screenbox.Core/Services/IFilesService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
-using Windows.Storage.FileProperties;
 using Windows.Storage.Search;
 
 namespace Screenbox.Core.Services
@@ -17,7 +16,6 @@ namespace Screenbox.Core.Services
             StorageFileQueryResult neighboringFilesQuery);
         public Task<StorageFile?> GetPreviousFileAsync(IStorageFile currentFile,
             StorageFileQueryResult neighboringFilesQuery);
-        public Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFile file, bool allowIcon = false);
         public StorageItemQueryResult GetSupportedItems(StorageFolder folder);
         public IAsyncOperation<uint> GetSupportedItemCountAsync(StorageFolder folder);
         public IAsyncOperation<StorageFile> PickFileAsync(params string[] formats);

--- a/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
@@ -5,7 +5,6 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
-using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -30,11 +29,9 @@ namespace Screenbox.Core.ViewModels
         public ObservableCollection<MediaViewModel> SortedItems { get; }
 
         private List<MediaViewModel>? _itemList;
-        private readonly IFilesService _filesService;
 
-        public AlbumDetailsPageViewModel(IFilesService filesService)
+        public AlbumDetailsPageViewModel()
         {
-            _filesService = filesService;
             SortedItems = new ObservableCollection<MediaViewModel>();
         }
 
@@ -64,7 +61,7 @@ namespace Screenbox.Core.ViewModels
 
             if (value.AlbumArt == null)
             {
-                await value.LoadAlbumArtAsync(_filesService);
+                await value.LoadAlbumArtAsync();
             }
         }
 

--- a/Screenbox.Core/ViewModels/AlbumViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumViewModel.cs
@@ -5,7 +5,6 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
-using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -59,11 +58,11 @@ namespace Screenbox.Core.ViewModels
             RelatedSongs.CollectionChanged += RelatedSongsOnCollectionChanged;
         }
 
-        public async Task LoadAlbumArtAsync(IFilesService filesService)
+        public async Task LoadAlbumArtAsync()
         {
             if (RelatedSongs.Count > 0)
             {
-                await RelatedSongs[0].LoadThumbnailAsync(filesService);
+                await RelatedSongs[0].LoadThumbnailAsync();
                 UpdateProperties();
             }
         }

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -25,14 +25,12 @@ namespace Screenbox.Core.ViewModels
         private string _sortBy = string.Empty;
 
         private readonly ILibraryService _libraryService;
-        private readonly IFilesService _filesService;
         private readonly DispatcherQueue _dispatcherQueue;
         private readonly DispatcherQueueTimer _refreshTimer;
 
-        public AlbumsPageViewModel(ILibraryService libraryService, IFilesService filesService)
+        public AlbumsPageViewModel(ILibraryService libraryService)
         {
             _libraryService = libraryService;
-            _filesService = filesService;
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             _refreshTimer = _dispatcherQueue.CreateTimer();
             GroupedAlbums = new ObservableGroupedCollection<string, AlbumViewModel>();
@@ -163,7 +161,7 @@ namespace Screenbox.Core.ViewModels
             if (args.Phase != 0) return;
             if (args.Item is AlbumViewModel album)
             {
-                await album.LoadAlbumArtAsync(_filesService);
+                await album.LoadAlbumArtAsync();
             }
         }
 

--- a/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
@@ -5,7 +5,6 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
-using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,11 +30,9 @@ namespace Screenbox.Core.ViewModels
         public int SongsCount => Source.RelatedSongs.Count;
 
         private List<MediaViewModel>? _itemList;
-        private readonly IFilesService _filesService;
 
-        public ArtistDetailsPageViewModel(IFilesService filesService)
+        public ArtistDetailsPageViewModel()
         {
-            _filesService = filesService;
             _source = new ArtistViewModel();
             _albums = new List<IGrouping<AlbumViewModel?, MediaViewModel>>();
         }
@@ -59,7 +56,7 @@ namespace Screenbox.Core.ViewModels
                 .OrderByDescending(g => g.Key?.Year ?? 0).ToList();
 
             IEnumerable<Task> loadingTasks = Albums.Where(g => g.Key is { AlbumArt: null })
-                .Select(g => g.Key?.LoadAlbumArtAsync(_filesService))
+                .Select(g => g.Key?.LoadAlbumArtAsync())
                 .OfType<Task>();
             await Task.WhenAll(loadingTasks);
         }

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -63,7 +63,14 @@ namespace Screenbox.Core.ViewModels
         public async void OnLoaded()
         {
             // Only run once. Assume this class is a singleton.
-            if (_isLoaded) return;
+            if (_isLoaded)
+            {
+                foreach (MediaViewModel media in Recent)
+                {
+                    await media.LoadThumbnailAsync();
+                }
+                return;
+            }
             _isLoaded = true;
             await UpdateContentAsync();
         }

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -223,7 +223,7 @@ namespace Screenbox.Core.ViewModels
             // Load media details for the remaining items
             if (!loadMediaDetails) return;
             IEnumerable<Task> loadingTasks = Recent.Select(x => x.LoadDetailsAsync(_filesService));
-            loadingTasks = Recent.Select(x => x.LoadThumbnailAsync(_filesService)).Concat(loadingTasks);
+            loadingTasks = Recent.Select(x => x.LoadThumbnailAsync()).Concat(loadingTasks);
             await Task.WhenAll(loadingTasks);
         }
 

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -370,7 +370,7 @@ namespace Screenbox.Core.ViewModels
             }
 
             _mediaBuffer = newBuffer;
-            await Task.WhenAll(toLoad.Select(x => x.LoadThumbnailAsync(_filesService)));
+            await Task.WhenAll(toLoad.Select(x => x.LoadThumbnailAsync()));
         }
 
         private void TransportControlsOnButtonPressed(SystemMediaTransportControls sender, SystemMediaTransportControlsButtonPressedEventArgs args)

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -53,12 +53,26 @@ namespace Screenbox.Core.ViewModels
         public string TrackNumberText =>
             MediaInfo.MusicProperties.TrackNumber > 0 ? MediaInfo.MusicProperties.TrackNumber.ToString() : string.Empty;    // Helper for binding
 
+        public BitmapImage? Thumbnail
+        {
+            get
+            {
+                if (_thumbnailRef == null) return null;
+                return _thumbnailRef.TryGetTarget(out BitmapImage image) ? image : null;
+            }
+            set
+            {
+                if (_thumbnailRef == null && value == null) return;
+                if ((_thumbnailRef?.TryGetTarget(out BitmapImage image) ?? false) && image == value) return;
+                SetProperty(ref _thumbnailRef, value == null ? null : new WeakReference<BitmapImage>(value));
+            }
+        }
+
         private readonly LibVlcService _libVlcService;
         private readonly List<string> _options;
 
         [ObservableProperty] private string _name;
         [ObservableProperty] private bool _isMediaActive;
-        [ObservableProperty] private BitmapImage? _thumbnail;
         [ObservableProperty] private AlbumViewModel? _album;
         [ObservableProperty] private string? _caption;  // For list item subtitle
         [ObservableProperty] private string? _altCaption;   // For player page subtitle
@@ -75,11 +89,13 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty]
         private bool? _isPlaying;
 
+        private WeakReference<BitmapImage>? _thumbnailRef;
+
         public MediaViewModel(MediaViewModel source)
         {
             _libVlcService = source._libVlcService;
             _name = source._name;
-            _thumbnail = source._thumbnail;
+            _thumbnailRef = source._thumbnailRef;
             _mediaInfo = source._mediaInfo;
             _artists = source._artists;
             _album = source._album;

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -328,16 +328,17 @@ namespace Screenbox.Core.ViewModels
                 : GetThumbnailSourceAsync(file);
         }
 
-        private async Task<IRandomAccessStream?> GetThumbnailSourceAsync(StorageFile file)
+        private static async Task<IRandomAccessStream?> GetThumbnailSourceAsync(StorageFile file)
         {
-            return await GetCoverFromTagAsync(file) ?? await GetThumbnailAsync(file);
+            return await GetCoverFromTagAsync(file) ?? await GetStorageFileThumbnailAsync(file);
         }
 
         private static async Task<IRandomAccessStream?> GetCoverFromTagAsync(StorageFile file)
         {
             if (!file.IsAvailable) return null;
             using var stream = await file.OpenStreamForReadAsync();
-            var fileAbstract = new StreamAbstraction(file.Path, stream);
+            var name = string.IsNullOrEmpty(file.Path) ? file.Name : file.Path;
+            var fileAbstract = new StreamAbstraction(name, stream);
             try
             {
                 using var tagFile = TagLib.File.Create(fileAbstract, ReadStyle.PictureLazy);
@@ -368,7 +369,7 @@ namespace Screenbox.Core.ViewModels
             return null;
         }
 
-        private static async Task<IRandomAccessStream?> GetThumbnailAsync(StorageFile file)
+        private static async Task<IRandomAccessStream?> GetStorageFileThumbnailAsync(StorageFile file)
         {
             if (!file.IsAvailable) return null;
             try

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -283,7 +283,7 @@ namespace Screenbox.Core.ViewModels
 
             if (Source is StorageFile file)
             {
-                var source = await GetThumbnailFromTag(file) ?? await GetThumbnailAsync(file);
+                var source = await GetCoverFromTagAsync(file) ?? await GetThumbnailAsync(file);
                 if (source == null) return;
                 ThumbnailSource = source;
                 BitmapImage image = new();
@@ -308,7 +308,7 @@ namespace Screenbox.Core.ViewModels
             }
         }
 
-        private static async Task<IRandomAccessStream?> GetThumbnailFromTag(StorageFile file)
+        private static async Task<IRandomAccessStream?> GetCoverFromTagAsync(StorageFile file)
         {
             if (!file.IsAvailable) return null;
             using var stream = await file.OpenStreamForReadAsync();

--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -342,9 +342,10 @@ namespace Screenbox.Core.ViewModels
             try
             {
                 using var tagFile = TagLib.File.Create(fileAbstract, ReadStyle.PictureLazy);
+                if (tagFile.Tag.Pictures.Length == 0) return null;
                 var cover =
                     tagFile.Tag.Pictures.FirstOrDefault(p => p.Type is PictureType.FrontCover or PictureType.Media) ??
-                    tagFile.Tag.Pictures.FirstOrDefault();
+                    tagFile.Tag.Pictures.FirstOrDefault(p => p.Type != PictureType.NotAPicture);
                 if (cover == null) return null;
                 if (cover.Data.IsEmpty)
                 {

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -592,7 +592,7 @@ namespace Screenbox.Core.ViewModels
             if (current != null)
             {
                 await current.LoadDetailsAsync(_filesService);
-                await current.LoadThumbnailAsync(_filesService);
+                await current.LoadThumbnailAsync();
                 AudioOnly = current.MediaType == MediaPlaybackType.Music;
                 ShowVisualizer = AudioOnly && !string.IsNullOrEmpty(_settingsService.LivelyActivePath);
                 bool shouldBeVisible = _settingsService.PlayerAutoResize == PlayerAutoResizeOption.Always && !AudioOnly;

--- a/Screenbox.Core/packages.lock.json
+++ b/Screenbox.Core/packages.lock.json
@@ -113,6 +113,12 @@
           "System.Text.Json": "6.0.8"
         }
       },
+      "TagLibSharp": {
+        "type": "Direct",
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "Qo4z6ZjnIfbR3Us1Za5M2vQ97OWZPmODvVmepxZ8XW0UIVLGdO2T63/N3b23kCcyiwuIe0TQvMEQG8wUCCD1mA=="
+      },
       "CommunityToolkit.Common": {
         "type": "Transitive",
         "resolved": "8.2.1",

--- a/Screenbox/Controls/Interactions/ThumbnailGridViewBehavior.cs
+++ b/Screenbox/Controls/Interactions/ThumbnailGridViewBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xaml.Interactivity;
-using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
 using Windows.UI.Xaml.Controls;
 
@@ -7,9 +6,6 @@ namespace Screenbox.Controls.Interactions
 {
     internal class ThumbnailGridViewBehavior : Behavior<GridView>
     {
-        private readonly IFilesService _filesService =
-            CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default.GetRequiredService<IFilesService>();
-
         protected override void OnAttached()
         {
             base.OnAttached();
@@ -28,16 +24,16 @@ namespace Screenbox.Controls.Interactions
             switch (args.Item)
             {
                 case AlbumViewModel album:
-                    await album.LoadAlbumArtAsync(_filesService);
+                    await album.LoadAlbumArtAsync();
                     break;
                 case MediaViewModel media:
-                    await media.LoadThumbnailAsync(_filesService);
+                    await media.LoadThumbnailAsync();
                     break;
                 case StorageItemViewModel storageItem:
                     await storageItem.UpdateCaptionAsync();
                     if (storageItem.Media != null)
                     {
-                        await storageItem.Media.LoadThumbnailAsync(_filesService);
+                        await storageItem.Media.LoadThumbnailAsync();
                     }
                     break;
             }

--- a/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
+++ b/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
@@ -14,8 +14,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using Windows.Security.Cryptography;
 using Windows.Storage;
-using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -312,15 +312,15 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         await _webView.ExecuteScriptFunctionAsync("livelyWallpaperPlaybackChanged", obj);
     }
 
-    private static async Task<string> StorageItemToBase64(StorageItemThumbnail? item)
+    private static async Task<string> StorageItemToBase64(IRandomAccessStream? item)
     {
         if (item == null)
             return string.Empty;
 
         using var stream = item.CloneStream();
 
-        var buffer = new byte[stream.Size];
-        await stream.ReadAsync(buffer.AsBuffer(), (uint)stream.Size, InputStreamOptions.None);
-        return Convert.ToBase64String(buffer);
+        var buffer = WindowsRuntimeBuffer.Create((int)stream.Size);
+        await stream.ReadAsync(buffer, (uint)stream.Size, InputStreamOptions.None);
+        return CryptographicBuffer.EncodeToBase64String(buffer);
     }
 }

--- a/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
+++ b/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
@@ -269,9 +269,10 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
             return;
 
         LivelyMusicModel? model = null;
-        if (Media != null)
+        if (Media?.Thumbnail != null)
         {
-            var base64 = Media.ThumbnailSource != null ? await ReadToBase64Async(Media.ThumbnailSource) : string.Empty;
+            using var thumbnailSource = await Media.GetThumbnailSourceAsync();
+            var base64 = thumbnailSource != null ? await ReadToBase64Async(thumbnailSource) : string.Empty;
             model = new LivelyMusicModel
             {
                 Title = Media.Name,

--- a/Screenbox/Pages/AlbumDetailsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Screenbox.Pages
             ViewModel.OnNavigatedTo(e.Parameter);
         }
 
-        private void AlbumDetailsPage_OnLoaded(object sender, RoutedEventArgs e)
+        private async void AlbumDetailsPage_OnLoaded(object sender, RoutedEventArgs e)
         {
             // Retrieve the ScrollViewer that the GridView is using internally
             ScrollViewer scrollViewer = _scrollViewer = ItemList.FindDescendant<ScrollViewer>() ??
@@ -80,9 +80,11 @@ namespace Screenbox.Pages
 
             if (ViewModel.Source.RelatedSongs.Count == 0) return;
             MediaViewModel firstSong = ViewModel.Source.RelatedSongs[0];
-            if (firstSong.ThumbnailSource != null)
+            if (firstSong.Thumbnail != null)
             {
-                CreateImageBackgroundGradientVisual(scrollingProperties.Translation.Y, firstSong.ThumbnailSource);
+                var thumbnailSource = await firstSong.GetThumbnailSourceAsync();
+                if (thumbnailSource == null) return;
+                CreateImageBackgroundGradientVisual(scrollingProperties.Translation.Y, thumbnailSource);
             }
             else
             {
@@ -90,15 +92,17 @@ namespace Screenbox.Pages
             }
         }
 
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private async void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (_scrollerPropertySet == null) return;
             MediaViewModel media = (MediaViewModel)sender;
-            if (e.PropertyName == nameof(MediaViewModel.Thumbnail) && media.ThumbnailSource != null)
+            if (e.PropertyName == nameof(MediaViewModel.Thumbnail) && media.Thumbnail != null)
             {
                 media.PropertyChanged -= OnPropertyChanged;
+                var thumbnailSource = await media.GetThumbnailSourceAsync();
+                if (thumbnailSource == null) return;
                 ManipulationPropertySetReferenceNode scrollingProperties = _scrollerPropertySet.GetSpecializedReference<ManipulationPropertySetReferenceNode>();
-                CreateImageBackgroundGradientVisual(scrollingProperties.Translation.Y, media.ThumbnailSource);
+                CreateImageBackgroundGradientVisual(scrollingProperties.Translation.Y, thumbnailSource);
             }
         }
 

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -515,6 +515,11 @@
         "resolved": "4.5.0",
         "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
       },
+      "TagLibSharp": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "Qo4z6ZjnIfbR3Us1Za5M2vQ97OWZPmODvVmepxZ8XW0UIVLGdO2T63/N3b23kCcyiwuIe0TQvMEQG8wUCCD1mA=="
+      },
       "screenbox.core": {
         "type": "Project",
         "dependencies": {
@@ -528,6 +533,7 @@
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.14, )",
           "Microsoft.UI.Xaml": "[2.8.6, )",
           "Sentry": "[4.10.2, )",
+          "TagLibSharp": "[2.3.0, )",
           "protobuf-net": "[3.2.30, )"
         }
       }


### PR DESCRIPTION
Use TaglibSharp to extract high-quality thumbnails from (mostly) audio files. There will be more use for TablibSharp down the line.