### PR TITLE
feat: improve subtitle picking logic - persist subtitle language selection

### DIFF
--- a/Screenbox.Core/Common/ServiceHelpers.cs
+++ b/Screenbox.Core/Common/ServiceHelpers.cs
@@ -12,7 +12,7 @@ public static class ServiceHelpers
         services.AddTransient<PlayerElementViewModel>();
         services.AddTransient<PropertyViewModel>();
         services.AddTransient<ChapterViewModel>();
-        services.AddTransient<AudioTrackSubtitleViewModel>();
+        services.AddTransient<CompositeTrackPickerViewModel>();
         services.AddTransient<SeekBarViewModel>();
         services.AddTransient<VideosPageViewModel>();
         services.AddTransient<NetworkPageViewModel>();

--- a/Screenbox.Core/Helpers/LanguageHelper.cs
+++ b/Screenbox.Core/Helpers/LanguageHelper.cs
@@ -1,4 +1,5 @@
-﻿using Windows.ApplicationModel.Resources;
+﻿using System.Linq;
+using Windows.ApplicationModel.Resources;
 
 namespace Screenbox.Core.Helpers;
 internal static class LanguageHelper
@@ -11,5 +12,10 @@ internal static class LanguageHelper
         if (threeLetterTag.Length != 3) return false;
         twoLetterTag = Loader.GetString(threeLetterTag);
         return !string.IsNullOrEmpty(twoLetterTag);
+    }
+
+    public static string GetPreferredLanguage()
+    {
+        return Windows.System.UserProfile.GlobalizationPreferences.Languages.FirstOrDefault() ?? string.Empty;
     }
 }

--- a/Screenbox.Core/Playback/MediaTrack.cs
+++ b/Screenbox.Core/Playback/MediaTrack.cs
@@ -15,6 +15,8 @@ public abstract class MediaTrack : IMediaTrack
 
     public string Language => _language?.DisplayName ?? _languageStr;
 
+    public string LanguageTag => _language?.LanguageTag ?? string.Empty;
+
     private readonly Language? _language;
     private readonly string _languageStr;
 

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -253,7 +253,7 @@
     <Compile Include="ViewModels\ArtistSearchResultPageViewModel.cs" />
     <Compile Include="ViewModels\ArtistsPageViewModel.cs" />
     <Compile Include="ViewModels\ArtistViewModel.cs" />
-    <Compile Include="ViewModels\AudioTrackSubtitleViewModel.cs" />
+    <Compile Include="ViewModels\CompositeTrackPickerViewModel.cs" />
     <Compile Include="ViewModels\BaseMusicContentViewModel.cs" />
     <Compile Include="ViewModels\CastControlViewModel.cs" />
     <Compile Include="ViewModels\ChapterViewModel.cs" />

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -12,6 +12,7 @@ namespace Screenbox.Core.Services
         bool PlayerTapGesture { get; set; }
         bool PlayerShowControls { get; set; }
         int PersistentVolume { get; set; }
+        string PersistentSubtitleLanguage { get; set; }
         bool ShowRecent { get; set; }
         bool SearchRemovableStorage { get; set; }
         int MaxVolume { get; set; }

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -29,6 +29,7 @@ namespace Screenbox.Core.Services
         private const string PersistentVolumeKey = "Values/Volume";
         private const string MaxVolumeKey = "Values/MaxVolume";
         private const string PersistentRepeatModeKey = "Values/RepeatMode";
+        private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
 
         public bool UseIndexer
         {
@@ -64,6 +65,12 @@ namespace Screenbox.Core.Services
         {
             get => GetValue<int>(PersistentVolumeKey);
             set => SetValue(PersistentVolumeKey, value);
+        }
+
+        public string PersistentSubtitleLanguage
+        {
+            get => GetValue<string>(PersistentSubtitleLanguageKey) ?? string.Empty;
+            set => SetValue(PersistentSubtitleLanguageKey, value);
         }
 
         public int MaxVolume

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -3,7 +3,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
-using LibVLCSharp.Shared;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
@@ -88,7 +87,7 @@ namespace Screenbox.Core.ViewModels
                 {
                     using var cts = new CancellationTokenSource();
                     _cts = cts;
-                    await WaitForMediaParsed(playbackItem, cts.Token);
+                    await playbackItem.Media.WaitForParsed(TimeSpan.FromSeconds(5), cts.Token);
                 }
                 catch (OperationCanceledException)
                 {
@@ -129,29 +128,6 @@ namespace Screenbox.Core.ViewModels
                             break;
                         }
                     }
