### PR TITLE
feat: add option to always resume from the last position

### DIFF
--- a/Screenbox.Core/Common/ServiceHelpers.cs
+++ b/Screenbox.Core/Common/ServiceHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Screenbox.Core.Factories;
+using Screenbox.Core.Helpers;
 using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
 
@@ -40,6 +41,9 @@ public static class ServiceHelpers
         services.AddSingleton<CommonViewModel>();   // Shared between many pages
         services.AddSingleton<VolumeViewModel>();   // Avoid thread lock
         services.AddSingleton<MediaListViewModel>(); // Global playlist
+
+        // Misc
+        services.AddTransient<LastPositionTracker>();
 
         // Factories
         services.AddSingleton<MediaViewModelFactory>();

--- a/Screenbox.Core/Helpers/LastPositionTracker.cs
+++ b/Screenbox.Core/Helpers/LastPositionTracker.cs
@@ -15,11 +15,12 @@ using Windows.Storage;
 namespace Screenbox.Core.Helpers
 {
     public sealed class LastPositionTracker : ObservableRecipient,
-        IRecipient<SuspendingMessage>,
-        IRecipient<MediaPlayerChangedMessage>
+        IRecipient<SuspendingMessage>
     {
         private const int Capacity = 64;
         private const string SaveFileName = "last_positions.bin";
+
+        public bool IsLoaded => LastUpdated != default;
 
         public DateTimeOffset LastUpdated { get; private set; }
 
@@ -38,12 +39,6 @@ namespace Screenbox.Core.Helpers
         public void Receive(SuspendingMessage message)
         {
             message.Reply(SaveToDiskAsync());
-        }
-
-        public async void Receive(MediaPlayerChangedMessage message)
-        {
-            if (_lastPositions.Count > 0) return;
-            await LoadFromDiskAsync();
         }
 
         public void UpdateLastPosition(string location, TimeSpan position)
@@ -119,6 +114,7 @@ namespace Screenbox.Core.Helpers
                     await _filesService.LoadFromDiskAsync<List<MediaLastPosition>>(ApplicationData.Current.TemporaryFolder, SaveFileName);
                 lastPositions.Capacity = Capacity;
                 _lastPositions = lastPositions;
+                LastUpdated = DateTimeOffset.UtcNow;
             }
             catch (FileNotFoundException)
             {

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -16,6 +16,7 @@ namespace Screenbox.Core.Services
         bool ShowRecent { get; set; }
         ThemeOption Theme { get; set; }
         bool EnqueueAllFilesInFolder { get; set; }
+        bool RestorePlaybackPosition { get; set; }
         bool SearchRemovableStorage { get; set; }
         int MaxVolume { get; set; }
         string GlobalArguments { get; set; }

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -25,6 +25,7 @@ namespace Screenbox.Core.Services
         private const string LibrariesSearchRemovableStorageKey = "Libraries/SearchRemovableStorage";
         private const string GeneralShowRecent = "General/ShowRecent";
         private const string GeneralEnqueueAllInFolder = "General/EnqueueAllInFolder";
+        private const string GeneralRestorePlaybackPosition = "General/RestorePlaybackPosition";
         private const string AdvancedModeKey = "Advanced/IsEnabled";
         private const string AdvancedMultipleInstancesKey = "Advanced/MultipleInstances";
         private const string GlobalArgumentsKey = "Values/GlobalArguments";
@@ -97,6 +98,12 @@ namespace Screenbox.Core.Services
         {
             get => GetValue<bool>(GeneralEnqueueAllInFolder);
             set => SetValue(GeneralEnqueueAllInFolder, value);
+        }
+
+        public bool RestorePlaybackPosition
+        {
+            get => GetValue<bool>(GeneralRestorePlaybackPosition);
+            set => SetValue(GeneralRestorePlaybackPosition, value);
         }
 
         public bool PlayerShowControls

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -177,7 +177,16 @@ namespace Screenbox.Core.ViewModels
             if (message.Value != null)
             {
                 TimeSpan lastPosition = _lastPositionTracker.GetPosition(message.Value.Location);
-                Messenger.Send(new RaiseResumePositionNotificationMessage(lastPosition));
+                if (lastPosition <= TimeSpan.Zero) return;
+                if (_settingsService.RestorePlaybackPosition)
+                {
+                    // TODO: Wait until playback starts then send time change message
+                    Messenger.Send(new ChangeTimeRequestMessage(lastPosition, debounce: false));
+                }
+                else
+                {
+                    Messenger.Send(new RaiseResumePositionNotificationMessage(lastPosition));
+                }
             }
         }
 

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -32,7 +32,6 @@ namespace Screenbox.Core.ViewModels
         IRecipient<UpdateStatusMessage>,
         IRecipient<UpdateVolumeStatusMessage>,
         IRecipient<TogglePlayerVisibilityMessage>,
-        IRecipient<SuspendingMessage>,
         IRecipient<MediaPlayerChangedMessage>,
         IRecipient<PlaylistCurrentItemChangedMessage>,
         IRecipient<ShowPlayPauseBadgeMessage>,
@@ -71,7 +70,6 @@ namespace Screenbox.Core.ViewModels
         private readonly ISettingsService _settingsService;
         private readonly IResourceService _resourceService;
         private readonly IFilesService _filesService;
-        private readonly LastPositionTracker _lastPositionTracker;
         private IMediaPlayer? _mediaPlayer;
         private bool _visibilityOverride;
         private bool _resizeNext;
@@ -90,7 +88,6 @@ namespace Screenbox.Core.ViewModels
             _playPauseBadgeTimer = _dispatcherQueue.CreateTimer();
             _navigationViewDisplayMode = Messenger.Send<NavigationViewDisplayModeRequestMessage>();
             _playerVisibility = PlayerVisibilityState.Hidden;
-            _lastPositionTracker = new LastPositionTracker();
             _lastUpdated = DateTimeOffset.MinValue;
 
             FocusManager.GotFocus += FocusManagerOnFocusChanged;
@@ -132,19 +129,11 @@ namespace Screenbox.Core.ViewModels
             });
         }
 
