### PR TITLE
style: adjust icon vertical alignment in buttons

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -66,7 +66,7 @@
                     <x:Double x:Key="TopNavigationViewItemFontSize">18</x:Double>
                     <x:Double x:Key="TitleMediumTextBlockFontSize">32</x:Double>
                     <!--  Icon font sizes  -->
-                    <x:Double x:Key="DefaultIconFontSize">16</x:Double>
+                    <x:Double x:Key="StandardIconFontSize">16</x:Double>
                     <x:Double x:Key="GridItemPlaceholderIconFontSize">56</x:Double>
                     <x:Double x:Key="WideGridItemPlaceholderIconFontSize">44</x:Double>
                     <x:Double x:Key="NoContentPanelIconFontSize">128</x:Double>
@@ -97,11 +97,11 @@
 
                     <CornerRadius x:Key="CircularCornerRadius">99</CornerRadius>
 
+                    <!--  Styles  -->
                     <Style TargetType="FontIcon">
-                        <Setter Property="FontSize" Value="{StaticResource DefaultIconFontSize}" />
+                        <Setter Property="FontSize" Value="{StaticResource StandardIconFontSize}" />
                     </Style>
 
-                    <!--  Header style  -->
                     <Style
                         x:Key="TitleMediumTextBlockStyle"
                         BasedOn="{StaticResource BaseTextBlockStyle}"

--- a/Screenbox/Controls/CommonGridViewItem.xaml
+++ b/Screenbox/Controls/CommonGridViewItem.xaml
@@ -52,7 +52,7 @@
                 Fill="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
                 Stroke="{ThemeResource ControlElevationBorderBrush}"
                 StrokeThickness="0.8" />
-            <FontIcon FontSize="{StaticResource DefaultIconFontSize}" Glyph="&#xE769;" />
+            <FontIcon FontSize="{StaticResource StandardIconFontSize}" Glyph="&#xE769;" />
         </Grid>
         <Button
             x:Name="PlayButton"
@@ -69,7 +69,7 @@
             Opacity="0"
             Style="{StaticResource AccentButtonStyle}"
             Visibility="{x:Bind CanPlay, Mode=OneWay}">
-            <FontIcon FontSize="{StaticResource DefaultIconFontSize}" Glyph="{x:Bind IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}, Mode=OneWay}" />
+            <FontIcon FontSize="{StaticResource StandardIconFontSize}" Glyph="{x:Bind IsPlaying, Converter={StaticResource PlayPauseGlyphConverter}, Mode=OneWay}" />
         </Button>
 
         <!--

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -94,7 +94,7 @@
                 Command="{x:Bind ViewModel.AddFilesCommand}"
                 Visibility="Collapsed">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon Glyph="&#xE838;" />
+                    <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE838;" />
                     <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFiles}" />
                 </StackPanel>
             </Button>
@@ -108,7 +108,7 @@
                 IsEnabled="{x:Bind ViewModel.HasItems, Mode=OneWay}"
                 KeyTipPlacementMode="Bottom">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon Glyph="&#xE74D;" />
+                    <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE74D;" />
                     <TextBlock
                         x:Name="ClearButtonLabel"
                         Margin="8,0,0,0"
@@ -125,7 +125,7 @@
                 KeyTipPlacementMode="Bottom"
                 XYFocusLeft="{x:Bind ClearButton}">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon Glyph="&#xE762;" />
+                    <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE762;" />
                     <TextBlock
                         x:Name="MultiSelectToggleLabel"
                         Margin="8,0,0,0"
@@ -373,10 +373,8 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="AddFilesButton.Visibility" Value="Visible" />
-                        <Setter Target="ClearButton.Padding" Value="10.5,6.5,11,7" />
                         <Setter Target="ClearButton.(ToolTipService.ToolTip)" Value="{x:Bind ClearButtonLabel.Text}" />
                         <Setter Target="ClearButtonLabel.Visibility" Value="Collapsed" />
