### PR TITLE
feat: improve folder support

### DIFF
--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -207,7 +207,7 @@ namespace Screenbox.Core.Services
             FileOpenPicker picker = new()
             {
                 ViewMode = PickerViewMode.Thumbnail,
-                SuggestedStartLocation = PickerLocationId.VideosLibrary
+                SuggestedStartLocation = PickerLocationId.ComputerFolder
             };
 
             IEnumerable<string> fileTypes = formats;

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -13,6 +13,7 @@ namespace Screenbox.Core.Services
         bool PlayerShowControls { get; set; }
         int PersistentVolume { get; set; }
         bool ShowRecent { get; set; }
+        bool EnqueueAllFilesInFolder { get; set; }
         bool SearchRemovableStorage { get; set; }
         int MaxVolume { get; set; }
         string GlobalArguments { get; set; }

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -23,6 +23,7 @@ namespace Screenbox.Core.Services
         private const string LibrariesUseIndexerKey = "Libraries/UseIndexer";
         private const string LibrariesSearchRemovableStorageKey = "Libraries/SearchRemovableStorage";
         private const string GeneralShowRecent = "General/ShowRecent";
+        private const string GeneralEnqueueAllInFolder = "General/EnqueueAllInFolder";
         private const string AdvancedModeKey = "Advanced/IsEnabled";
         private const string AdvancedMultipleInstancesKey = "Advanced/MultipleInstances";
         private const string GlobalArgumentsKey = "Values/GlobalArguments";
@@ -76,6 +77,12 @@ namespace Screenbox.Core.Services
         {
             get => GetValue<bool>(GeneralShowRecent);
             set => SetValue(GeneralShowRecent, value);
+        }
+
+        public bool EnqueueAllFilesInFolder
+        {
+            get => GetValue<bool>(GeneralEnqueueAllInFolder);
+            set => SetValue(GeneralEnqueueAllInFolder, value);
         }
 
         public bool PlayerShowControls

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -28,6 +28,7 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private int _volumeBoost;
         [ObservableProperty] private bool _useIndexer;
         [ObservableProperty] private bool _showRecent;
+        [ObservableProperty] private bool _enqueueAllFilesInFolder;
         [ObservableProperty] private bool _searchRemovableStorage;
         [ObservableProperty] private bool _advancedMode;
         [ObservableProperty] private bool _useMultipleInstances;
@@ -76,6 +77,7 @@ namespace Screenbox.Core.ViewModels
             _playerShowControls = _settingsService.PlayerShowControls;
             _useIndexer = _settingsService.UseIndexer;
             _showRecent = _settingsService.ShowRecent;
+            _enqueueAllFilesInFolder = _settingsService.EnqueueAllFilesInFolder;
             _searchRemovableStorage = _settingsService.SearchRemovableStorage;
             _advancedMode = _settingsService.AdvancedMode;
             _useMultipleInstances = _settingsService.UseMultipleInstances;
@@ -135,6 +137,12 @@ namespace Screenbox.Core.ViewModels
         {
             _settingsService.ShowRecent = value;
             Messenger.Send(new SettingsChangedMessage(nameof(ShowRecent), typeof(SettingsPageViewModel)));
+        }
+
+        partial void OnEnqueueAllFilesInFolderChanged(bool value)
+        {
+            _settingsService.EnqueueAllFilesInFolder = value;
+            Messenger.Send(new SettingsChangedMessage(nameof(EnqueueAllFilesInFolder), typeof(SettingsPageViewModel)));
         }
 
         async partial void OnSearchRemovableStorageChanged(bool value)

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -288,7 +288,9 @@
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}"
-                    Header="{strings:Resources Key=SettingsEnqueueAllFilesInFolderHeader}">
+                    Header="{strings:Resources Key=SettingsEnqueueAllFilesInFolderHeader}"
+                    HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
+                                             Glyph=&#xF2CE;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -285,6 +285,13 @@
                     </ctc:SettingsExpander.Items>
                 </ctc:SettingsExpander>
 
+                <ctc:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
+                    Description="Automatically add all media files in the folder to the play queue when opening a single file"
+                    Header="Enqueue all media files in a folder">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
+                </ctc:SettingsCard>
+
                 <!--  Player section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />
 

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -287,8 +287,8 @@
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="Automatically add all media files in the folder to the play queue when opening a single file"
-                    Header="Enqueue all media files in a folder">
+                    Description="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}"
+                    Header="{strings:Resources Key=SettingsEnqueueAllFilesInFolderHeader}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -3066,6 +3066,32 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region SettingsEnqueueAllFilesInFolderDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: When opening a single file, automatically add all other files in the folder to the play queue.
+        /// </summary>
+        public static string SettingsEnqueueAllFilesInFolderDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsEnqueueAllFilesInFolderDescription");
+            }
+        }
+        #endregion
+
+        #region SettingsEnqueueAllFilesInFolderHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: Add all files in folder to queue
+        /// </summary>
+        public static string SettingsEnqueueAllFilesInFolderHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsEnqueueAllFilesInFolderHeader");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -3311,6 +3337,8 @@ namespace Screenbox.Strings{
             ShowAlbum,
             ShowArtist,
             FailedToLoadVisualNotificationTitle,
+            SettingsEnqueueAllFilesInFolderDescription,
+            SettingsEnqueueAllFilesInFolderHeader,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -887,4 +887,10 @@
   <data name="FailedToLoadVisualNotificationTitle" xml:space="preserve">
     <value>Failed to load visual</value>
   </data>
+  <data name="SettingsEnqueueAllFilesInFolderDescription" xml:space="preserve">
+    <value>When opening a single file, automatically add all other files in the folder to the play queue.</value>
+  </data>
+  <data name="SettingsEnqueueAllFilesInFolderHeader" xml:space="preserve">
+    <value>Add all files in folder to queue</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR implements
- Perform recursive folder search when dropping a mix of files and folders into the app. Closes #482 
- Add an option to automatically add all media files in a folder into the play queue upon opening a single file. Close #497 #441
