### PR TITLE
feat: enrich Sentry error reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,16 +80,16 @@ jobs:
         SENTRY_ORG: starpine
         SENTRY_PROJECT: screenbox
         SENTRY_URL: sentry.starpine.dev
-        SENTRY_RELEASE : ${{ steps.get-tag-version.outputs.version }}
+        SENTRY_RELEASE : screenbox@${{ steps.get-tag-version.outputs.version }}
       run: |
         $sentryArgs = ""
         if ('${{ github.ref_type }}' -eq 'tag') {
           $sentryArgs = "-p:SentryUploadSymbols=true ` 
-                        -p:SentryCreateRelease=true ` 
                         -p:SentryOrg=$env:SENTRY_ORG ` 
                         -p:SentryProject=$env:SENTRY_PROJECT ` 
                         -p:SentryUrl=$env:SENTRY_URL `
                         -p:SentryAuthToken='${{ secrets.SENTRY_AUTH_TOKEN }}' ` 
+                        -p:SentryCreateRelease=true ` 
                         -p:SentrySetCommits=true"
         }
         msbuild Screenbox.sln `

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,23 +73,37 @@ jobs:
       run: .\scripts\update-manifest.ps1 -Version "${{ steps.get-tag-version.outputs.version }}"
       
     - name: Build store package
-      run: |
-        msbuild Screenbox.sln `
-        -v:d `
-        -p:RestoreConfigFile=nuget.config `
-        -p:RestoreLockedMode=true `
-        -p:Configuration=Release `
-        -p:Platform=x64 `
-        -p:AppxBundle=Always `
-        -p:AppxBundlePlatforms="$env:BuildPlatforms" `
-        -p:UapAppxPackageBuildMode=$env:BuildMode `
-        -p:AppxPackageDir=$env:PackageDir `
-        -p:AppxPackageSigningEnabled=false `
-        -restore
       env:
         BuildMode: StoreUpload
         BuildPlatforms: x86|x64|arm64
         PackageDir: C:\DeployOutput