-        public void Receive(SuspendingMessage message)
-        {
-            message.Reply(_lastPositionTracker.SaveToDiskAsync(_filesService));
-        }
-
-        public async void Receive(MediaPlayerChangedMessage message)
+        public void Receive(MediaPlayerChangedMessage message)
         {
             _mediaPlayer = message.Value;
             _mediaPlayer.PlaybackStateChanged += OnStateChanged;
-            _mediaPlayer.PositionChanged += OnPositionChanged;
             _mediaPlayer.NaturalVideoSizeChanged += OnNaturalVideoSizeChanged;
-
-            await _lastPositionTracker.LoadFromDiskAsync(_filesService);
         }
 
         public void Receive(UpdateVolumeStatusMessage message)
@@ -174,20 +163,6 @@ namespace Screenbox.Core.ViewModels
         public void Receive(PlaylistCurrentItemChangedMessage message)
         {
             _dispatcherQueue.TryEnqueue(() => ProcessOpeningMedia(message.Value));
-            if (message.Value != null)
-            {
-                TimeSpan lastPosition = _lastPositionTracker.GetPosition(message.Value.Location);
-                if (lastPosition <= TimeSpan.Zero) return;
-                if (_settingsService.RestorePlaybackPosition)
-                {
-                    // TODO: Wait until playback starts then send time change message
-                    Messenger.Send(new ChangeTimeRequestMessage(lastPosition, debounce: false));
-                }
-                else
-                {
-                    Messenger.Send(new RaiseResumePositionNotificationMessage(lastPosition));
-                }
-            }
         }
 
         public void Receive(ShowPlayPauseBadgeMessage message)
@@ -671,27 +646,6 @@ namespace Screenbox.Core.ViewModels
                     DelayHideControls();
                 }
             });
-        }
-
-        private void OnPositionChanged(IMediaPlayer sender, object? args)
-        {
-            // Only record position for media over 1 minute
-            // Update every 3 seconds
-            TimeSpan position = sender.Position;
-            if (Media == null || sender.NaturalDuration <= TimeSpan.FromMinutes(1) ||
-                DateTimeOffset.Now - _lastUpdated <= TimeSpan.FromSeconds(3))
-                return;
-
-            if (position > TimeSpan.FromSeconds(30) && position + TimeSpan.FromSeconds(10) < sender.NaturalDuration)
-            {
-                _lastUpdated = DateTimeOffset.Now;
-                _lastPositionTracker.UpdateLastPosition(Media.Location, position);
-            }
-            else if (position > TimeSpan.FromSeconds(5))
-            {
-                _lastUpdated = DateTimeOffset.Now;
-                _lastPositionTracker.RemovePosition(Media.Location);
-            }
         }
 
         private void OnNaturalVideoSizeChanged(IMediaPlayer sender, EventArgs args)

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -30,6 +30,7 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private bool _showRecent;
         [ObservableProperty] private int _theme;
         [ObservableProperty] private bool _enqueueAllFilesInFolder;
+        [ObservableProperty] private bool _restorePlaybackPosition;
         [ObservableProperty] private bool _searchRemovableStorage;
         [ObservableProperty] private bool _advancedMode;
         [ObservableProperty] private bool _useMultipleInstances;
@@ -80,6 +81,7 @@ namespace Screenbox.Core.ViewModels
             _showRecent = _settingsService.ShowRecent;
             _theme = ((int)_settingsService.Theme + 2) % 3;
             _enqueueAllFilesInFolder = _settingsService.EnqueueAllFilesInFolder;
+            _restorePlaybackPosition = _settingsService.RestorePlaybackPosition;
             _searchRemovableStorage = _settingsService.SearchRemovableStorage;
             _advancedMode = _settingsService.AdvancedMode;
             _useMultipleInstances = _settingsService.UseMultipleInstances;
