### PR TITLE
style: critical error panel redesign

### DIFF
--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -356,7 +356,6 @@
                 HorizontalScrollMode="Disabled">
                 <StackPanel>
                     <TextBlock
-                        x:Name="CriticalErrorDescription"
                         MaxWidth="768"
                         HorizontalAlignment="Left"
                         d:Text="{strings:Resources Key=CriticalErrorDirect3D11NotAvailable}"
@@ -394,7 +393,7 @@
                                 AutomationProperties.AccessibilityView="Content"
                                 FontWeight="SemiLight"
                                 Style="{StaticResource SubtitleTextBlockStyle}">
-                                <Run Text="For more information about this issue and possible fixes, visit" /><LineBreak />
+                                <Run Text="{strings:Resources Key=CriticalErrorMoreInformation}" /><LineBreak />
                                 <Hyperlink NavigateUri="https://github.com/huynhsontung/Screenbox">https://github.com/huynhsontung/Screenbox</Hyperlink>
                             </TextBlock>
 

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -333,29 +333,81 @@
             </interactivity:Interaction.Behaviors>
         </controls:CustomNavigationView>
 
+        <!--  Critical error  -->
         <Grid
-            x:Name="CriticalErrorPanel"
-            Padding="80,80"
+            x:Name="CriticalErrorGrid"
+            Margin="0,32,0,0"
             Visibility="Collapsed">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
             <TextBlock
-                Grid.Column="0"
-                Margin="0,0,40,0"
-                FontSize="90"
+                Padding="{StaticResource ContentPagePadding}"
+                FontSize="{StaticResource NoContentPanelIconFontSize}"
+                FontWeight="SemiLight"
                 Text=":(" />
-            <TextBlock
-                Grid.Column="1"
-                Margin="0,40,0,0"
-                FontSize="20"
-                TextWrapping="Wrap">
-                <Run
-                    FontSize="24"
-                    FontWeight="Bold"
-                    Text="{strings:Resources Key=CriticalError}" /><LineBreak /><Run Text="{x:Bind ViewModel.CriticalErrorMessage, Mode=OneWay}" />
-            </TextBlock>
+
+            <ScrollViewer
+                Grid.Row="1"
+                Margin="{StaticResource TopLargeMargin}"
+                Padding="{StaticResource ContentPagePadding}"
+                HorizontalScrollMode="Disabled">
+                <StackPanel>
+                    <TextBlock
+                        x:Name="CriticalErrorDescription"
+                        MaxWidth="768"
+                        HorizontalAlignment="Left"
+                        d:Text="{strings:Resources Key=CriticalErrorDirect3D11NotAvailable}"
+                        AutomationProperties.AccessibilityView="Content"
+                        AutomationProperties.LiveSetting="Assertive"
+                        FontWeight="Light"
+                        Style="{StaticResource TitleMediumTextBlockStyle}"
+                        Text="{x:Bind ViewModel.CriticalErrorMessage, Mode=OneWay}" />
+
+                    <Grid Grid.Row="1" Margin="0,48,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border
+                            Width="148"
+                            Height="148"
+                            Margin="0,0,16,0"
+                            VerticalAlignment="Top"
+                            Background="{ThemeResource SystemControlBackgroundChromeWhiteBrush}">
+                            <Path
+                                Data="M16,18 H44 M48,18 H56 M60,18 H68 M80,18 H100 M104,18 H132 M16,22 H20 M40,22 H44 M48,22 H56 M80,22 H84 M88,22 H92 M104,22 H108 M128,22 H132 M16,26 H20 M24,26 H36 M40,26 H44 M52,26 H76 M92,26 H96 M104,26 H108 M112,26 H124 M128,26 H132 M16,30 H20 M24,30 H36 M40,30 H44 M48,30 H52 M68,30 H80 M84,30 H88 M92,30 H100 M104,30 H108 M112,30 H124 M128,30 H132 M16,34 H20 M24,34 H36 M40,34 H44 M56,34 H60 M68,34 H84 M92,34 H96 M104,34 H108 M112,34 H124 M128,34 H132 M16,38 H20 M40,38 H44 M52,38 H56 M64,38 H68 M72,38 H76 M80,38 H84 M92,38 H100 M104,38 H108 M128,38 H132 M16,42 H44 M48,42 H52 M56,42 H60 M64,42 H68 M72,42 H76 M80,42 H84 M88,42 H92 M96,42 H100 M104,42 H132 M48,46 H52 M60,46 H64 M72,46 H80 M84,46 H88 M16,50 H20 M24,50 H32 M36,50 H48 M60,50 H68 M72,50 H76 M84,50 H100 M104,50 H108 M116,50 H120 M124,50 H132 M16,54 H20 M28,54 H36 M48,54 H56 M80,54 H84 M92,54 H100 M104,54 H116 M128,54 H132 M20,58 H24 M32,58 H44 M48,58 H56 M64,58 H76 M80,58 H84 M96,58 H104 M108,58 H112 M120,58 H128 M16,62 H20 M24,62 H40 M56,62 H72 M76,62 H84 M88,62 H96 M100,62 H108 M112,62 H116 M128,62 H132 M36,66 H44 M48,66 H64 M68,66 H80 M84,66 H88 M92,66 H96 M116,66 H124 M20,70 H24 M28,70 H40 M44,70 H48 M52,70 H64 M68,70 H84 M92,70 H96 M104,70 H108 M120,70 H132 M16,74 H24 M32,74 H36 M40,74 H44 M52,74 H56 M60,74 H68 M72,74 H76 M84,74 H100 M104,74 H108 M120,74 H132 M28,78 H32 M36,78 H40 M44,78 H68 M72,78 H76 M92,78 H116 M124,78 H128 M28,82 H44 M48,82 H52 M68,82 H72 M80,82 H84 M88,82 H100 M112,82 H120 M124,82 H128 M20,86 H24 M28,86 H32 M48,86 H56 M72,86 H76 M84,86 H88 M108,86 H112 M116,86 H128 M16,90 H20 M28,90 H32 M40,90 H48 M52,90 H56 M76,90 H88 M96,90 H100 M104,90 H116 M120,90 H124 M36,94 H40 M44,94 H48 M60,94 H68 M72,94 H88 M104,94 H116 M120,94 H124 M20,98 H52 M64,98 H72 M76,98 H92 M96,98 H124 M48,102 H56 M60,102 H64 M68,102 H72 M96,102 H100 M112,102 H132 M16,106 H44 M48,106 H56 M64,106 H72 M80,106 H100 M104,106 H108 M112,106 H120 M124,106 H128 M16,110 H20 M40,110 H44 M48,110 H52 M56,110 H64 M76,110 H80 M96,110 H100 M112,110 H120 M124,110 H132 M16,114 H20 M24,114 H36 M40,114 H44 M52,114 H68 M72,114 H80 M84,114 H88 M96,114 H116 M120,114 H132 M16,118 H20 M24,118 H36 M40,118 H44 M48,118 H52 M64,118 H96 M100,118 H104 M108,118 H120 M128,118 H132 M16,122 H20 M24,122 H36 M40,122 H44 M48,122 H72 M80,122 H84 M88,122 H92 M96,122 H100 M108,122 H112 M120,122 H124 M128,122 H132 M16,126 H20 M40,126 H44 M60,126 H64 M68,126 H76 M80,126 H84 M96,126 H104 M108,126 H112 M116,126 H120 M124,126 H128 M16,130 H44 M48,130 H56 M72,130 H80 M88,130 H108 M124,130 H128"
+                                Stroke="#0078D7"
+                                StrokeThickness="4" />
+                        </Border>
+
+                        <Grid Grid.Column="1">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <TextBlock
+                                AutomationProperties.AccessibilityView="Content"
+                                FontWeight="SemiLight"
+                                Style="{StaticResource SubtitleTextBlockStyle}">
+                                <Run Text="For more information about this issue and possible fixes, visit" /><LineBreak />
+                                <Hyperlink NavigateUri="https://github.com/huynhsontung/Screenbox">https://github.com/huynhsontung/Screenbox</Hyperlink>
+                            </TextBlock>
+
+                            <TextBlock
+                                Grid.Row="1"
+                                Margin="{StaticResource TopMediumMargin}"
+                                VerticalAlignment="Bottom"
+                                Style="{StaticResource BodyTextBlockStyle}"
+                                Text="{strings:Resources Key=CriticalError}" />
+                        </Grid>
+                    </Grid>
+                </StackPanel>
+            </ScrollViewer>
         </Grid>
 
         <VisualStateManager.VisualStateGroups>
