### PR TITLE
fix: various lively wallpaper issues

### DIFF
--- a/Screenbox.Core/Helpers/LivelyWallpaperUtil.cs
+++ b/Screenbox.Core/Helpers/LivelyWallpaperUtil.cs
@@ -1,10 +1,7 @@
-﻿using Newtonsoft.Json;
-using Screenbox.Core.Enums;
+﻿using Screenbox.Core.Enums;
 using Screenbox.Core.Models;
-using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
-using Windows.Storage;
 
 namespace Screenbox.Core.Helpers;
 
@@ -14,23 +11,11 @@ namespace Screenbox.Core.Helpers;
 // Source: https://github.com/rocksdanister/lively
 public static class LivelyWallpaperUtil
 {
-    public static async Task InstallWallpaper(StorageFile wallpaperFile, StorageFolder destinationFolder, bool verify = false)
-    {
-        if (verify && !await IsWallpaperFile(wallpaperFile))
-            return;
-
-        using var zipStream = await wallpaperFile.OpenStreamForReadAsync();
-        using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-        zipArchive.ExtractToDirectory(destinationFolder.Path);
-    }
-
-    public static async Task<bool> IsWallpaperFile(StorageFile wallpaperFile)
+    public static async Task<bool> IsWallpaperFile(ZipArchive wallpaperFile)
     {
         try
         {
-            using var zipStream = await wallpaperFile.OpenStreamForReadAsync();
-            using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-            var livelyInfoEntry = zipArchive.GetEntry("LivelyInfo.json");
+            var livelyInfoEntry = wallpaperFile.GetEntry("LivelyInfo.json");
             if (livelyInfoEntry != null)
                 return true;
         }

--- a/Screenbox.Core/Helpers/WebView2Util.cs
+++ b/Screenbox.Core/Helpers/WebView2Util.cs
@@ -34,7 +34,7 @@ public static class WebView2Util
 
         var fileName = Path.GetFileName(filePath);
         // Use unique hostname to avoid webview cache issues.
-        var hostName = new DirectoryInfo(filePath).Parent.Name;
+        var hostName = filePath.ToLower().GetHashCode().ToString("x8");
         var directoryPath = Path.GetDirectoryName(filePath);
         webView.CoreWebView2.SetVirtualHostNameToFolderMapping(
             hostName,

--- a/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
 using System;
@@ -30,6 +31,11 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
     public void Receive(PropertyChangedMessage<LivelyWallpaperModel?> message)
     {
         Source = message.NewValue;
+    }
+
+    public void SendError(string title, string message)
+    {
+        Messenger.Send(new ErrorMessage(title, message));
     }
 
     public async Task LoadAsync()

--- a/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -3,12 +3,21 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using Microsoft.UI.Xaml.Controls;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Streams;
 
 namespace Screenbox.Core.ViewModels;
 public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
@@ -48,5 +57,103 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
                 visualizer.Path.Equals(activeVisualizerPath, StringComparison.OrdinalIgnoreCase));
 
         Source = selectedVisualizer;
+    }
+
+    // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#controls
+    public async Task UpdateLivelyProperties(WebView2 webView)
+    {
+        if (Source is null)
+            return;
+
+        var functionName = "livelyPropertyListener";
+        var propertyPath = Path.Combine(Source.Path, "LivelyProperties.json");
+
+        string jsonString;
+        try
+        {
+            var file = await StorageFile.GetFileFromPathAsync(propertyPath);
+            jsonString = await FileIO.ReadTextAsync(file);
+        }
+        catch (Exception)
+        {
+            return;
+        }
+
+        var jsonObject = JObject.Parse(jsonString);
+        foreach (KeyValuePair<string, JToken?> item in jsonObject)
+        {
+            var typeToken = item.Value?["type"];
+            var valueToken = item.Value?["value"];
+            if (typeToken == null || valueToken == null) continue;
+            switch (typeToken.ToString())
+            {
+                case "slider":
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, (double)valueToken);
+                    break;
+                case "dropdown":
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, (int)valueToken);
+                    break;
+                case "checkbox":
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, (bool)valueToken);
+                    break;
+                case "color":
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, valueToken.ToString());
+                    break;
+                case "folderDropdown":
+                    var relativePath = Path.Combine(item.Value?["folder"]?.ToString() ?? string.Empty, valueToken.ToString());
+                    var filePath = Path.Combine(Source.Path, relativePath);
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, File.Exists(filePath) ? relativePath : null);
+                    break;
+                case "button":
+                case "label":
+                    // Ignore, user action only.
+                    break;
+            }
+        }
+    }
+
+    // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--pause-event
+    public async Task UpdatePauseState(WebView2 webView, bool isPaused)
+    {
+        if (Source is null || !Source.IsPauseNotify)
+            return;
+
+        var obj = new LivelyPlaybackStateModel()
+        {
+            IsPaused = isPaused
+        };
+        await webView.ExecuteScriptFunctionAsync("livelyWallpaperPlaybackChanged", obj);
+    }
+
+    // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--system-nowplaying
+    public async Task UpdateCurrentTrack(WebView2 webView, MediaViewModel media)
+    {
+        if (Source is null || webView.CoreWebView2.IsSuspended || !Source.IsMusic)
+            return;
+
+        LivelyMusicModel? model = null;
+        if (media.Thumbnail != null)
+        {
+            using var thumbnailSource = await media.GetThumbnailSourceAsync();
+            var base64 = thumbnailSource != null ? await ReadToBase64Async(thumbnailSource) : string.Empty;
+            model = new LivelyMusicModel
+            {
+                Title = media.Name,
+                Artist = media.MainArtist?.Name,
+                Thumbnail = base64,
+                // Optional: Complete the mapping.
+            };
+        }
+
+        await webView.ExecuteScriptFunctionAsync("livelyCurrentTrack", JsonConvert.SerializeObject(model));
+    }
+
+    private static async Task<string> ReadToBase64Async(IRandomAccessStream source)
+    {
+        using var stream = source.CloneStream();
+
+        var buffer = new byte[stream.Size];
+        await stream.ReadAsync(buffer.AsBuffer(), (uint)stream.Size, InputStreamOptions.None);
+        return Convert.ToBase64String(buffer);
     }
 }

