### PR TITLE
feat: window resize steps using Ctrl + Plus and Ctrl + Minus

### DIFF
--- a/Screenbox.Core/Services/IWindowService.cs
+++ b/Screenbox.Core/Services/IWindowService.cs
@@ -17,7 +17,7 @@ namespace Screenbox.Core.Services
         public Task<bool> TryExitCompactLayoutAsync();
         public Task<bool> TryEnterCompactLayoutAsync(Size viewSize);
         Size GetMaxWindowSize();
-        double ResizeWindow(Size desiredSize, double scalar = 0);
+        double ResizeWindow(Size desiredSize, double scalar = 1);
         void HideCursor();
         void ShowCursor();
     }

--- a/Screenbox.Core/Services/IWindowService.cs
+++ b/Screenbox.Core/Services/IWindowService.cs
@@ -17,7 +17,7 @@ namespace Screenbox.Core.Services
         public Task<bool> TryExitCompactLayoutAsync();
         public Task<bool> TryEnterCompactLayoutAsync(Size viewSize);
         Size GetMaxWindowSize();
-        double ResizeWindow(Size videoDimension, double scalar = 0);
+        double ResizeWindow(Size desiredSize, double scalar = 0);
         void HideCursor();
         void ShowCursor();
     }

--- a/Screenbox.Core/Services/WindowService.cs
+++ b/Screenbox.Core/Services/WindowService.cs
@@ -122,7 +122,7 @@ namespace Screenbox.Core.Services
             return new Size(maxWidth, maxHeight);
         }
 
-        public double ResizeWindow(Size desiredSize, double scalar = 0)
+        public double ResizeWindow(Size desiredSize, double scalar = 1)
         {
             if (scalar < 0 || desiredSize.IsEmpty) return -1;
             ApplicationView view = ApplicationView.GetForCurrentView();

--- a/Screenbox.Core/Services/WindowService.cs
+++ b/Screenbox.Core/Services/WindowService.cs
@@ -122,9 +122,9 @@ namespace Screenbox.Core.Services
             return new Size(maxWidth, maxHeight);
         }
 
-        public double ResizeWindow(Size videoDimension, double scalar = 0)
+        public double ResizeWindow(Size desiredSize, double scalar = 0)
         {
-            if (scalar < 0 || videoDimension.IsEmpty) return -1;
+            if (scalar < 0 || desiredSize.IsEmpty) return -1;
             ApplicationView view = ApplicationView.GetForCurrentView();
             DisplayInformation displayInformation = DisplayInformation.GetForCurrentView();
             Size maxWindowSize = GetMaxWindowSize(view, displayInformation);
@@ -133,16 +133,16 @@ namespace Screenbox.Core.Services
 
             if (scalar == 0)
             {
-                double widthRatio = maxWidth / videoDimension.Width;
-                double heightRatio = maxHeight / videoDimension.Height;
+                double widthRatio = maxWidth / desiredSize.Width;
+                double heightRatio = maxHeight / desiredSize.Height;
                 scalar = Math.Min(widthRatio, heightRatio);
             }
 
-            double aspectRatio = videoDimension.Width / videoDimension.Height;
-            double newWidth = videoDimension.Width * scalar;
+            double aspectRatio = desiredSize.Width / desiredSize.Height;
+            double newWidth = desiredSize.Width * scalar;
             if (newWidth > maxWidth) newWidth = maxWidth;
             double newHeight = newWidth / aspectRatio;
-            scalar = newWidth / videoDimension.Width;
+            scalar = newWidth / desiredSize.Width;
             if (view.TryResizeView(new Size(newWidth, newHeight)))
             {
                 return scalar;

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -434,7 +434,7 @@ namespace Screenbox.Core.ViewModels
                     ResizeWindow(videoSize, 1);
                     break;
                 case VirtualKey.Number3 when sender.Modifiers == VirtualKeyModifiers.None:
-                    ResizeWindow(videoSize, 2);
+                    ResizeWindow(videoSize, 1.5);
                     break;
                 case VirtualKey.Number4 when sender.Modifiers == VirtualKeyModifiers.None:
                     ResizeWindow(videoSize, 0);

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -700,11 +700,11 @@ namespace Screenbox.Core.ViewModels
                 Size maxWindowSize = _windowService.GetMaxWindowSize();
                 if (sender.NaturalVideoWidth >= maxWindowSize.Width ||
                     sender.NaturalVideoHeight >= maxWindowSize.Height)
-                    ResizeWindow(desiredSize);
+                    ResizeWindow(desiredSize, 0);
             });
         }
 
