### PR TITLE
style: simplify PlaylistView UI logic

### DIFF
--- a/Screenbox.Core/ViewModels/PlaylistViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlaylistViewModel.cs
@@ -76,6 +76,8 @@ namespace Screenbox.Core.ViewModels
 
         private static bool HasSelection(IList<object>? selectedItems) => selectedItems?.Count > 0;
 
+        private static bool HasSingleSelection(IList<object>? selectedItems) => selectedItems?.Count == 1;
+
         private bool IsItemNotFirst(MediaViewModel item) => Playlist.Items.Count > 0 && Playlist.Items[0] != item;
 
         private bool IsItemNotLast(MediaViewModel item) => Playlist.Items.Count > 0 && Playlist.Items[Playlist.Items.Count - 1] != item;
@@ -134,10 +136,10 @@ namespace Screenbox.Core.ViewModels
             Playlist.Items.Insert(Playlist.CurrentIndex + 1, new MediaViewModel(item));
         }
 
-        [RelayCommand(CanExecute = nameof(HasSelection))]
+        [RelayCommand(CanExecute = nameof(HasSingleSelection))]
         private void MoveSelectedItemUp(IList<object>? selectedItems)
         {
-            if (selectedItems == null || selectedItems.Count != 1) return;
+            if (selectedItems is not { Count: 1 }) return;
             MediaViewModel item = (MediaViewModel)selectedItems[0];
             MoveItemUp(item);
 
@@ -156,10 +158,10 @@ namespace Screenbox.Core.ViewModels
             Playlist.Items.Insert(index - 1, item);
         }
 
-        [RelayCommand(CanExecute = nameof(HasSelection))]
+        [RelayCommand(CanExecute = nameof(HasSingleSelection))]
         private void MoveSelectedItemDown(IList<object>? selectedItems)
         {
-            if (selectedItems == null || selectedItems.Count != 1) return;
+            if (selectedItems is not { Count: 1 }) return;
             MediaViewModel item = (MediaViewModel)selectedItems[0];
             MoveItemDown(item);
 

--- a/Screenbox.Core/ViewModels/PlaylistViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlaylistViewModel.cs
@@ -76,7 +76,11 @@ namespace Screenbox.Core.ViewModels
 
         private static bool HasSelection(IList<object>? selectedItems) => selectedItems?.Count > 0;
 
-        private static bool HasSingleSelection(IList<object>? selectedItems) => selectedItems?.Count == 1;
+        private bool IsSelectedItemNotFirst(IList<object>? selectedItems) =>
+            selectedItems?.Count == 1 && Playlist.Items.Count > 0 && Playlist.Items[0] != selectedItems[0];
+
+        private bool IsSelectedItemNotLast(IList<object>? selectedItems) =>
+            selectedItems?.Count == 1 && Playlist.Items[Playlist.Items.Count - 1] != selectedItems[0];
 
         private bool IsItemNotFirst(MediaViewModel item) => Playlist.Items.Count > 0 && Playlist.Items[0] != item;
 
@@ -136,7 +140,7 @@ namespace Screenbox.Core.ViewModels
             Playlist.Items.Insert(Playlist.CurrentIndex + 1, new MediaViewModel(item));
         }
 
-        [RelayCommand(CanExecute = nameof(HasSingleSelection))]
+        [RelayCommand(CanExecute = nameof(IsSelectedItemNotFirst))]
         private void MoveSelectedItemUp(IList<object>? selectedItems)
         {
             if (selectedItems is not { Count: 1 }) return;
@@ -158,7 +162,7 @@ namespace Screenbox.Core.ViewModels
             Playlist.Items.Insert(index - 1, item);
         }
 
