### PR TITLE
style: minor UI fixes and optimizations

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -13,7 +13,6 @@
         <muxc:XamlControlsResources>
             <muxc:XamlControlsResources.MergedDictionaries>
                 <ResourceDictionary>
-
                     <!--  Brushes  -->
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Default">
@@ -97,6 +96,10 @@
                             Duration="{StaticResource ControlFasterAnimationDuration}" />
                     </ctAnimations:ImplicitAnimationSet>
 
+                    <!--  Shadow  -->
+                    <ThemeShadow x:Key="ElevationThemeShadow" />
+
+                    <!--  Styles  -->
                     <Style
                         x:Key="TitleMediumTextBlockStyle"
                         BasedOn="{StaticResource BaseTextBlockStyle}"
@@ -122,7 +125,6 @@
                                 TextWrapping="NoWrap" />
                         </Button>
                     </DataTemplate>
-
                 </ResourceDictionary>
 
                 <ResourceDictionary Source="ms-appx:///Styles/Button.xaml" />

--- a/Screenbox/Controls/CompositeTrackPicker.xaml
+++ b/Screenbox/Controls/CompositeTrackPicker.xaml
@@ -123,7 +123,7 @@
                                     <SolidColorBrush x:Key="SubtleButtonForegroundPressed" Color="{ThemeResource TextFillColorPrimary}" />
                                 </ResourceDictionary>
                                 <ResourceDictionary x:Key="HighContrast">
-                                    <StaticResource x:Key="SubtleButtonForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+                                    <SolidColorBrush x:Key="SubtleButtonForegroundPressed" Color="{ThemeResource SystemColorHighlightTextColor}" />
                                 </ResourceDictionary>
                             </ResourceDictionary.ThemeDictionaries>
                         </ResourceDictionary>

--- a/Screenbox/Controls/NotificationView.xaml.cs
+++ b/Screenbox/Controls/NotificationView.xaml.cs
@@ -17,7 +17,7 @@ namespace Screenbox.Controls
         {
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<NotificationViewModel>();
-            InfoBar.Translation = new Vector3(0, 0, 8);
+            InfoBar.Translation = new Vector3(0, 0, 16);
         }
 
         private InfoBarSeverity ConvertInfoBarSeverity(NotificationLevel level)

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -105,7 +105,7 @@
             Orientation="Horizontal">
             <Button
                 x:Name="AddFilesButton"
-                Margin="0,0,12,0"
+                Margin="0,0,8,0"
                 AccessKey="{strings:KeyboardResources Key=CommandAddOpenFilesKey}"
                 AutomationProperties.Name="{strings:Resources Key=AddFiles}"
                 Command="{x:Bind ViewModel.AddFilesCommand}"
@@ -121,7 +121,7 @@
 
             <Button
                 x:Name="ClearButton"
-                Margin="0,0,12,0"
+                Margin="0,0,8,0"
                 AccessKey="{strings:KeyboardResources Key=CommandClearKey}"
                 AutomationProperties.Name="{x:Bind ClearButtonLabel.Text}"
                 Command="{x:Bind ViewModel.Playlist.ClearCommand}"

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -27,8 +27,6 @@
                     <ResourceDictionary Source="ms-appx:///Styles/CommandBar.xaml" />
                 </ResourceDictionary.MergedDictionaries>
 
-                <ThemeShadow x:Name="SharedShadow" />
-
                 <ctConverters:BoolToObjectConverter
                     x:Key="BoolToSelectAllNoneToolTipTextConverter"
                     FalseValue="{strings:Resources Key=SelectAllToolTip}"
@@ -175,7 +173,7 @@
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 BorderThickness="{StaticResource CommandBarFlyoutBorderThemeThickness}"
                 CornerRadius="{StaticResource OverlayCornerRadius}"
-                Shadow="{StaticResource SharedShadow}"
+                Shadow="{StaticResource ElevationThemeShadow}"
                 Translation="0,0,32" />
             <CommandBar
                 x:Name="SelectionCommandBar"

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -23,8 +23,6 @@
                 <ResourceDictionary Source="ms-appx:///Styles/CommandBar.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <ThemeShadow x:Name="SharedShadow" />
