### PR TITLE
fix: various crashing exceptions

### DIFF
--- a/Screenbox.Core/Helpers/LastPositionTracker.cs
+++ b/Screenbox.Core/Helpers/LastPositionTracker.cs
@@ -75,7 +75,7 @@ namespace Screenbox.Core.Helpers
         {
             try
             {
-                await filesService.SaveToDiskAsync(ApplicationData.Current.TemporaryFolder, SaveFileName, _lastPositions);
+                await filesService.SaveToDiskAsync(ApplicationData.Current.TemporaryFolder, SaveFileName, _lastPositions.ToList());
             }
             catch (FileLoadException)
             {

--- a/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumDetailsPageViewModel.cs
@@ -18,13 +18,13 @@ namespace Screenbox.Core.ViewModels
         [NotifyPropertyChangedFor(nameof(Year))]
         [NotifyPropertyChangedFor(nameof(SongsCount))]
         [NotifyPropertyChangedFor(nameof(TotalDuration))]
-        private AlbumViewModel _source = null!;
+        private AlbumViewModel? _source;
 
-        public uint? Year => Source.Year;
+        public uint? Year => Source?.Year;
 
-        public int SongsCount => Source.RelatedSongs.Count;
+        public int SongsCount => Source?.RelatedSongs.Count ?? 0;
 
-        public TimeSpan TotalDuration => GetTotalDuration(Source.RelatedSongs);
+        public TimeSpan TotalDuration => Source != null ? GetTotalDuration(Source.RelatedSongs) : TimeSpan.Zero;
 
         public ObservableCollection<MediaViewModel> SortedItems { get; }
 
@@ -45,8 +45,15 @@ namespace Screenbox.Core.ViewModels
             };
         }
 
-        async partial void OnSourceChanged(AlbumViewModel value)
+        async partial void OnSourceChanged(AlbumViewModel? value)
         {
+            if (value == null)
+            {
+                SortedItems.Clear();
+                _itemList = null;
+                return;
+            }
+
             var sorted = value.RelatedSongs.OrderBy(m =>
                     m.MediaInfo.MusicProperties.TrackNumber != 0    // Track number should start with 1
                         ? m.MediaInfo.MusicProperties.TrackNumber
@@ -75,7 +82,7 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand]
         private void ShuffleAndPlay()
         {
-            if (Source.RelatedSongs.Count == 0) return;
+            if (Source == null || Source.RelatedSongs.Count == 0) return;
             Random rnd = new();
             List<MediaViewModel> shuffledList = Source.RelatedSongs.OrderBy(_ => rnd.Next()).ToList();
             Messenger.Send(new ClearPlaylistMessage());

--- a/Screenbox.Core/ViewModels/ArtistViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistViewModel.cs
@@ -22,16 +22,11 @@ namespace Screenbox.Core.ViewModels
 
         [ObservableProperty] private bool _isPlaying;
 
-        public ArtistViewModel()
-        {
-            Name = string.Empty;
-            RelatedSongs = new ObservableCollection<MediaViewModel>();
-            RelatedSongs.CollectionChanged += RelatedSongsOnCollectionChanged;
-        }
-
-        public ArtistViewModel(string artist) : this()
+        public ArtistViewModel(string artist)
         {
             Name = artist;
+            RelatedSongs = new ObservableCollection<MediaViewModel>();
+            RelatedSongs.CollectionChanged += RelatedSongsOnCollectionChanged;
         }
 
         public override string ToString()

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -260,6 +260,11 @@ namespace Screenbox.Core.ViewModels
             {
                 return null;
             }
+            catch (Exception e)
+            {
+                LogService.Log(e);
+                return null;
+            }
         }
     }
 }

