### PR TITLE
fix: unexpected lively player load due to Storyboard animation

### DIFF
--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -750,9 +750,10 @@
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BackgroundElement" Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
                             </ObjectAnimationUsingKeyFrames>
-                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LivelyWallpaperPlayer" Storyboard.TargetProperty="Visibility">
+                            <!--  Do not apply transition on LivelyWallpaperPlayer here. The player may not been loaded yet.  -->
+                            <!--<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LivelyWallpaperPlayer" Storyboard.TargetProperty="Visibility" >
                                 <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
-                            </ObjectAnimationUsingKeyFrames>
+                            </ObjectAnimationUsingKeyFrames>-->
                             <RepositionThemeAnimation FromVerticalOffset="200" TargetName="AlbumArtPanel" />
                         </Storyboard>
                     </VisualTransition>

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -361,10 +361,13 @@ namespace Screenbox.Pages
 
         private void UpdateContentState()
         {
-            var contentVisualStateName = ViewModel.AudioOnly
-                ? (ViewModel is { ShowVisualizer: true, PlayerVisibility: PlayerVisibilityState.Visible, ViewMode: not WindowViewMode.Compact }
+            // LivelyWallpaperPlayer == null when the control is not loaded
+            var audioVisualStateName = LivelyWallpaperPlayer != null &&
+                ViewModel is { ShowVisualizer: true, PlayerVisibility: PlayerVisibilityState.Visible, ViewMode: not WindowViewMode.Compact }
                     ? "AudioWithVisualizer"
-                    : "AudioOnly")
+                    : "AudioOnly";
+            var contentVisualStateName = ViewModel.AudioOnly
+                ? audioVisualStateName
                 : "Video";
             VisualStateManager.GoToState(this, contentVisualStateName, true);
 

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -361,13 +361,10 @@ namespace Screenbox.Pages
 
         private void UpdateContentState()
         {
-            // LivelyWallpaperPlayer == null when the control is not loaded
-            var audioVisualStateName = LivelyWallpaperPlayer != null &&
-                ViewModel is { ShowVisualizer: true, PlayerVisibility: PlayerVisibilityState.Visible, ViewMode: not WindowViewMode.Compact }
-                    ? "AudioWithVisualizer"
-                    : "AudioOnly";
             var contentVisualStateName = ViewModel.AudioOnly
-                ? audioVisualStateName
+                ? (ViewModel is { ShowVisualizer: true, PlayerVisibility: PlayerVisibilityState.Visible, ViewMode: not WindowViewMode.Compact }
+                    ? "AudioWithVisualizer"
+                    : "AudioOnly")
                 : "Video";
             VisualStateManager.GoToState(this, contentVisualStateName, true);
 


### PR DESCRIPTION
There is a bug that makes WebView always loaded by default. This is because of the transition storyboard animation, as mentioned in the [x:Load attribute](https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/x-load-attribute#loading-elements) docs.