### PR TITLE
fix(l10n): UI issues when displaying right-to-left layout 

### DIFF
--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -87,6 +87,11 @@ namespace Screenbox
             CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default.ConfigureServices(services);
         }
 
+        public static FlowDirection GetFlowDirection()
+        {
+            return IsRightToLeftLanguage ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+        }
+
         [SecurityCritical]
         [HandleProcessCorruptedStateExceptions]
         private static void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/Screenbox/Controls/OpenUrlDialog.xaml.cs
+++ b/Screenbox/Controls/OpenUrlDialog.xaml.cs
@@ -14,6 +14,7 @@ namespace Screenbox.Controls
         {
             this.DefaultStyleKey = typeof(ContentDialog);
             this.InitializeComponent();
+            FlowDirection = App.GetFlowDirection();
         }
 
         public static async Task<Uri?> GetUrlAsync()

--- a/Screenbox/Controls/PropertiesDialog.xaml.cs
+++ b/Screenbox/Controls/PropertiesDialog.xaml.cs
@@ -1,10 +1,9 @@
 ﻿#nullable enable
 
-
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Screenbox.Core.Common;
 using Screenbox.Core.ViewModels;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -15,7 +14,7 @@ namespace Screenbox.Controls
         public static readonly DependencyProperty MediaProperty = DependencyProperty.Register(
             nameof(Media),
             typeof(MediaViewModel),
-            typeof(PropertiesView),
+            typeof(PropertiesDialog),
             new PropertyMetadata(null));
 
         public MediaViewModel? Media
@@ -27,6 +26,7 @@ namespace Screenbox.Controls
         public PropertiesDialog()
         {
             this.InitializeComponent();
+            FlowDirection = App.GetFlowDirection();
         }
     }
 }

--- a/Screenbox/Controls/SetOptionsDialog.xaml.cs
+++ b/Screenbox/Controls/SetOptionsDialog.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class SetOptionsDialog : ContentDialog
     public SetOptionsDialog(string existingOptions, bool global = false)
     {
         this.InitializeComponent();
+        FlowDirection = App.GetFlowDirection();
         OptionTextBoxPlaceholder = global ? "--option=value" : ":option=value";
         Options = existingOptions;
         OptionsTextBox.Text = Options;

--- a/Screenbox/Controls/VLCLoginDialog.xaml.cs
+++ b/Screenbox/Controls/VLCLoginDialog.xaml.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 
+using Screenbox.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Screenbox.Core;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -43,6 +43,7 @@ namespace Screenbox.Controls
         public VLCLoginDialog()
         {
             this.InitializeComponent();
+            FlowDirection = App.GetFlowDirection();
         }
     }
 }

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -74,8 +74,11 @@ namespace Screenbox.Pages
         private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
         {
             // Get the size of the caption controls and set padding.
-            LeftPaddingColumn.Width = new GridLength(sender.SystemOverlayLeftInset);
-            RightPaddingColumn.Width = new GridLength(sender.SystemOverlayRightInset);
+            // In RTL languages, Grid is flipped automatically.
+            // Left is always the side without the system controls.
+            // Left padding should only be set if we pin flow direction on the title bar.
+            // LeftPaddingColumn.Width = new GridLength(sender.SystemOverlayLeftInset);
+            RightPaddingColumn.Width = new GridLength(Math.Max(sender.SystemOverlayLeftInset, sender.SystemOverlayRightInset));
         }
 
         // Update the TitleBar based on the inactive/active state of the app

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -166,8 +166,11 @@ namespace Screenbox.Pages
         private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
         {
             // Get the size of the caption controls and set padding.
-            LeftPaddingColumn.Width = new GridLength(sender.SystemOverlayLeftInset);
-            RightPaddingColumn.Width = new GridLength(sender.SystemOverlayRightInset);
+            // In RTL languages, Grid is flipped automatically.
+            // Left is always the side without the system controls.
+            // Left padding should only be set if we pin flow direction on the title bar.
+            // LeftPaddingColumn.Width = new GridLength(sender.SystemOverlayLeftInset);
+            RightPaddingColumn.Width = new GridLength(Math.Max(sender.SystemOverlayLeftInset, sender.SystemOverlayRightInset));
         }
 
         private void BackgroundElementOnSizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
Fix issues reported in https://github.com/huynhsontung/Screenbox/issues/429#issuecomment-2314811010 and https://github.com/huynhsontung/Screenbox/issues/429#issuecomment-2375005607

Before

![image](https://github.com/user-attachments/assets/21604085-6583-47a2-9135-eb14870a21f4)
![image](https://github.com/user-attachments/assets/15e03ed8-63f3-4e9f-8e76-f97d11a0fa15)
![image](https://github.com/user-attachments/assets/b6473bb9-4ed4-47db-8213-90acce83fd43)

After

![ApplicationFrameHost_mJQIUd31Fv](https://github.com/user-attachments/assets/6e1a1896-7511-4e75-8c68-8b170b077b58)
![ApplicationFrameHost_DVT6pU2Jqb](https://github.com/user-attachments/assets/fe02aa30-703e-4d8b-814d-66fd3992a30e)