--- a/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Core/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -103,7 +103,7 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
 
     public async Task NavigatePage(WebView2 webView)
     {
-        if (Source is null)
+        if (Source is null || webView.CoreWebView2 == null)
             return;
 
         if (string.IsNullOrEmpty(Source.Path) || string.IsNullOrEmpty(Source.Model.FileName))
@@ -189,7 +189,8 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
     // Ref: https://github.com/rocksdanister/lively/wiki/Web-Guide-V-:-System-Data#--system-nowplaying
     public async Task UpdateCurrentTrack(WebView2 webView)
     {
-        if (Source is null || Media == null || webView.CoreWebView2.IsSuspended || !Source.IsMusic)
+        if (Source is null || Media == null || webView.CoreWebView2 == null ||
+            webView.CoreWebView2.IsSuspended || !Source.IsMusic)
             return;
 
         var model = new LivelyMusicModel

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -113,12 +113,12 @@
                     SizeChanged="AlbumArt_OnSizeChanged"
                     Translation="0,0,16">
                     <Grid.Background>
-                        <ImageBrush ImageSource="{x:Bind ViewModel.Source.AlbumArt, Mode=OneWay}" Stretch="UniformToFill" />
+                        <ImageBrush ImageSource="{x:Bind ViewModel.Source.AlbumArt, Mode=OneWay, FallbackValue={x:Null}}" Stretch="UniformToFill" />
                     </Grid.Background>
                     <Border
                         Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                         CornerRadius="{x:Bind CoverArt.CornerRadius, Mode=OneWay}"
-                        Visibility="{x:Bind ViewModel.Source.AlbumArt, Mode=OneWay, Converter={StaticResource EmptyObjectToVisibilityConverter}, ConverterParameter=true}">
+                        Visibility="{x:Bind ViewModel.Source.AlbumArt, Mode=OneWay, Converter={StaticResource EmptyObjectToVisibilityConverter}, ConverterParameter=true, FallbackValue=Visible}">
                         <FontIcon
                             x:Name="CoverArtIcon"
                             FontSize="64"
@@ -134,7 +134,7 @@
                     <TextBlock
                         x:Name="TitleText"
                         Style="{StaticResource TitleMediumTextBlockStyle}"
-                        Text="{x:Bind ViewModel.Source.Name}"
+                        Text="{x:Bind ViewModel.Source.Name, FallbackValue={x:Null}}"
                         TextWrapping="NoWrap">
                         <interactivity:Interaction.Behaviors>
                             <interactions:OverflowTextToolTipBehavior />
@@ -146,7 +146,7 @@
                         Margin="0,8,0,0"
                         FontWeight="Normal"
                         Style="{StaticResource SubtitleTextBlockStyle}"
-                        Text="{x:Bind ViewModel.Source.ArtistName}"
+                        Text="{x:Bind ViewModel.Source.ArtistName, FallbackValue={x:Null}}"
                         TextWrapping="NoWrap">
                         <interactivity:Interaction.Behaviors>
                             <interactions:OverflowTextToolTipBehavior />

--- a/Screenbox/Pages/AlbumDetailsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml.cs
@@ -86,7 +86,7 @@ namespace Screenbox.Pages
 
             CreateHeaderAnimation(_props, scrollingProperties.Translation.Y);
 
-            if (ViewModel.Source.RelatedSongs.Count == 0) return;
+            if (ViewModel.Source == null || ViewModel.Source.RelatedSongs.Count == 0) return;
             MediaViewModel firstSong = ViewModel.Source.RelatedSongs[0];
             if (firstSong.Thumbnail != null)
             {

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -215,7 +215,7 @@
                     <TextBlock
                         x:Name="TitleText"
                         Style="{StaticResource TitleMediumTextBlockStyle}"
-                        Text="{x:Bind ViewModel.Source.Name}"
+                        Text="{x:Bind ViewModel.Source.Name, FallbackValue={x:Null}}"
                         TextWrapping="NoWrap">
                         <interactivity:Interaction.Behaviors>
                             <interactions:OverflowTextToolTipBehavior />

--- a/Screenbox/Pages/ArtistDetailsPage.xaml.cs
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
+﻿#nullable enable
+
+using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Animations.Expressions;
 using Screenbox.Core;


### PR DESCRIPTION
This pull request includes several changes to improve null safety and handle potential exceptions in the `Screenbox.Core` project.

- Ignore all MRU related exceptions
- Fix last position tracker uses the main storage list directly in an async save function. The list can change and cause enumeration exceptions.
- Better null handling for Artist and Album details pages
- Handle exception when trying to convert `Uri` into `StorageFile`
- Check for CoreWebView2 is initialized before accessing to avoid null exception