@@ -152,6 +154,12 @@ namespace Screenbox.Core.ViewModels
         {
             _settingsService.EnqueueAllFilesInFolder = value;
             Messenger.Send(new SettingsChangedMessage(nameof(EnqueueAllFilesInFolder), typeof(SettingsPageViewModel)));
+        }
+
+        partial void OnRestorePlaybackPositionChanged(bool value)
+        {
+            _settingsService.RestorePlaybackPosition = value;
+            Messenger.Send(new SettingsChangedMessage(nameof(RestorePlaybackPosition), typeof(SettingsPageViewModel)));
         }
 
         async partial void OnSearchRemovableStorageChanged(bool value)

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -318,7 +318,8 @@
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="{strings:Resources Key=SettingsRestorePlaybackPositionDescription}"
-                    Header="{strings:Resources Key=SettingsRestorePlaybackPositionHeader}">
+                    Header="{strings:Resources Key=SettingsRestorePlaybackPositionHeader}"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xEF3B;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.RestorePlaybackPosition, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -315,6 +315,13 @@
                     <ToggleSwitch AutomationProperties.HelpText="{x:Bind SettingsEnqueueAllFilesInFolderCard.Description}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 
+                <ctc:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
+                    Description="Continue playing from where you last stopped when opening a file"
+                    Header="Always resume from last position">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.RestorePlaybackPosition, Mode=TwoWay}" />
+                </ctc:SettingsCard>
+
                 <!--  Player section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />
 

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -172,7 +172,7 @@
                     </interactivity:Interaction.Behaviors>
                     <Button
                         x:Name="AddMusicFolderButton"
-                        AutomationProperties.HelpText="{x:Bind AddMusicFolderButton.(ToolTipService.ToolTip)}"
+                        AutomationProperties.HelpText="{strings:Resources Key=AddMusicFolderToolTip}"
                         AutomationProperties.Name="{strings:Resources Key=AddFolder}"
                         Command="{x:Bind ViewModel.AddMusicFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}">
@@ -201,7 +201,7 @@
                     </interactivity:Interaction.Behaviors>
                     <Button
                         x:Name="AddVideoFolderButton"
-                        AutomationProperties.HelpText="{x:Bind AddVideoFolderButton.(ToolTipService.ToolTip)}"
+                        AutomationProperties.HelpText="{strings:Resources Key=AddVideoFolderToolTip}"
                         AutomationProperties.Name="{strings:Resources Key=AddFolder}"
                         Command="{x:Bind ViewModel.AddVideosFolderCommand}"
                         ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}">
@@ -312,7 +312,7 @@
                     Header="{strings:Resources Key=SettingsEnqueueAllFilesInFolderHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource FolderListGlyph}}">
-                    <ToggleSwitch AutomationProperties.HelpText="{x:Bind SettingsEnqueueAllFilesInFolderCard.Description}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
+                    <ToggleSwitch AutomationProperties.HelpText="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 
                 <ctc:SettingsCard
@@ -320,7 +320,7 @@
                     Description="{strings:Resources Key=SettingsRestorePlaybackPositionDescription}"
                     Header="{strings:Resources Key=SettingsRestorePlaybackPositionHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xEF3B;}">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.RestorePlaybackPosition, Mode=TwoWay}" />
+                    <ToggleSwitch AutomationProperties.HelpText="{strings:Resources Key=SettingsRestorePlaybackPositionDescription}" IsOn="{x:Bind ViewModel.RestorePlaybackPosition, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 
                 <!--  Player section  -->

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -317,8 +317,8 @@
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="Continue playing from where you last stopped when opening a file"
-                    Header="Always resume from last position">
+                    Description="{strings:Resources Key=SettingsRestorePlaybackPositionDescription}"
+                    Header="{strings:Resources Key=SettingsRestorePlaybackPositionHeader}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.RestorePlaybackPosition, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -3170,6 +3170,32 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region SettingsRestorePlaybackPositionHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: Always resume from last position
+        /// </summary>
+        public static string SettingsRestorePlaybackPositionHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsRestorePlaybackPositionHeader");
+            }
+        }
+        #endregion
+
+        #region SettingsRestorePlaybackPositionDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: Continue playing from where you last stopped when opening a file
+        /// </summary>
+        public static string SettingsRestorePlaybackPositionDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsRestorePlaybackPositionDescription");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -3423,6 +3449,8 @@ namespace Screenbox.Strings{
             SettingsThemeSelectionDescription,
             SettingsThemeSelectionHeader,
             SettingsCategoryPersonalization,
+            SettingsRestorePlaybackPositionHeader,
+            SettingsRestorePlaybackPositionDescription,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -911,4 +911,10 @@
   <data name="SettingsCategoryPersonalization" xml:space="preserve">
     <value>Personalization</value>
   </data>
+  <data name="SettingsRestorePlaybackPositionHeader" xml:space="preserve">
+    <value>Always resume from last position</value>
+  </data>
+  <data name="SettingsRestorePlaybackPositionDescription" xml:space="preserve">
+    <value>Continue playing from where you last stopped when opening a file</value>
+  </data>
 </root>


### PR DESCRIPTION
Closes #495

Add the ability to always resume from the last position when opening a previously played file. This PR also refactor `LastPositionTracker` to participate in dependency injection. The instance is now hosted by the `SeekBarViewModel` instead of the `PlayerPageViewModel`.