--- a/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Controls;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -12,27 +13,53 @@ using Screenbox.Core.Models;
 using Screenbox.Core.Services;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.Streams;
+using Windows.System;
 
 namespace Screenbox.Core.ViewModels;
+
 public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
-    IRecipient<PropertyChangedMessage<LivelyWallpaperModel?>>
+    IRecipient<PropertyChangedMessage<LivelyWallpaperModel?>>,
+    IRecipient<PlaylistCurrentItemChangedMessage>
 {
+    public event EventHandler? TrackUpdateRequested;
+
     [ObservableProperty] private LivelyWallpaperModel? _source;
     [ObservableProperty] private bool _isLoading;
 
+    private MediaViewModel? Media
+    {
+        get => _media;
+        set
+        {
+            if (_media == value) return;
+            var oldValue = _media;
+            _media = value;
+            if (oldValue != null)
+                oldValue.PropertyChanged -= MediaOnPropertyChanged;
+
+            if (value != null)
+                value.PropertyChanged += MediaOnPropertyChanged;
+        }
+    }
+
+    private MediaViewModel? _media;
+
     private readonly ILivelyWallpaperService _livelyService;
     private readonly ISettingsService _settingsService;
+    private readonly DispatcherQueueTimer _timer;
 
     public LivelyWallpaperPlayerViewModel(ILivelyWallpaperService livelyService, ISettingsService settingsService)
     {
         _livelyService = livelyService;
         _settingsService = settingsService;
+        _timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
         IsActive = true;
     }
@@ -40,6 +67,20 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
     public void Receive(PropertyChangedMessage<LivelyWallpaperModel?> message)
     {
         Source = message.NewValue;
+    }
+
+    public void Receive(PlaylistCurrentItemChangedMessage message)
+    {
+        Media = message.Value;
+        TrackUpdateRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void MediaOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MediaViewModel.Name) or nameof(MediaViewModel.MainArtist))
+        {
+            _timer.Debounce(() => TrackUpdateRequested?.Invoke(this, EventArgs.Empty), TimeSpan.FromMilliseconds(50));
+        }
     }
 
     public void SendError(string title, string message)
