### PR TITLE
l10n: create dedicated strings for music and video libraries

### DIFF
--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -147,14 +147,14 @@
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8B2;" />
                     </muxc:NavigationViewItem.Icon>
-                    <TextBlock x:Name="VideosNavItemText" Text="{strings:Resources Key=Videos}" />
+                    <TextBlock x:Name="VideosNavItemText" Text="{strings:Resources Key=VideoLibrary}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     AccessKey="{strings:KeyboardResources Key=NavigationItemMusicKey}"
                     Icon="Audio"
                     KeyTipPlacementMode="Right"
                     Tag="music">
-                    <TextBlock x:Name="MusicNavItemText" Text="{strings:Resources Key=Music}" />
+                    <TextBlock x:Name="MusicNavItemText" Text="{strings:Resources Key=MusicLibrary}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     AccessKey="{strings:KeyboardResources Key=NavigationItemNetworkKey}"

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -116,7 +116,7 @@
                     x:Name="HeaderNavView"
                     Margin="56,0,16,0"
                     Style="{StaticResource PageHeaderTextBlockStyle}"
-                    Text="{strings:Resources Key=Music}" />
+                    Text="{strings:Resources Key=MusicLibrary}" />
             </muxc:NavigationView.PaneHeader>
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -32,7 +32,7 @@
             Margin="{StaticResource BottomMediumMargin}"
             Padding="{StaticResource ContentPagePadding}"
             Visibility="Collapsed">
-            <TextBlock Style="{StaticResource PageHeaderTextBlockStyle}" Text="{strings:Resources Key=Music}" />
+            <TextBlock Style="{StaticResource PageHeaderTextBlockStyle}" Text="{strings:Resources Key=MusicLibrary}" />
         </Grid>
 
         <Grid

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -123,7 +123,7 @@
                     x:Name="HeaderNavView"
                     Margin="56,0,16,0"
                     Style="{StaticResource PageHeaderTextBlockStyle}"
-                    Text="{strings:Resources Key=Videos}" />
+                    Text="{strings:Resources Key=VideoLibrary}" />
             </muxc:NavigationView.PaneHeader>
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -40,7 +40,7 @@
             Margin="{StaticResource BottomMediumMargin}"
             Padding="{StaticResource ContentPagePadding}"
             Visibility="Collapsed">
-            <TextBlock Style="{StaticResource PageHeaderTextBlockStyle}" Text="{strings:Resources Key=Videos}" />
+            <TextBlock Style="{StaticResource PageHeaderTextBlockStyle}" Text="{strings:Resources Key=VideoLibrary}" />
         </Grid>
 
         <Grid

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2832,6 +2832,32 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region MusicLibrary
+        /// <summary>
+        ///   Looks up a localized string similar to: Music
+        /// </summary>
+        public static string MusicLibrary
+        {
+            get
+            {
+                return _resourceLoader.GetString("MusicLibrary");
+            }
+        }
+        #endregion
+
+        #region VideoLibrary
+        /// <summary>
+        ///   Looks up a localized string similar to: Videos
+        /// </summary>
+        public static string VideoLibrary
+        {
+            get
+            {
+                return _resourceLoader.GetString("VideoLibrary");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -3059,6 +3085,8 @@ namespace Screenbox.Strings{
             Media,
             Video,
             File,
+            MusicLibrary,
+            VideoLibrary,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -833,4 +833,10 @@
   <data name="File" xml:space="preserve">
     <value>File</value>
   </data>
+  <data name="MusicLibrary" xml:space="preserve">
+    <value>Music</value>
+  </data>
+  <data name="VideoLibrary" xml:space="preserve">
+    <value>Videos</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #457 

The translation of "Music" in some languages doesn't convey the music library in context. Create a dedicated string to accommodate for these differences