### PR TITLE
feat: track media availability

### DIFF
--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -73,6 +73,7 @@ namespace Screenbox.Core.ViewModels
 
         [ObservableProperty] private string _name;
         [ObservableProperty] private bool _isMediaActive;
+        [ObservableProperty] private bool _isAvailable = true;
         [ObservableProperty] private AlbumViewModel? _album;
         [ObservableProperty] private string? _caption;  // For list item subtitle
         [ObservableProperty] private string? _altCaption;   // For player page subtitle

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -63,12 +63,14 @@
             Text="{Binding TrackNumberText, FallbackValue=''}"
             TextWrapping="NoWrap"
             Visibility="{x:Bind IsTrackNumberVisible}" />
+
         <FontIcon
             x:Name="ItemMediaTypeIcon"
             Grid.Column="1"
             Glyph="{Binding Converter={StaticResource MediaGlyphConverter}}"
             IsHitTestVisible="False"
             Visibility="{x:Bind IsIconVisible}" />
+
         <HyperlinkButton
             x:Name="PlayButton"
             Grid.Column="1"
@@ -180,6 +182,23 @@
                         <Setter Target="GenreText.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                         <Setter Target="GenreText.Opacity" Value="1" />
                         <Setter Target="DurationText.Foreground" Value="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                        <Setter Target="DurationText.Opacity" Value="1" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Unavailable">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{Binding IsAvailable, Mode=OneWay, Converter={StaticResource BoolNegationConverter}, FallbackValue=False}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="TrackNumberText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="TrackNumberText.Opacity" Value="1" />
+                        <Setter Target="ItemMediaTypeIcon.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="TitleText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="ArtistButton.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="AlbumButton.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="GenreText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="GenreText.Opacity" Value="1" />
+                        <Setter Target="DurationText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
                         <Setter Target="DurationText.Opacity" Value="1" />
                     </VisualState.Setters>
                 </VisualState>


### PR DESCRIPTION
Track availability in the `MediaViewModel` and add an unavailable state to the `MediaListViewItem`. This will be useful for managing playlists where not all files can be reached using the file path.