@@ -57,6 +98,24 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
                 visualizer.Path.Equals(activeVisualizerPath, StringComparison.OrdinalIgnoreCase));
 
         Source = selectedVisualizer;
+        LoadMedia();
+    }
+
+    public async Task NavigatePage(WebView2 webView)
+    {
+        if (Source is null)
+            return;
+
+        if (string.IsNullOrEmpty(Source.Path) || string.IsNullOrEmpty(Source.Model.FileName))
+        {
+            webView.CoreWebView2.Navigate("about:blank");
+        }
+        else
+        {
+            var htmlPath = Path.Combine(Source.Path, Source.Model.FileName);
+            webView.NavigateToLocalPath(htmlPath);
+            await UpdateCurrentTrack(webView);
+        }
     }
 
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#controls
@@ -100,9 +159,11 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
                     await webView.ExecuteScriptFunctionAsync(functionName, item.Key, valueToken.ToString());
                     break;
                 case "folderDropdown":
-                    var relativePath = Path.Combine(item.Value?["folder"]?.ToString() ?? string.Empty, valueToken.ToString());
+                    var relativePath = Path.Combine(item.Value?["folder"]?.ToString() ?? string.Empty,
+                        valueToken.ToString());
                     var filePath = Path.Combine(Source.Path, relativePath);
-                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key, File.Exists(filePath) ? relativePath : null);
+                    await webView.ExecuteScriptFunctionAsync(functionName, item.Key,
+                        File.Exists(filePath) ? relativePath : null);
                     break;
                 case "button":
                 case "label":
@@ -126,26 +187,32 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
     }
 
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--system-nowplaying
-    public async Task UpdateCurrentTrack(WebView2 webView, MediaViewModel media)
+    public async Task UpdateCurrentTrack(WebView2 webView)
     {
-        if (Source is null || webView.CoreWebView2.IsSuspended || !Source.IsMusic)
+        if (Source is null || Media == null || webView.CoreWebView2.IsSuspended || !Source.IsMusic)
             return;
 
-        LivelyMusicModel? model = null;
-        if (media.Thumbnail != null)
+        var model = new LivelyMusicModel
         {
-            using var thumbnailSource = await media.GetThumbnailSourceAsync();
+            Title = Media.Name,
+            Artist = Media.MainArtist?.Name,
+            // Optional: Complete the mapping.
+        };
+
+        if (Media.Thumbnail != null)
+        {
+            using var thumbnailSource = await Media.GetThumbnailSourceAsync();
             var base64 = thumbnailSource != null ? await ReadToBase64Async(thumbnailSource) : string.Empty;
-            model = new LivelyMusicModel
-            {
-                Title = media.Name,
-                Artist = media.MainArtist?.Name,
-                Thumbnail = base64,
-                // Optional: Complete the mapping.
-            };
+            model.Thumbnail = base64;
         }
 
         await webView.ExecuteScriptFunctionAsync("livelyCurrentTrack", JsonConvert.SerializeObject(model));
+    }
+
+    private void LoadMedia()
+    {
+        PlaylistInfo reply = Messenger.Send(new PlaylistRequestMessage());
+        Media = reply.ActiveItem;
     }
 
     private static async Task<string> ReadToBase64Async(IRandomAccessStream source)

