### PR TITLE
feat: use SharedStorageAccessManager as a fallback for FutureAccessList

### DIFF
--- a/Screenbox.Core/ViewModels/MediaViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaViewModel.cs
@@ -208,7 +208,7 @@ namespace Screenbox.Core.ViewModels
             PlaybackItem? item = Item.Value;
             Item = new Lazy<PlaybackItem?>(CreatePlaybackItem);
             if (item == null) return;
-            LibVlcService.DisposeMedia(item.Media);
+            _libVlcService.DisposeMedia(item.Media);
         }
 
         public void UpdateSource(StorageFile file)


### PR DESCRIPTION
Since SharedStorageAccessManager does not work with network files. We can use the file path directly in those cases instead.