-                        <Setter Target="MultiSelectToggle.Padding" Value="10.5,6.5,11,7" />
                         <Setter Target="MultiSelectToggle.(ToolTipService.ToolTip)" Value="{x:Bind MultiSelectToggleLabel.Text}" />
                         <Setter Target="MultiSelectToggleLabel.Visibility" Value="Collapsed" />
                         <Setter Target="PlayNextButton.LabelPosition" Value="Collapsed" />

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -138,12 +138,12 @@
                                 <StaticResource x:Key="CommandBarBorderBrushOpen" ResourceKey="ControlFillColorTransparentBrush" />
                                 <StaticResource x:Key="CommandBarHighContrastBorder" ResourceKey="ControlFillColorTransparentBrush" />
 
-                                <!--  Try to match the dimensions to those of the default button  -->
+                                <!--  Values modified to align with the dimensions and layout of the default button  -->
                                 <x:Double x:Key="AppBarThemeCompactHeight">44</x:Double>
-                                <Thickness x:Key="AppBarButtonContentViewboxMargin">15,12,0,13</Thickness>
+                                <Thickness x:Key="AppBarButtonContentViewboxMargin">16,14,0,14</Thickness>
                                 <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,14,0,2</Thickness>
                                 <!--<Thickness x:Key="AppBarButtonTextLabelMargin">6,0,6,8</Thickness>-->
-                                <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,12,15,13</Thickness>
+                                <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,12,16,13</Thickness>
                                 <Thickness x:Key="AppBarButtonInnerBorderMargin">4,6,4,6</Thickness>
                                 <!--<Thickness x:Key="AppBarButtonInnerBorderCompactMargin">4,6,4,26</Thickness>-->
                                 <!--<StaticResource x:Key="AppBarButtonDefaultWidth" ResourceKey="AppBarButtonCompactWidth" />-->

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -64,7 +64,7 @@
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
-                <FontIcon Glyph="&#xE8B1;" />
+                <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8B1;" />
                 <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
             </StackPanel>
         </Button>

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -220,12 +220,12 @@
                                 <StaticResource x:Key="CommandBarBorderBrushOpen" ResourceKey="ControlFillColorTransparentBrush" />
                                 <StaticResource x:Key="CommandBarHighContrastBorder" ResourceKey="ControlFillColorTransparentBrush" />
 
-                                <!--  Try to match the dimensions to those of the default button  -->
+                                <!--  Values modified to align with the dimensions and layout of the default button  -->
                                 <x:Double x:Key="AppBarThemeCompactHeight">44</x:Double>
-                                <Thickness x:Key="AppBarButtonContentViewboxMargin">15,12,0,13</Thickness>
+                                <Thickness x:Key="AppBarButtonContentViewboxMargin">16,14,0,14</Thickness>
                                 <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,14,0,2</Thickness>
                                 <!--<Thickness x:Key="AppBarButtonTextLabelMargin">6,0,6,8</Thickness>-->
-                                <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,12,15,13</Thickness>
+                                <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,12,16,13</Thickness>
                                 <Thickness x:Key="AppBarButtonInnerBorderMargin">4,6,4,6</Thickness>
                                 <!--<Thickness x:Key="AppBarButtonInnerBorderCompactMargin">4,6,4,26</Thickness>-->
                                 <!--<StaticResource x:Key="AppBarButtonDefaultWidth" ResourceKey="AppBarButtonCompactWidth" />-->

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -62,7 +62,7 @@
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
-                <FontIcon Glyph="&#xE8B1;" />
+                <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8B1;" />
                 <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
             </StackPanel>
         </Button>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -121,7 +121,7 @@
                 Command="{x:Bind Common.OpenFilesCommand}"
                 Flyout="{StaticResource OpenFlyout}">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon Glyph="&#xE838;" />
+                    <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE838;" />
                     <TextBlock
                         x:Name="HeaderOpenButtonText"
                         Margin="8,0,0,0"
@@ -188,7 +188,7 @@
                     Command="{x:Bind Common.OpenFilesCommand}"
                     Flyout="{StaticResource OpenFlyout}">
                     <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xE838;" />