--- a/Screenbox/Controls/LivelyWallpaperSelector.xaml
+++ b/Screenbox/Controls/LivelyWallpaperSelector.xaml
@@ -64,9 +64,9 @@
                         Height="96"
                         CornerRadius="{StaticResource GridViewItemCornerRadius}"
                         FlowDirection="LeftToRight"
-                        ToolTipService.ToolTip="{x:Bind Model.Title}">
+                        ToolTipService.ToolTip="{x:Bind Model.Title, FallbackValue={x:Null}}">
                         <Grid.Background>
-                            <ImageBrush ImageSource="{Binding PreviewPath}" Stretch="UniformToFill" />
+                            <ImageBrush ImageSource="{Binding PreviewPath, FallbackValue={x:Null}}" Stretch="UniformToFill" />
                         </Grid.Background>
                         <Grid.ContextFlyout>
                             <MenuFlyout>

--- a/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
+++ b/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
@@ -3,19 +3,12 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Screenbox.Core.Helpers;
-using Screenbox.Core.Models;
 using Screenbox.Core.ViewModels;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Windows.Storage;
-using Windows.Storage.Streams;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -36,20 +29,18 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
     public static readonly DependencyProperty MediaProperty =
         DependencyProperty.Register("Media", typeof(MediaViewModel), typeof(LivelyWebWallpaperPlayer), new PropertyMetadata(null, OnMediaChanged));
 
-    public double[] Audio
-    {
-        get { return (double[])GetValue(AudioProperty); }
-        set
-        {
-            SetValue(AudioProperty, value);
-            _ = UpdateAudio();
-        }
-    }
-
-    public static readonly DependencyProperty AudioProperty =
-        DependencyProperty.Register("Audio", typeof(double[]), typeof(LivelyWebWallpaperPlayer), new PropertyMetadata(Array.Empty<double>()));
-
-    public event EventHandler<Exception>? WallpaperError;
+    // public double[] Audio
+    // {
+    //     get { return (double[])GetValue(AudioProperty); }
+    //     set
+    //     {
+    //         SetValue(AudioProperty, value);
+    //         _ = UpdateAudio();
+    //     }
+    // }
+    //
+    // public static readonly DependencyProperty AudioProperty =
+    //     DependencyProperty.Register("Audio", typeof(double[]), typeof(LivelyWebWallpaperPlayer), new PropertyMetadata(Array.Empty<double>()));
 
     internal LivelyWallpaperPlayerViewModel ViewModel => (LivelyWallpaperPlayerViewModel)DataContext;
 
@@ -71,14 +62,14 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         var control = (LivelyWebWallpaperPlayer)d;
         if (e.OldValue is MediaViewModel oldMedia) oldMedia.PropertyChanged -= control.MediaOnPropertyChanged;
         if (e.NewValue is MediaViewModel newValue) newValue.PropertyChanged += control.MediaOnPropertyChanged;
-        await control.UpdateMusic();
+        await control.UpdateCurrentTrack();
     }
 
     private async void MediaOnPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName is nameof(MediaViewModel.Name) or nameof(MediaViewModel.MainArtist))
         {
-            await UpdateMusic();
+            await UpdateCurrentTrack();
         }
     }
 
@@ -143,7 +134,7 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         }
         catch (Exception ex)
         {
-            WallpaperError?.Invoke(this, ex);
+            ViewModel.SendError(Strings.Resources.FailedToLoadVisualNotificationTitle, ex.Message);
         }
     }
 
@@ -166,8 +157,8 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         if (args.NavigationId != _currentNavigationId)
             return;
 
-        await UpdateLivelyProperties();
-        await UpdateMusic();
+        await ViewModel.UpdateLivelyProperties(sender);
+        await UpdateCurrentTrack();
         ViewModel.IsLoading = false;
     }
 
@@ -205,7 +196,7 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
                 // WebView rendering stops while hidden/minimized but JS can still execute.
                 // To avoid queuing music change code we don't sent update while the control is hidden and only update one time once visible.
                 // This does mean there will be a brief duration in which previous albumart will be visible, workaround - change Opacity instead.