-                }
-            }
-        }
-
-        private static async Task WaitForMediaParsed(PlaybackItem item, CancellationToken cancellationToken = default)
-        {
-            if (item.Media.IsParsed || item.Media.ParsedStatus != 0) return;
-            TaskCompletionSource<bool> tcs = new();
-            using (cancellationToken.Register(token => tcs.TrySetCanceled((CancellationToken)token), cancellationToken))
-            {
-                void OnMediaOnParsedChanged(object sender, MediaParsedChangedEventArgs args)
-                {
-                    tcs.TrySetResult(args.ParsedStatus == MediaParsedStatus.Done);
-                }
-
-                item.Media.ParsedChanged += OnMediaOnParsedChanged;
-                try
-                {
-                    await tcs.Task;
-                }
-                finally
-                {
-                    item.Media.ParsedChanged -= OnMediaOnParsedChanged;
                 }
             }
         }

--- a/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
+++ b/Screenbox.Core/ViewModels/AudioTrackSubtitleViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using LibVLCSharp.Shared;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
@@ -13,6 +14,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.Search;
@@ -37,12 +39,16 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private int _audioTrackIndex;
         private readonly IFilesService _filesService;
         private readonly IResourceService _resourceService;
+        private readonly ISettingsService _settingsService;
         private IMediaPlayer? _mediaPlayer;
+        private bool _flyoutOpened;
+        private CancellationTokenSource? _cts;
 
