### PR TITLE
chore: make home page view model transient

### DIFF
--- a/Screenbox.Core/Common/ServiceHelpers.cs
+++ b/Screenbox.Core/Common/ServiceHelpers.cs
@@ -36,9 +36,9 @@ public static class ServiceHelpers
         services.AddTransient<NotificationViewModel>();
         services.AddTransient<LivelyWallpaperPlayerViewModel>();
         services.AddTransient<LivelyWallpaperSelectorViewModel>();
+        services.AddTransient<HomePageViewModel>();
         services.AddSingleton<CommonViewModel>();   // Shared between many pages
         services.AddSingleton<VolumeViewModel>();   // Avoid thread lock
-        services.AddSingleton<HomePageViewModel>(); // Prevent recent media reload on every page navigation
         services.AddSingleton<MediaListViewModel>(); // Global playlist
 
         // Factories

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -29,21 +29,16 @@ namespace Screenbox.Core.ViewModels
 
         private readonly MediaViewModelFactory _mediaFactory;
         private readonly IFilesService _filesService;
-        private readonly ILibraryService _libraryService;
         private readonly ISettingsService _settingsService;
         private readonly CoreDispatcher _dispatcher;
         private readonly Dictionary<string, string> _pathToMruMappings;
-        private bool _isLoaded; // Assume this class is a singleton
 
-        public HomePageViewModel(MediaViewModelFactory mediaFactory,
-            IFilesService filesService,
-            ISettingsService settingsService,
-            ILibraryService libraryService)
+        public HomePageViewModel(MediaViewModelFactory mediaFactory, IFilesService filesService,
+            ISettingsService settingsService)
         {
             _mediaFactory = mediaFactory;
             _filesService = filesService;
             _settingsService = settingsService;
-            _libraryService = libraryService;
             _dispatcher = CoreWindow.GetForCurrentThread().Dispatcher;
             _pathToMruMappings = new Dictionary<string, string>();
             Recent = new ObservableCollection<MediaViewModel>();
@@ -62,16 +57,6 @@ namespace Screenbox.Core.ViewModels
 
         public async void OnLoaded()
         {
-            // Only run once. Assume this class is a singleton.
-            if (_isLoaded)
-            {
-                foreach (MediaViewModel media in Recent)
-                {
-                    await media.LoadThumbnailAsync();
-                }
-                return;
-            }
-            _isLoaded = true;
             await UpdateContentAsync();
         }
 
@@ -113,54 +98,14 @@ namespace Screenbox.Core.ViewModels
 
         private async Task UpdateContentAsync()
         {
-            // Pre-fetch libraries
-            List<Task> tasks = new(3) { PrefetchMusicLibraryAsync(), PrefetchVideosLibraryAsync() };
-
             // Update recent media
             if (_settingsService.ShowRecent)
             {
-                tasks.Add(UpdateRecentMediaListAsync(true));
+                await UpdateRecentMediaListAsync(true);
             }
             else
             {
                 Recent.Clear();
-            }
-
-            // Await for all of them
-            await Task.WhenAll(tasks);
-        }
-
-        private async Task PrefetchMusicLibraryAsync()
-        {
-            try
-            {
-                await _libraryService.FetchMusicAsync();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Music));
-            }
-            catch (Exception e)
-            {
-                Messenger.Send(new ErrorMessage(null, e.Message));
-                LogService.Log(e);
-            }
-        }
-
-        private async Task PrefetchVideosLibraryAsync()
-        {
-            try
-            {
-                await _libraryService.FetchVideosAsync();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Messenger.Send(new RaiseLibraryAccessDeniedNotificationMessage(KnownLibraryId.Videos));
-            }
-            catch (Exception e)
-            {
-                Messenger.Send(new ErrorMessage(null, e.Message));
-                LogService.Log(e);
             }
         }
 

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -17,7 +17,6 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 using muxc = Microsoft.UI.Xaml.Controls;
@@ -144,6 +143,7 @@ namespace Screenbox.Pages
             {
                 SetTitleBar();
                 NavView.SelectedItem = NavView.MenuItems[0];
+                _ = ViewModel.FetchLibraries();
             }
 
             if (ApplicationView.GetForCurrentView()?.TitleBar is { } titleBar)
@@ -164,6 +164,7 @@ namespace Screenbox.Pages
                     if (ContentFrame.Content == null)
                     {
                         NavView.SelectedItem = NavView.MenuItems[0];
+                        _ = ViewModel.FetchLibraries();
                     }
                 }
 


### PR DESCRIPTION
Media load speed is pretty fast and stable now. There is no reason to cache the MRU result in the home page view model. Keeping the home page view model as a singleton can sometimes encounter race conditions.

Since home page is no longer a singleton, we can't rely on the home page load to trigger library fetching. Move that logic to main page.