+                        <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE838;" />
                         <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=OpenFiles}" />
                     </StackPanel>
                     <interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -50,7 +50,7 @@
 
             <DataTemplate x:Key="SearchAutoSuggestBoxItemTemplate">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon FontSize="{StaticResource DefaultIconFontSize}" Glyph="{Binding Converter={StaticResource SearchItemGlyphConverter}}" />
+                    <FontIcon FontSize="{StaticResource StandardIconFontSize}" Glyph="{Binding Converter={StaticResource SearchItemGlyphConverter}}" />
                     <TextBlock Margin="8,0,0,0" Text="{Binding Name}" />
                 </StackPanel>
             </DataTemplate>

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -85,7 +85,7 @@
                     ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}"
                     Visibility="{x:Bind helpers:SystemInformation.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xE8F4;" />
+                        <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                         <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
                     </StackPanel>
                 </Button>
@@ -149,7 +149,7 @@
                     ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}"
                     Visibility="{x:Bind helpers:SystemInformation.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xE8F4;" />
+                        <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                         <TextBlock
                             x:Name="HeaderAddFolderButtonText"
                             Margin="8,0,0,0"

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -72,7 +72,7 @@
                 Command="{x:Bind PlaylistView.ViewModel.AddFilesCommand}"
                 Flyout="{StaticResource AddToPlayQueueFlyout}">
                 <StackPanel Orientation="Horizontal">
-                    <FontIcon Glyph="&#xE838;" />
+                    <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE838;" />
                     <TextBlock
                         x:Name="HeaderAddButtonText"
                         Margin="8,0,0,0"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -181,7 +181,7 @@
                         Command="{x:Bind ViewModel.AddMusicFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}">
                         <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xE8F4;" />
+                            <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
                         </StackPanel>
                     </Button>
@@ -205,7 +205,7 @@
                         Command="{x:Bind ViewModel.AddVideosFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}">
                         <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xE8F4;" />
+                            <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                             <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
                         </StackPanel>
                     </Button>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -83,7 +83,7 @@
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
-                <FontIcon Glyph="&#xE8B1;" />
+                <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8B1;" />
                 <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
             </StackPanel>
         </Button>

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -93,7 +93,7 @@
                     ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}"
                     Visibility="{x:Bind helpers:SystemInformation.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xE8F4;" />
+                        <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                         <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
                     </StackPanel>
                 </Button>
@@ -152,7 +152,7 @@
                     ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}"
                     Visibility="{x:Bind helpers:SystemInformation.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
-                        <FontIcon Glyph="&#xE8F4;" />
+                        <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE8F4;" />
                         <TextBlock
                             x:Name="HeaderAddFolderButtonText"
                             Margin="8,0,0,0"

--- a/Screenbox/Styles/Button.xaml
+++ b/Screenbox/Styles/Button.xaml
@@ -55,6 +55,9 @@
     <!--  Uniform padding to ensure the text baseline aligns with TextBlocks (Caption) that have centered vertical alignment  -->
     <Thickness x:Key="HyperlinkButtonUniformPadding">11,6.75,11,6.75</Thickness>
 
+    <!--  Margin to vertically center an icon within a button with default padding, ensures the height remains consistent even when it contains only an icon  -->
+    <Thickness x:Key="IconButtonStandardIconMargin">0,1.95,0,0.9</Thickness>
+
     <Thickness x:Key="SplitButtonPadding">12,6,12,7.05</Thickness>
 
     <!--  Subtle Button according to the Windows UI 3 design guidelines  -->


### PR DESCRIPTION
Based on the design pattern outlined in the Figma WinUI document, the icon should be vertically centered within buttons.

![Button with text and icon](https://github.com/user-attachments/assets/03df0800-95e1-4c53-b393-b793b4da64f2)

The margin also makes sure that buttons maintain a consistent height in the icon only layout, especially important for those that hide the text content in the minimal visual state.