@@ -375,8 +427,12 @@
                         <StateTrigger IsActive="{x:Bind ViewModel.HasCriticalError, Mode=OneWay}" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="AppTitleBar.Height" Value="32" />
+                        <Setter Target="TitleBarElement.Margin" Value="0" />
+                        <Setter Target="AppTitle.Margin" Value="16,0,0,0" />
+                        <Setter Target="AppTitleText.Margin" Value="16,0,0,2" />
                         <Setter Target="NavView.Visibility" Value="Collapsed" />
-                        <Setter Target="CriticalErrorPanel.Visibility" Value="Visible" />
+                        <Setter Target="CriticalErrorGrid.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -2235,6 +2235,19 @@ namespace Screenbox.Strings{
         }
         #endregion
 
+        #region CriticalErrorMoreInformation
+        /// <summary>
+        ///   Looks up a localized string similar to: For more information about this issue and possible fixes, visit
+        /// </summary>
+        public static string CriticalErrorMoreInformation
+        {
+            get
+            {
+                return _resourceLoader.GetString("CriticalErrorMoreInformation");
+            }
+        }
+        #endregion
+
         #region FailedToOpenFilesNotificationTitle
         /// <summary>
         ///   Looks up a localized string similar to: Failed to open file(s)
@@ -3273,6 +3286,7 @@ namespace Screenbox.Strings{
             SubtitleAddedNotificationTitle,
             CriticalError,
             CriticalErrorDirect3D11NotAvailable,
+            CriticalErrorMoreInformation,
             FailedToOpenFilesNotificationTitle,
             OpenUrlPlaceholder,
             OpenConnectedDevicesSettingsButtonText,

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -694,6 +694,9 @@
   <data name="CriticalErrorDirect3D11NotAvailable" xml:space="preserve">
     <value>No compatible renderer available. Please make sure Direct3D 11 is available on your device.</value>
   </data>
+  <data name="CriticalErrorMoreInformation" xml:space="preserve">
+    <value>For more information about this issue and possible fixes, visit</value>
+  </data>
   <data name="FailedToOpenFilesNotificationTitle" xml:space="preserve">
     <value>Failed to open file(s)</value>
   </data>


### PR DESCRIPTION
Changes the design of the critical error panel to resemble the BSOD.

Edit: Mockup added
<img width="1328" alt="Page with critical error grid" src="https://github.com/user-attachments/assets/083dc407-f1d6-4d4b-a88a-11ebeb902644" />