-                await UpdateMusic();
+                await UpdateCurrentTrack();
                 break;
             case Visibility.Collapsed:
                 // This is not required, ref: https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.trysuspendasync
@@ -216,112 +207,30 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         await UpdatePauseState();
     }
 
-    // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#controls
-    private async Task UpdateLivelyProperties()
-    {
-        if (ViewModel.Source is null || _webView is null)
-            return;
-
-        var functionName = "livelyPropertyListener";
-        var propertyPath = Path.Combine(ViewModel.Source.Path, "LivelyProperties.json");
-
-        string jsonString;
-        try
-        {
-            var file = await StorageFile.GetFileFromPathAsync(propertyPath);
-            jsonString = await FileIO.ReadTextAsync(file);
-        }
-        catch (Exception)
-        {
-            return;
-        }
-
-        var jsonObject = JObject.Parse(jsonString);
-        foreach (KeyValuePair<string, JToken?> item in jsonObject)
-        {
-            var typeToken = item.Value?["type"];
-            var valueToken = item.Value?["value"];
-            if (typeToken == null || valueToken == null) continue;
-            switch (typeToken.ToString())
-            {
-                case "slider":
-                    await _webView.ExecuteScriptFunctionAsync(functionName, item.Key, (double)valueToken);
-                    break;
-                case "dropdown":
-                    await _webView.ExecuteScriptFunctionAsync(functionName, item.Key, (int)valueToken);
-                    break;
-                case "checkbox":
-                    await _webView.ExecuteScriptFunctionAsync(functionName, item.Key, (bool)valueToken);
-                    break;
-                case "color":
-                    await _webView.ExecuteScriptFunctionAsync(functionName, item.Key, valueToken.ToString());
-                    break;
-                case "folderDropdown":
-                    var relativePath = Path.Combine(item.Value?["folder"]?.ToString() ?? string.Empty, valueToken.ToString());
-                    var filePath = Path.Combine(ViewModel.Source.Path, relativePath);
-                    await _webView.ExecuteScriptFunctionAsync(functionName, item.Key, File.Exists(filePath) ? relativePath : null);
-                    break;
-                case "button":
-                case "label":
-                    // Ignore, user action only.
-                    break;
-            }
-        }
-    }
-
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--system-nowplaying
-    private async Task UpdateMusic()
+    private async Task UpdateCurrentTrack()
     {
         // WebView rendering process pauses when visibility is hidden.
-        if (ViewModel.Source == null || (_webView?.CoreWebView2.IsSuspended ?? true) || !ViewModel.Source.IsMusic || Visibility == Visibility.Collapsed)
+        if (_webView == null || Media == null || Visibility == Visibility.Collapsed)
             return;
 
-        LivelyMusicModel? model = null;
-        if (Media?.Thumbnail != null)
-        {
-            using var thumbnailSource = await Media.GetThumbnailSourceAsync();
-            var base64 = thumbnailSource != null ? await ReadToBase64Async(thumbnailSource) : string.Empty;
-            model = new LivelyMusicModel
-            {
-                Title = Media.Name,
-                Artist = Media.MainArtist?.Name,
-                Thumbnail = base64,
-                // Optional: Complete the mapping.
-            };
-        }
-
-        await _webView.ExecuteScriptFunctionAsync("livelyCurrentTrack", JsonConvert.SerializeObject(model));
+        await ViewModel.UpdateCurrentTrack(_webView, Media);
     }
 
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--audio
-    private async Task UpdateAudio()
-    {
-        // WebView rendering process pauses when visibility is hidden.
-        if (ViewModel.Source == null || (_webView?.CoreWebView2.IsSuspended ?? true) || !ViewModel.Source.IsMusic)
-            return;
-
-        await _webView.ExecuteScriptFunctionAsync("livelyAudioListener", Audio);
-    }
+    // private async Task UpdateAudio()
+    // {
+    //     // WebView rendering process pauses when visibility is hidden.
+    //     if (ViewModel.Source == null || (_webView?.CoreWebView2.IsSuspended ?? true) || !ViewModel.Source.IsMusic)
+    //         return;
+    //
+    //     await _webView.ExecuteScriptFunctionAsync("livelyAudioListener", Audio);
+    // }
 
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--pause-event
     private async Task UpdatePauseState()
     {
-        if (ViewModel.Source is null || _webView is null || !ViewModel.Source.IsPauseNotify)
-            return;
-
-        var obj = new LivelyPlaybackStateModel()
-        {
-            IsPaused = Visibility == Visibility.Collapsed
-        };
-        await _webView.ExecuteScriptFunctionAsync("livelyWallpaperPlaybackChanged", obj);
-    }
-
-    private static async Task<string> ReadToBase64Async(IRandomAccessStream source)
-    {
-        using var stream = source.CloneStream();
-
-        var buffer = new byte[stream.Size];
-        await stream.ReadAsync(buffer.AsBuffer(), (uint)stream.Size, InputStreamOptions.None);
-        return Convert.ToBase64String(buffer);
+        if (_webView is null) return;
+        await ViewModel.UpdatePauseState(_webView, Visibility == Visibility.Collapsed);
     }
 }

