### PR TITLE
fix: correct ImageBrush orientation for RTL languages

### DIFF
--- a/Screenbox/Controls/CommonGridViewItem.xaml
+++ b/Screenbox/Controls/CommonGridViewItem.xaml
@@ -19,23 +19,24 @@
         <Grid
             Grid.Row="0"
             Height="{x:Bind ThumbnailHeight, Mode=OneWay}"
-            Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource ControlElevationBorderBrush}"
             BorderThickness="1"
-            CornerRadius="{x:Bind CornerRadius}">
-            <IconSourceElement
-                x:Name="PlaceholderIcon"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                IconSource="{x:Bind PlaceholderIconSource, Mode=OneWay}"
-                Visibility="{x:Bind ThumbnailSource, Converter={StaticResource InverseEmptyObjectToVisibilityConverter}, Mode=OneWay}" />
-            <Border CornerRadius="{x:Bind CornerRadius}">
-                <Image
+            CornerRadius="{x:Bind CornerRadius}"
+            FlowDirection="LeftToRight">
+            <Grid.Background>
+                <ImageBrush
                     x:Name="ThumbnailImage"
-                    HorizontalAlignment="Center"
-                    Source="{x:Bind ThumbnailSource, Mode=OneWay}"
+                    ImageSource="{x:Bind ThumbnailSource, Mode=OneWay}"
                     Stretch="UniformToFill" />
+            </Grid.Background>
+            <Border
+                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
+                CornerRadius="{x:Bind CornerRadius}"
+                Visibility="{x:Bind ThumbnailSource, Converter={StaticResource InverseEmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                <IconSourceElement
+                    x:Name="PlaceholderIcon"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    IconSource="{x:Bind PlaceholderIconSource, Mode=OneWay}" />
             </Border>
         </Grid>
 

--- a/Screenbox/Controls/LivelyWallpaperSelector.xaml
+++ b/Screenbox/Controls/LivelyWallpaperSelector.xaml
@@ -63,6 +63,7 @@
                         Width="112"
                         Height="96"
                         CornerRadius="{StaticResource GridViewItemCornerRadius}"
+                        FlowDirection="LeftToRight"
                         ToolTipService.ToolTip="{x:Bind Model.Title}">
                         <Grid.Background>
                             <ImageBrush ImageSource="{Binding PreviewPath}" Stretch="UniformToFill" />

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -69,6 +69,7 @@
                     BorderBrush="{ThemeResource ControlElevationBorderBrush}"
                     BorderThickness="1"
                     CornerRadius="{StaticResource OverlayCornerRadius}"
+                    FlowDirection="LeftToRight"
                     Shadow="{StaticResource SharedShadow}"
                     SizeChanged="AlbumArt_OnSizeChanged"
                     Translation="0,0,16">

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -34,7 +34,9 @@
 
         <Grid
             x:Name="BackgroundHost"
+            Grid.Row="0"
             Margin="0,-136,0,0"
+            FlowDirection="LeftToRight"
             SizeChanged="BackgroundHost_OnSizeChanged" />
 
         <Grid

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -43,6 +43,7 @@
                             BorderBrush="{ThemeResource ControlElevationBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="{StaticResource ControlCornerRadius}"
+                            FlowDirection="LeftToRight"
                             Shadow="{StaticResource SharedShadow}"
                             Translation="0,0,8">
                             <Grid.Background>

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -125,6 +125,7 @@
             Grid.Row="0"
             Grid.RowSpan="2"
             Margin="0,-136,0,0"
+            FlowDirection="LeftToRight"
             SizeChanged="BackgroundHost_OnSizeChanged" />-->
 
         <Grid

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -426,6 +426,7 @@
                 BorderBrush="{ThemeResource ControlElevationBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="{StaticResource OverlayCornerRadius}"
+                FlowDirection="LeftToRight"
                 Shadow="{StaticResource SharedShadow}"
                 Translation="0,0,32">
                 <Grid.Background>


### PR DESCRIPTION
Resolves #429 regression on some images. `ImageBrush`, unlike the [Image](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.image?view=winrt-26100#flowdirection-for-image) control, doesn't enforce a `LeftToRight` direction.