-        [RelayCommand(CanExecute = nameof(HasSingleSelection))]
+        [RelayCommand(CanExecute = nameof(IsSelectedItemNotLast))]
         private void MoveSelectedItemDown(IList<object>? selectedItems)
         {
             if (selectedItems is not { Count: 1 }) return;

--- a/Screenbox.Core/ViewModels/PlaylistViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlaylistViewModel.cs
@@ -77,10 +77,12 @@ namespace Screenbox.Core.ViewModels
         private static bool HasSelection(IList<object>? selectedItems) => selectedItems?.Count > 0;
 
         private bool IsSelectedItemNotFirst(IList<object>? selectedItems) =>
-            selectedItems?.Count == 1 && Playlist.Items.Count > 0 && Playlist.Items[0] != selectedItems[0];
+            selectedItems?.Count == 1 &&
+            Playlist.Items.Count > 0 && Playlist.Items[0] != selectedItems[0];
 
         private bool IsSelectedItemNotLast(IList<object>? selectedItems) =>
-            selectedItems?.Count == 1 && Playlist.Items[Playlist.Items.Count - 1] != selectedItems[0];
+            selectedItems?.Count == 1 &&
+            Playlist.Items.Count > 0 && Playlist.Items[Playlist.Items.Count - 1] != selectedItems[0];
 
         private bool IsItemNotFirst(MediaViewModel item) => Playlist.Items.Count > 0 && Playlist.Items[0] != item;
 

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -267,14 +267,12 @@
                     <VisualState.Setters>
                         <Setter Target="RootGridTranslateTransform.X" Value="0" />
                         <Setter Target="PlayingIndicator.Opacity" Value="1" />
-                        <Setter Target="ItemMediaTypeIcon.Opacity" Value="1" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="MultiSelectEnabled">
                     <VisualState.Setters>
                         <Setter Target="RootGridTranslateTransform.X" Value="-32" />
                         <Setter Target="PlayingIndicator.Opacity" Value="0" />
-                        <Setter Target="ItemMediaTypeIcon.Opacity" Value="0" />
                     </VisualState.Setters>
                 </VisualState>
 

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
-    xmlns:core="using:Microsoft.Xaml.Interactions.Core"
     xmlns:ctAnimations="using:CommunityToolkit.WinUI.Animations"
     xmlns:ctConverters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -206,23 +205,18 @@
                         <KeyboardAccelerator Key="Delete" />
                     </AppBarButton.KeyboardAccelerators>
                 </AppBarButton>
-
-                <CommandBar.SecondaryCommands>
-                    <AppBarButton
-                        x:Name="MoveUpButton"
-                        Command="{x:Bind ViewModel.MoveSelectedItemUpCommand}"
-                        CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
-                        Icon="{ui:FontIcon Glyph=&#xE74A;}"
-                        IsEnabled="False"
-                        Label="{strings:Resources Key=MoveUp}" />
-                    <AppBarButton
-                        x:Name="MoveDownButton"
-                        Command="{x:Bind ViewModel.MoveSelectedItemDownCommand}"
-                        CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
-                        Icon="{ui:FontIcon Glyph=&#xE74B;}"
-                        IsEnabled="False"
-                        Label="{strings:Resources Key=MoveDown}" />
-                </CommandBar.SecondaryCommands>
+                <AppBarButton
+                    x:Name="MoveUpButton"
+                    Command="{x:Bind ViewModel.MoveSelectedItemUpCommand}"
+                    CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
+                    Icon="{ui:FontIcon Glyph=&#xE74A;}"
+                    Label="{strings:Resources Key=MoveUp}" />
+                <AppBarButton
+                    x:Name="MoveDownButton"
+                    Command="{x:Bind ViewModel.MoveSelectedItemDownCommand}"
+                    CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
+                    Icon="{ui:FontIcon Glyph=&#xE74B;}"
+                    Label="{strings:Resources Key=MoveDown}" />
 
                 <CommandBar.Content>
                     <StackPanel Orientation="Horizontal">
@@ -349,16 +343,6 @@
                         <Setter Target="SelectionCommandRow.Visibility" Value="Visible" />
                         <Setter Target="ActionButtonRow.Visibility" Value="Collapsed" />
                         <Setter Target="PlaylistListView.SelectionMode" Value="Multiple" />
-                    </VisualState.Setters>
-                </VisualState>
-
-                <VisualState x:Name="MultipleSingleSelected">
-                    <VisualState.Setters>
-                        <Setter Target="SelectionCommandRow.Visibility" Value="Visible" />
-                        <Setter Target="ActionButtonRow.Visibility" Value="Collapsed" />
-                        <Setter Target="PlaylistListView.SelectionMode" Value="Multiple" />
-                        <Setter Target="MoveUpButton.IsEnabled" Value="True" />
-                        <Setter Target="MoveDownButton.IsEnabled" Value="True" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -64,8 +64,7 @@ namespace Screenbox.Controls
             SelectionCheckBox.IsChecked = PlaylistListView.SelectedItems.Count == ViewModel.Playlist.Items.Count;
             if (ViewModel.EnableMultiSelect)
             {
-                VisualStateManager.GoToState(this,
-                    PlaylistListView.SelectedItems.Count == 1 ? "MultipleSingleSelected" : "Multiple", true);
+                VisualStateManager.GoToState(this, "Multiple", true);
             }
 
             ViewModel.SelectionCount = PlaylistListView.SelectedItems.Count;


### PR DESCRIPTION
Remove the `MultipleSingleSelected` visual state. Promote "Move up" and "Move down" buttons to primary commands.