-        private bool ResizeWindow(Size desiredSize, double scalar = 0)
+        private bool ResizeWindow(Size desiredSize, double scalar = 1)
         {
             if (scalar < 0 || _windowService.ViewMode != WindowViewMode.Default) return false;
             double actualScalar = _windowService.ResizeWindow(desiredSize, scalar);

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -425,6 +425,12 @@ namespace Screenbox.Core.ViewModels
             var view = ApplicationView.GetForCurrentView();
             // Visible bounds always have 1 pixel less than actual window height?
             var currentSize = new Size(view.VisibleBounds.Width, view.VisibleBounds.Height + 1);
+            // Desired step is 10% of the current window size
+            // However, 10% step doesn't always give a round number for resizing and rounding error will accumulate
+            // We want to maintain the original aspect ratio as long as possible
+            var stepHeight = Math.Round(currentSize.Height * 0.1);
+            var stepWidth = Math.Round(currentSize.Width * 0.1);
+            var desiredStepSize = Math.Min(stepWidth / currentSize.Width, stepHeight / currentSize.Height);
             switch (sender.Key)
             {
                 case VirtualKey.Number1 when sender.Modifiers == VirtualKeyModifiers.None:
@@ -440,10 +446,10 @@ namespace Screenbox.Core.ViewModels
                     ResizeWindow(videoSize, 0);
                     break;
                 case (VirtualKey)0xBB when sender.Modifiers == VirtualKeyModifiers.Control:  // Plus ("+")
-                    ResizeWindow(currentSize, 1.1);
+                    ResizeWindow(currentSize, 1 + desiredStepSize);
                     break;
                 case (VirtualKey)0xBD when sender.Modifiers == VirtualKeyModifiers.Control:  // Minus ("-")
-                    ResizeWindow(currentSize, 0.9);
+                    ResizeWindow(currentSize, 1 - desiredStepSize);
                     break;
                 default:
                     args.Handled = false;

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -150,6 +150,14 @@
                 Modifiers="Shift" />
             <KeyboardAccelerator Key="{x:Bind pages:PlayerPage.PeriodKey}" Invoked="{x:Bind ViewModel.OnFrameJumpKeyboardAcceleratorInvoked}" />
             <KeyboardAccelerator Key="{x:Bind pages:PlayerPage.CommaKey}" Invoked="{x:Bind ViewModel.OnFrameJumpKeyboardAcceleratorInvoked}" />
+            <KeyboardAccelerator
+                Key="{x:Bind pages:PlayerPage.PlusKey}"
+                Invoked="{x:Bind ViewModel.OnResizeKeyboardAcceleratorInvoked}"
+                Modifiers="Control" />
+            <KeyboardAccelerator
+                Key="{x:Bind pages:PlayerPage.MinusKey}"
+                Invoked="{x:Bind ViewModel.OnResizeKeyboardAcceleratorInvoked}"
+                Modifiers="Control" />
             <KeyboardAccelerator Key="Number1" Invoked="{x:Bind ViewModel.OnResizeKeyboardAcceleratorInvoked}" />
             <KeyboardAccelerator Key="Number2" Invoked="{x:Bind ViewModel.OnResizeKeyboardAcceleratorInvoked}" />
             <KeyboardAccelerator Key="Number3" Invoked="{x:Bind ViewModel.OnResizeKeyboardAcceleratorInvoked}" />


### PR DESCRIPTION
This pull request includes several changes to the `Screenbox.Core` services and view models to enhance the window resizing functionality and improve keyboard shortcuts for resizing. 
- Change the resize preset number 3 to use a scalar value of 1.5 instead of 2. Scaling to 2 often results in excessive enlargement for 1080p videos displayed on a 2K or 4K screen. Using preset number 4 can often achieve a similar outcome.
- Implement window resizing by 10% step using Ctrl + Plus and Ctrl + Minus.

https://github.com/user-attachments/assets/6317ceae-ff57-4c63-93f2-309ad8ba4702