-        public AudioTrackSubtitleViewModel(IFilesService filesService, IResourceService resourceService)
+        public AudioTrackSubtitleViewModel(IFilesService filesService, IResourceService resourceService, ISettingsService settingsService)
         {
             _filesService = filesService;
             _resourceService = resourceService;
+            _settingsService = settingsService;
             SubtitleTracks = new ObservableCollection<string>();
             AudioTracks = new ObservableCollection<string>();
             _mediaPlayer = Messenger.Send(new MediaPlayerRequestMessage()).Response;
@@ -60,17 +66,93 @@ namespace Screenbox.Core.ViewModels
         /// </summary>
         public async void Receive(PlaylistCurrentItemChangedMessage message)
         {
+            _cts?.Cancel();
             if (_mediaPlayer is not VlcMediaPlayer player) return;
             if (message.Value is not { Source: StorageFile file, MediaType: MediaPlaybackType.Video } media)
                 return;
 
+            bool subtitleInitialized = false;
+            var playbackSubtitleTrackList = media.Item.Value?.SubtitleTracks;
+            if (playbackSubtitleTrackList == null) return;
+            if (playbackSubtitleTrackList.Count > 0) subtitleInitialized = true;
             IReadOnlyList<StorageFile> subtitles = await GetSubtitlesForFile(file);
-
-            if (subtitles.Count <= 0) return;
             foreach (StorageFile subtitleFile in subtitles)
             {
                 // Preload subtitle but don't select it
-                media.Item.Value?.SubtitleTracks.AddExternalSubtitle(player, subtitleFile, false);
+                playbackSubtitleTrackList.AddExternalSubtitle(player, subtitleFile, false);
+            }
+
+            if (!subtitleInitialized && media.Item.Value is { } playbackItem)
+            {
+                try
+                {
+                    using var cts = new CancellationTokenSource();
+                    _cts = cts;
+                    await WaitForMediaParsed(playbackItem, cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // pass
+                }
+                finally
+                {
+                    _cts = null;
+                }
+            }
+
+            TrySetSubtitleFromLanguage(playbackSubtitleTrackList, _settingsService.PersistentSubtitleLanguage);
+        }
+
+        private static void TrySetSubtitleFromLanguage(PlaybackSubtitleTrackList subtitleTrackList, string persistentLanguage)
+        {
+            // Check persistent subtitle value to try and select a subtitle
+            if (!string.IsNullOrEmpty(persistentLanguage))
+            {
+                // If there is only one subtitle then select it
+                if (subtitleTrackList.Count == 1)
+                {
+                    subtitleTrackList.SelectedIndex = 0;
+                    return;
+                }
+
+                // Try to select the subtitle with the same language as the persistent value
+                var langPreferences = persistentLanguage.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (string language in langPreferences)
+                {
+                    for (int i = 0; i < subtitleTrackList.Count; i++)
+                    {
+                        var subtitleTrack = subtitleTrackList[i];
+                        // Try to match language tag first, then language name
+                        if (language == subtitleTrack.LanguageTag || language.Equals(subtitleTrack.Language, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            subtitleTrackList.SelectedIndex = i;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static async Task WaitForMediaParsed(PlaybackItem item, CancellationToken cancellationToken = default)
+        {
+            if (item.Media.IsParsed || item.Media.ParsedStatus != 0) return;
+            TaskCompletionSource<bool> tcs = new();
+            using (cancellationToken.Register(token => tcs.TrySetCanceled((CancellationToken)token), cancellationToken))
+            {
+                void OnMediaOnParsedChanged(object sender, MediaParsedChangedEventArgs args)
+                {
+                    tcs.TrySetResult(args.ParsedStatus == MediaParsedStatus.Done);
+                }
+
+                item.Media.ParsedChanged += OnMediaOnParsedChanged;
+                try
+                {
+                    await tcs.Task;
+                }
+                finally
+                {
+                    item.Media.ParsedChanged -= OnMediaOnParsedChanged;
+                }
             }
         }
 
@@ -114,7 +196,24 @@ namespace Screenbox.Core.ViewModels
         partial void OnSubtitleTrackIndexChanged(int value)
         {
             if (ItemSubtitleTrackList != null && value >= 0 && value < SubtitleTracks.Count)
+            {
                 ItemSubtitleTrackList.SelectedIndex = value - 1;
+
+                if (_flyoutOpened)
+                {
+                    if (value == 0)
+                    {
+                        _settingsService.PersistentSubtitleLanguage = string.Empty;
+                    }
+                    else
+                    {
+                        var subtitle = ItemSubtitleTrackList[ItemSubtitleTrackList.SelectedIndex];
+                        _settingsService.PersistentSubtitleLanguage =
+                            $"{subtitle.LanguageTag},{subtitle.Language},{LanguageHelper.GetPreferredLanguage().Substring(0, 2)}";
+                    }
+                }
+            }
+
         }
 
         partial void OnAudioTrackIndexChanged(int value)
@@ -142,12 +241,19 @@ namespace Screenbox.Core.ViewModels
             }
         }
 
-        public void OnAudioCaptionFlyoutOpening()
+        public void OnFlyoutOpening()
         {
             UpdateSubtitleTrackList();
             UpdateAudioTrackList();
             SubtitleTrackIndex = ItemSubtitleTrackList?.SelectedIndex + 1 ?? 0;
             AudioTrackIndex = ItemAudioTrackList?.SelectedIndex ?? -1;
+
+            _flyoutOpened = true;
+        }
+
+        public void OnFlyoutClosed()
+        {
+            _flyoutOpened = false;
         }
 
         private void UpdateAudioTrackList()

--- a/Screenbox.Core/ViewModels/CompositeTrackPickerViewModel.cs
+++ b/Screenbox.Core/ViewModels/CompositeTrackPickerViewModel.cs
@@ -22,7 +22,7 @@ using SubtitleTrack = Screenbox.Core.Playback.SubtitleTrack;
 
 namespace Screenbox.Core.ViewModels
 {
-    public sealed partial class AudioTrackSubtitleViewModel : ObservableRecipient,
+    public sealed partial class CompositeTrackPickerViewModel : ObservableRecipient,
         IRecipient<PlaylistCurrentItemChangedMessage>,
         IRecipient<MediaPlayerChangedMessage>
     {
@@ -43,7 +43,7 @@ namespace Screenbox.Core.ViewModels
         private bool _flyoutOpened;
         private CancellationTokenSource? _cts;
 
-        public AudioTrackSubtitleViewModel(IFilesService filesService, IResourceService resourceService, ISettingsService settingsService)
+        public CompositeTrackPickerViewModel(IFilesService filesService, IResourceService resourceService, ISettingsService settingsService)
         {
             _filesService = filesService;
             _resourceService = resourceService;

--- a/Screenbox/Controls/CompositeTrackPicker.xaml
+++ b/Screenbox/Controls/CompositeTrackPicker.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="Screenbox.Controls.AudioTrackSubtitlePicker"
+    x:Class="Screenbox.Controls.CompositeTrackPicker"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contract14Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,14)"

--- a/Screenbox/Controls/CompositeTrackPicker.xaml.cs
+++ b/Screenbox/Controls/CompositeTrackPicker.xaml.cs
@@ -7,17 +7,17 @@ using Windows.UI.Xaml.Controls;
 
 namespace Screenbox.Controls
 {
-    public sealed partial class AudioTrackSubtitlePicker : UserControl
+    public sealed partial class CompositeTrackPicker : UserControl
     {
         public IRelayCommand? ShowSubtitleOptionsCommand { get; set; }
         public IRelayCommand? ShowAudioOptionsCommand { get; set; }
 
-        internal AudioTrackSubtitleViewModel ViewModel => (AudioTrackSubtitleViewModel)DataContext;
+        internal CompositeTrackPickerViewModel ViewModel => (CompositeTrackPickerViewModel)DataContext;
 
-        public AudioTrackSubtitlePicker()
+        public CompositeTrackPicker()
         {
             this.InitializeComponent();
-            DataContext = Ioc.Default.GetRequiredService<AudioTrackSubtitleViewModel>();
+            DataContext = Ioc.Default.GetRequiredService<CompositeTrackPickerViewModel>();
         }
     }
 }

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -515,7 +515,7 @@
                         FlyoutPresenterStyle="{StaticResource FlyoutPresenterMenuFlyoutStyle}"
                         Opening="{x:Bind AudioTrackSubtitlePicker.ViewModel.OnFlyoutOpening}"
                         ShouldConstrainToRootBounds="False">
-                        <controls:AudioTrackSubtitlePicker x:Name="AudioTrackSubtitlePicker" IsAccessKeyScope="True" />
+                        <controls:CompositeTrackPicker x:Name="AudioTrackSubtitlePicker" IsAccessKeyScope="True" />
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -511,8 +511,9 @@
                 <Button.Flyout>
                     <Flyout
                         x:Name="AudioSubtitlePickerFlyout"
+                        Closed="{x:Bind AudioTrackSubtitlePicker.ViewModel.OnFlyoutClosed}"
                         FlyoutPresenterStyle="{StaticResource FlyoutPresenterMenuFlyoutStyle}"
-                        Opening="{x:Bind AudioTrackSubtitlePicker.ViewModel.OnAudioCaptionFlyoutOpening}"
+                        Opening="{x:Bind AudioTrackSubtitlePicker.ViewModel.OnFlyoutOpening}"
                         ShouldConstrainToRootBounds="False">
                         <controls:AudioTrackSubtitlePicker x:Name="AudioTrackSubtitlePicker" IsAccessKeyScope="True" />
                     </Flyout>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -149,8 +149,8 @@
     <Compile Include="Commands\ShowPropertiesCommand.cs" />
     <Compile Include="Controls\AcceleratorService.cs" />
     <Compile Include="Controls\Animations\AnimatedPlayingVisualSource.cs" />
-    <Compile Include="Controls\AudioTrackSubtitlePicker.xaml.cs">
-      <DependentUpon>AudioTrackSubtitlePicker.xaml</DependentUpon>
+    <Compile Include="Controls\CompositeTrackPicker.xaml.cs">
+      <DependentUpon>CompositeTrackPicker.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\CastControl.xaml.cs">
       <DependentUpon>CastControl.xaml</DependentUpon>
@@ -514,7 +514,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
-    <Page Include="Controls\AudioTrackSubtitlePicker.xaml">
+    <Page Include="Controls\CompositeTrackPicker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
When users select a subtitle, they will likely want the same subtitle **language** for the next media, similar to how YouTube operates. Since there is no standard method to detect the language of a subtitle track, we attempt to retain and compare both the language tag and the language label of the track. If both methods fail, we will select based on the preferred system language.

The logic is as follows:
- When the user opens the subtitle track picker and selects a subtitle, the app tries to guess what language the subtitle track is and remembers that information.
- When opening another media file, if the persistent value is not empty
  - Select the first subtitle track if there is only one.
  - Try to find the first subtitle track in the same language if there is more than one.
- Reset the persistent value to empty when the user opens the track picker and disable the subtitle.

Closes #515