-
             <MenuFlyout x:Name="ItemFlyout">
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.PlayCommand}"
@@ -89,7 +87,7 @@
                 Fill="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
                 RadiusX="8"
                 RadiusY="12"
-                Shadow="{StaticResource SharedShadow}"
+                Shadow="{StaticResource ElevationThemeShadow}"
                 Stroke="{ThemeResource ControlElevationBorderBrush}"
                 StrokeThickness="1"
                 Translation="0,0,32" />
@@ -110,7 +108,7 @@
                     BorderThickness="1"
                     CornerRadius="{StaticResource OverlayCornerRadius}"
                     FlowDirection="LeftToRight"
-                    Shadow="{StaticResource SharedShadow}"
+                    Shadow="{StaticResource ElevationThemeShadow}"
                     SizeChanged="AlbumArt_OnSizeChanged"
                     Translation="0,0,16">
                     <Grid.Background>

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -23,8 +23,6 @@
                 <ResourceDictionary Source="ms-appx:///Styles/CommandBar.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <ThemeShadow x:Name="SharedShadow" />
-
             <CollectionViewSource
                 x:Name="AlbumSource"
                 IsSourceGrouped="True"
@@ -45,7 +43,7 @@
                             BorderThickness="1"
                             CornerRadius="{StaticResource ControlCornerRadius}"
                             FlowDirection="LeftToRight"
-                            Shadow="{StaticResource SharedShadow}"
+                            Shadow="{StaticResource ElevationThemeShadow}"
                             Translation="0,0,8">
                             <Grid.Background>
                                 <ImageBrush ImageSource="{Binding Key.AlbumArt}" Stretch="UniformToFill" />
@@ -178,7 +176,7 @@
                 Fill="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
                 RadiusX="8"
                 RadiusY="12"
-                Shadow="{StaticResource SharedShadow}"
+                Shadow="{StaticResource ElevationThemeShadow}"
                 Stroke="{ThemeResource ControlElevationBorderBrush}"
                 StrokeThickness="1"
                 Translation="0,0,32" />
@@ -199,7 +197,7 @@
                     BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}"
                     BorderThickness="1"
                     CornerRadius="96"
-                    Shadow="{StaticResource SharedShadow}"
+                    Shadow="{StaticResource ElevationThemeShadow}"
                     SizeChanged="ProfilePicture_OnSizeChanged"
                     Translation="0,0,16">
                     <FontIcon

--- a/Screenbox/Pages/HomePage.xaml.cs
+++ b/Screenbox/Pages/HomePage.xaml.cs
@@ -36,7 +36,7 @@ namespace Screenbox.Pages
         private void HomePage_OnDragOver(object sender, DragEventArgs e)
         {
             e.AcceptedOperation = DataPackageOperation.Link;
-            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Open;
+            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
         }
 
         private async void HomePage_OnDrop(object sender, DragEventArgs e)

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -365,6 +365,7 @@
                 <VisualState x:Name="Deactivated">
                     <VisualState.Setters>
                         <Setter Target="AppTitleText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                        <Setter Target="NavView.IsBackEnabled" Value="False" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -130,8 +130,6 @@
                     <TextBlock Margin="8,0,0,0" Text="{Binding Name}" />
                 </StackPanel>
             </DataTemplate>
-
-            <ThemeShadow x:Key="SharedShadow" />
         </ResourceDictionary>
     </Page.Resources>
 
@@ -325,7 +323,7 @@
                     Margin="10,0,10,16"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
-                    Shadow="{StaticResource SharedShadow}" />
+                    Shadow="{StaticResource ElevationThemeShadow}" />
             </Grid>
 
             <interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -53,7 +53,7 @@ namespace Screenbox.Pages
             //Register a handler for when the window changes focus
             Window.Current.CoreWindow.Activated += CoreWindow_Activated;
 