+        SENTRY_ORG: starpine
+        SENTRY_PROJECT: screenbox
+        SENTRY_URL: sentry.starpine.dev
+        SENTRY_RELEASE : ${{ steps.get-tag-version.outputs.version }}
+      run: |
+        $sentryArgs = ""
+        if ('${{ github.ref_type }}' -eq 'tag') {
+          $sentryArgs = "-p:SentryUploadSymbols=true ` 
+                        -p:SentryCreateRelease=true ` 
+                        -p:SentryOrg=$env:SENTRY_ORG ` 
+                        -p:SentryProject=$env:SENTRY_PROJECT ` 
+                        -p:SentryUrl=$env:SENTRY_URL `
+                        -p:SentryAuthToken='${{ secrets.SENTRY_AUTH_TOKEN }}' ` 
+                        -p:SentrySetCommits=true"
+        }
+        msbuild Screenbox.sln `
+          -v:d `
+          -p:RestoreConfigFile=nuget.config `
+          -p:RestoreLockedMode=true `
+          -p:Configuration=Release `
+          -p:Platform=x64 `
+          -p:AppxBundle=Always `
+          -p:AppxBundlePlatforms="$env:BuildPlatforms" `
+          -p:UapAppxPackageBuildMode=$env:BuildMode `
+          -p:AppxPackageDir=$env:PackageDir `
+          -p:AppxPackageSigningEnabled=false $sentryArgs `
+          -restore
     
     - name: Create store-upload artifact
       uses: actions/upload-artifact@v4

--- a/Screenbox.Core/ViewModels/CastControlViewModel.cs
+++ b/Screenbox.Core/ViewModels/CastControlViewModel.cs
@@ -2,10 +2,10 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.AppCenter.Analytics;
 using Screenbox.Core.Events;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
+using Sentry;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Windows.System;
@@ -52,16 +52,16 @@ namespace Screenbox.Core.ViewModels
         private void Cast()
         {
             if (SelectedRenderer == null) return;
-            _castService.SetActiveRenderer(SelectedRenderer);
-            CastingDevice = SelectedRenderer;
-            IsCasting = true;
-            Analytics.TrackEvent("StartCasting", new Dictionary<string, string>
+            SentrySdk.AddBreadcrumb("Start casting", category: "command", type: "user", data: new Dictionary<string, string>
             {
                 {"rendererHash", SelectedRenderer.Name.GetHashCode().ToString()},
-                {"type", SelectedRenderer.Type},
+                {"rendererType", SelectedRenderer.Type},
                 {"canRenderAudio", SelectedRenderer.CanRenderAudio.ToString()},
                 {"canRenderVideo", SelectedRenderer.CanRenderVideo.ToString()},
             });
+            _castService.SetActiveRenderer(SelectedRenderer);
+            CastingDevice = SelectedRenderer;
+            IsCasting = true;
         }
 
         private bool CanCast() => SelectedRenderer is { IsAvailable: true };
@@ -69,10 +69,10 @@ namespace Screenbox.Core.ViewModels
         [RelayCommand]
         private void StopCasting()
         {
+            SentrySdk.AddBreadcrumb("Stop casting", category: "command", type: "user");
             _castService.SetActiveRenderer(null);
             IsCasting = false;
             StartDiscovering();
-            Analytics.TrackEvent("StopCasting");
         }
 
         private void CastServiceOnRendererLost(object sender, RendererLostEventArgs e)

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -4,13 +4,13 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using LibVLCSharp.Shared;
-using Microsoft.AppCenter.Analytics;
 using Screenbox.Core.Factories;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
+using Sentry;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -318,6 +318,13 @@ namespace Screenbox.Core.ViewModels
 
         async partial void OnCurrentItemChanged(MediaViewModel? value)
         {
+            SentrySdk.AddBreadcrumb("Play queue current item changed", data: value != null
+                ? new Dictionary<string, string>
+                {
+                    { "MediaType", value.MediaType.ToString() }
+                }
+                : null);
+
             switch (value?.Source)
             {
                 case StorageFile file:
@@ -340,12 +347,6 @@ namespace Screenbox.Core.ViewModels
             Messenger.Send(new PlaylistCurrentItemChangedMessage(value));
             await _transportControlsService.UpdateTransportControlsDisplayAsync(value);
             await UpdateMediaBufferAsync();
-            Analytics.TrackEvent("PlaylistCurrentItemChanged", value != null
-                ? new Dictionary<string, string>
-                {
-                    { "MediaType", value.MediaType.ToString() }
-                }
-                : null);
         }
 
         partial void OnRepeatModeChanged(MediaPlaybackAutoRepeatMode value)

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -186,6 +186,11 @@ namespace Screenbox
 
         protected override void OnFileActivated(FileActivatedEventArgs args)
         {
+            SentrySdk.AddBreadcrumb("File activated", category: "activation", type: "user", data: new Dictionary<string, string>
+            {
+                { "PreviousExecutionState", args.PreviousExecutionState.ToString() }
+            });
+
             Frame rootFrame = InitRootFrame();
             if (rootFrame.Content is not MainPage)
             {
@@ -194,10 +199,6 @@ namespace Screenbox
 
             Window.Current.Activate();
             WeakReferenceMessenger.Default.Send(new PlayFilesMessage(args.Files, args.NeighboringFilesQuery));
-            Analytics.TrackEvent("FileActivated", new Dictionary<string, string>
-            {
-                { "PreviousExecutionState", args.PreviousExecutionState.ToString() }
-            });
         }
 
         /// <summary>
@@ -207,6 +208,12 @@ namespace Screenbox
         /// <param name="e">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
+            SentrySdk.AddBreadcrumb("Launched", category: "lifecycle", data: new Dictionary<string, string>
+            {
+                { "PrelaunchActivated", e.PrelaunchActivated.ToString() },
+                { "PreviousExecutionState", e.PreviousExecutionState.ToString() }
+            });
+
             Frame rootFrame = InitRootFrame();
             LibVLCSharp.Shared.Core.Initialize();
 
@@ -254,8 +261,8 @@ namespace Screenbox
         private async void OnSuspending(object sender, SuspendingEventArgs e)
         {
             SuspendingDeferral deferral = e.SuspendingOperation.GetDeferral();
+            SentrySdk.AddBreadcrumb("Suspending", category: "lifecycle");
             IReadOnlyCollection<Task> tasks = WeakReferenceMessenger.Default.Send<SuspendingMessage>().Responses;
-            Analytics.TrackEvent("Suspending");
             await Task.WhenAll(tasks);
             await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
             deferral.Complete();

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -1,8 +1,11 @@
 ﻿#nullable enable
 
 using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.WinUI.Helpers;
 using LibVLCSharp.Shared;
+using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
+using Microsoft.AppCenter.Crashes;
 using Microsoft.Extensions.DependencyInjection;
 using Screenbox.Controls;
 using Screenbox.Core;
@@ -25,12 +28,6 @@ using Windows.ApplicationModel.Resources.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-
-#if !DEBUG
-using CommunityToolkit.WinUI.Helpers;
-using Microsoft.AppCenter;
-using Microsoft.AppCenter.Crashes;
-#endif
 
 namespace Screenbox
 {
@@ -164,24 +161,21 @@ namespace Screenbox
 
         private static void ConfigureAppCenter()
         {
-#if !DEBUG
-            AppCenter.Start(Secrets.AppCenterApiKey,
-                typeof(Analytics), typeof(Crashes));
-#endif
+            AppCenter.Start(Secrets.AppCenterApiKey, typeof(Analytics), typeof(Crashes));
         }
 
         private static void ConfigureSentry()
         {
-#if !DEBUG
+
             SentrySdk.Init(options =>
             {
                 options.Dsn = Secrets.SentryDsn;
-                options.SampleRate = 0.5f;
+                options.SampleRate = 1.0f;
+                options.StackTraceMode = StackTraceMode.Enhanced;
                 options.IsGlobalModeEnabled = true;
                 options.AutoSessionTracking = true;
                 options.Release = $"screenbox@{Package.Current.Id.Version.ToFormattedString()}";
             });
-#endif
         }
 
         private void SetMinWindowSize()

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Microsoft.AppCenter.Analytics;
 using Screenbox.Core;
 using Screenbox.Core.ViewModels;
+using Sentry;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -67,7 +67,7 @@ namespace Screenbox.Pages
 
             DataContext = Ioc.Default.GetRequiredService<MainPageViewModel>();
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
-            ContentFrame.Navigated += ContentFrameOnNavigated;
+            ContentFrame.Navigating += ContentFrame_Navigating;
         }
 
         private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
@@ -172,11 +172,12 @@ namespace Screenbox.Pages
             }
         }
 
-        private void ContentFrameOnNavigated(object sender, NavigationEventArgs e)
+        private void ContentFrame_Navigating(object sender, NavigatingCancelEventArgs e)
         {
-            Analytics.TrackEvent(e.SourcePageType.Name, new Dictionary<string, string>()
-            {
-                {"NavigationMode", e.NavigationMode.ToString()}
+            SentrySdk.AddBreadcrumb(string.Empty, category: "navigation", type: "navigation", data: new Dictionary<string, string> {
+                { "from", ((Frame)sender).CurrentSourcePageType?.Name ?? string.Empty },
+                { "to", e.SourcePageType?.Name ?? string.Empty },
+                { "NavigationMode", e.NavigationMode.ToString()  }
             });
         }
 


### PR DESCRIPTION
Now that we have a self-hosted Sentry, we can go ham with the settings.

Use Sentry CLI to create and associate symbols and commits to releases.

Replace all AppCenter usages for analytics and error reporting and replace them with Sentry's ones. AppCenter is still active but is considered deprecated and will be removed in March 2025.