### PR TITLE
fix(ci): wack test failing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,9 @@ jobs:
 
   wack:
     needs: build
-    runs-on: windows-latest
+    # wack gives faulty results on Windows 2022 as of 2024-11-13
+    # https://github.com/actions/runner-images/releases/tag/win22%2F20241113.3
+    runs-on: windows-2019
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
~~Fix wack check failing after merging #479~~

Update: A new GitHub Actions Windows image release broke wack test. https://github.com/actions/runner-images/releases/tag/win22%2F20241113.3

Attempt to fix this issue by using an older Windows runner.