-            NotificationView.Translation = new Vector3(0, 0, 8);
+            NotificationView.Translation = new Vector3(0, 0, 16);
 
             _pages = new Dictionary<string, Type>
             {

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -451,7 +451,7 @@
                 BorderThickness="1"
                 CornerRadius="{StaticResource OverlayCornerRadius}"
                 FlowDirection="LeftToRight"
-                Shadow="{StaticResource SharedShadow}"
+                Shadow="{StaticResource ElevationThemeShadow}"
                 Translation="0,0,32">
                 <Grid.Background>
                     <ImageBrush
@@ -861,7 +861,7 @@
                         <Setter Target="LayoutRoot.Height" Value="128" />
                         <Setter Target="LayoutRoot.Padding" Value="8,8,8,8" />
                         <Setter Target="LayoutRoot.VerticalAlignment" Value="Bottom" />
-                        <Setter Target="LayoutRoot.Shadow" Value="{StaticResource SharedShadow}" />
+                        <Setter Target="LayoutRoot.Shadow" Value="{StaticResource ElevationThemeShadow}" />
                         <Setter Target="SecondColumn.Width" Value="*" />
                         <Setter Target="HeaderBackground.Visibility" Value="Collapsed" />
                         <Setter Target="TitleBarArea.(Grid.Column)" Value="1" />
@@ -904,7 +904,7 @@
                         <Setter Target="LayoutRoot.Height" Value="0" />
                         <Setter Target="LayoutRoot.Padding" Value="8,8,8,8" />
                         <Setter Target="LayoutRoot.VerticalAlignment" Value="Bottom" />
-                        <Setter Target="LayoutRoot.Shadow" Value="{StaticResource SharedShadow}" />
+                        <Setter Target="LayoutRoot.Shadow" Value="{StaticResource ElevationThemeShadow}" />
                         <Setter Target="SecondColumn.Width" Value="*" />
                         <Setter Target="HeaderBackground.Visibility" Value="Collapsed" />
                         <Setter Target="TitleBarArea.(Grid.Column)" Value="1" />

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -489,7 +489,7 @@ namespace Screenbox.Pages
         private void OnDragOver(object sender, DragEventArgs e)
         {
             e.AcceptedOperation = DataPackageOperation.Link;
-            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Open;
+            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
         }
     }
 }

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -30,8 +30,6 @@
         <!--<x:Double x:Key="SettingsCardActionIconMaxSize">14</x:Double>-->
         <Thickness x:Key="SettingsCardMargin">0,0,0,4</Thickness>
 
-        <ThemeShadow x:Name="SharedShadow" />
-
         <converters:ResourceNameToResourceStringConverter x:Key="ResourceNameToResourceStringConverter" />
 
         <!--  Section header text style  -->
@@ -517,7 +515,7 @@
             IsOpen="{x:Bind ViewModel.IsRelaunchRequired, Mode=OneWay}"
             Message="{strings:Resources Key=RelaunchForChangesMessage}"
             Severity="Warning"
-            Shadow="{StaticResource SharedShadow}">
+            Shadow="{StaticResource ElevationThemeShadow}">
             <muxc:InfoBar.Transitions>
                 <TransitionCollection>
                     <RepositionThemeTransition />

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -26,7 +26,7 @@ namespace Screenbox.Pages
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<SettingsPageViewModel>();
             Common = Ioc.Default.GetRequiredService<CommonViewModel>();
-            PendingChangesInfoBar.Translation = new Vector3(0, 0, 8);
+            PendingChangesInfoBar.Translation = new Vector3(0, 0, 16);
 
             VlcCommandLineHelpTextParts = new string[2];
             string[] parts = Strings.Resources.VlcCommandLineHelpText

--- a/Screenbox/Styles/Button.xaml
+++ b/Screenbox/Styles/Button.xaml
@@ -62,14 +62,20 @@
 
     <!--  Subtle Button according to the Windows UI 3 design guidelines  -->
     <!--  https://github.com/microsoft/microsoft-ui-xaml/blob/v2.8.6/dev/CommonStyles/Button_themeresources.xaml  -->