--- a/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
+++ b/Screenbox/Controls/LivelyWebWallpaperPlayer.xaml.cs
@@ -182,8 +182,15 @@ public sealed partial class LivelyWebWallpaperPlayer : UserControl
         }
         else
         {
-            var htmlPath = Path.Combine(ViewModel.Source.Path, ViewModel.Source.Model.FileName);
-            _webView.NavigateToLocalPath(htmlPath);
+            try
+            {
+                var htmlPath = Path.Combine(ViewModel.Source.Path, ViewModel.Source.Model.FileName);
+                _webView.NavigateToLocalPath(htmlPath);
+            }
+            catch (Exception e)
+            {
+                ViewModel.SendError(Strings.Resources.FailedToLoadVisualNotificationTitle, e.Message);
+            }
         }
     }
 

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -391,7 +391,6 @@
             Grid.RowSpan="3"
             Grid.Column="0"
             x:Load="False"
-            Media="{x:Bind ViewModel.Media, Mode=OneWay}"
             Visibility="Collapsed" />
 
         <controls:PlayerElement

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -425,6 +425,7 @@
     <PRIResource Include="Strings\en-US\Resources.resw">
       <Generator>ReswPlusAdvancedGenerator</Generator>
       <LastGenOutput>Resources.generated.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </PRIResource>
     <PRIResource Include="Strings\ar-SA\ManifestResources.resw" />
     <PRIResource Include="Strings\ar-SA\Resources.resw" />

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -3014,6 +3014,19 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region FailedToLoadVisualNotificationTitle
+        /// <summary>
+        ///   Looks up a localized string similar to: Failed to load visual
+        /// </summary>
+        public static string FailedToLoadVisualNotificationTitle
+        {
+            get
+            {
+                return _resourceLoader.GetString("FailedToLoadVisualNotificationTitle");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -3255,6 +3268,7 @@ namespace Screenbox.Strings{
             VideoLibrary,
             ShowAlbum,
             ShowArtist,
+            FailedToLoadVisualNotificationTitle,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -875,4 +875,7 @@
   <data name="ShowArtist" xml:space="preserve">
     <value>Show artist</value>
   </data>
+  <data name="FailedToLoadVisualNotificationTitle" xml:space="preserve">
+    <value>Failed to load visual</value>
+  </data>
 </root>


### PR DESCRIPTION
- Normalized hostname argument for `WebView2.NavigateToLocalPath()` and handle exceptions if occurs.
- Simplified Lively wallpaper installs using less async methods and reusing `ZipArchive` references.
- Propagate Lively related exceptions to app notifications instead of passing them.
- Move all JavaScript integration code and track change logic in the `LivelyWallpaperPlayerViewModel`.