-    <Style
-        x:Key="SubtleButtonStyle"
-        BasedOn="{StaticResource DefaultButtonStyle}"
-        TargetType="Button">
+    <Style x:Key="SubtleButtonStyle" TargetType="Button">
         <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />
-        <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+        <!--<Setter Property="BackgroundSizing" Value="InnerBorderEdge" />-->
         <Setter Property="Foreground" Value="{ThemeResource SubtleButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SubtleButtonBorderBrush}" />
+        <!--<Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />-->
+        <!--<Setter Property="Padding" Value="{StaticResource ButtonPadding}" />-->
+        <!--<Setter Property="HorizontalAlignment" Value="Left" />-->
+        <!--<Setter Property="VerticalAlignment" Value="Center" />-->
+        <!--<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />-->
+        <!--<Setter Property="FontWeight" Value="Normal" />-->
+        <!--<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />-->
+        <!--<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />-->
+        <!--<Setter Property="FocusVisualMargin" Value="-3" />-->
         <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -175,16 +181,23 @@
         <Setter Property="Padding" Value="0" />
     </Style>
 
-    <!--  Subtle ToggleButton according to the Windows UI 3 design guidelines, except for the Checked states where the subtle resources were applied  -->
+    <!--  Subtle ToggleButton according to the Windows UI 3 design guidelines, except for the checked states where the subtle resources were applied  -->
     <!--  https://github.com/microsoft/microsoft-ui-xaml/blob/v2.8.6/dev/CommonStyles/ToggleButton_themeresources.xaml  -->
-    <Style
-        x:Key="SubtleToggleButtonStyle"
-        BasedOn="{StaticResource DefaultToggleButtonStyle}"
-        TargetType="ToggleButton">
+    <Style x:Key="SubtleToggleButtonStyle" TargetType="ToggleButton">
         <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />
-        <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+        <!--<Setter Property="BackgroundSizing" Value="InnerBorderEdge" />-->
         <Setter Property="Foreground" Value="{ThemeResource SubtleButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SubtleButtonBorderBrush}" />
+        <!--<Setter Property="BorderThickness" Value="{ThemeResource ToggleButtonBorderThemeThickness}" />-->
+        <!--<Setter Property="Padding" Value="{StaticResource ButtonPadding}" />-->
+        <!--<Setter Property="HorizontalAlignment" Value="Left" />-->
+        <!--<Setter Property="VerticalAlignment" Value="Center" />-->
+        <!--<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />-->
+        <!--<Setter Property="FontWeight" Value="Normal" />-->
+        <!--<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />-->
+        <!--<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />-->
+        <!--<Setter Property="FocusVisualMargin" Value="-3" />-->
+        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">

--- a/Screenbox/Styles/ItemContainer.xaml
+++ b/Screenbox/Styles/ItemContainer.xaml
@@ -42,8 +42,8 @@
             <StaticResource x:Key="MediaListViewHeaderItemForegroundPointerOver" ResourceKey="AccentTextFillColorSecondaryBrush" />
             <StaticResource x:Key="MediaListViewHeaderItemForegroundPressed" ResourceKey="AccentTextFillColorTertiaryBrush" />
             <StaticResource x:Key="MediaListViewHeaderItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="MediaListViewHeaderItemBorderBrushPointerOver" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="MediaListViewHeaderItemBorderBrushPressed" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="MediaListViewHeaderItemBorderBrushPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="MediaListViewHeaderItemBorderBrushPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <x:Double x:Key="TextFillColorSecondaryOpacity">1</x:Double>


### PR DESCRIPTION
- Fixes `CompositeTrackPicker` add subtitle button foreground brush for high contrast
- Fixes media group header border brush on light mode
- Disables the back button when the window is not active, according to the design documentation
- Combines and moves `ThemeShadow` resources to the app resources
- Replaces the drag UI caption verb from 'Open' to 'Play'