### PR TITLE
feat: improve app theme change

### DIFF
--- a/Screenbox.Core/Helpers/EnumExtensions.cs
+++ b/Screenbox.Core/Helpers/EnumExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Screenbox.Core.Enums;
+using System;
+using Windows.UI.Xaml;
+
+namespace Screenbox.Core.Helpers;
+public static class EnumExtensions
+{
+    public static ElementTheme ToElementTheme(this ThemeOption themeOption)
+    {
+        return themeOption switch
+        {
+            ThemeOption.Auto => ElementTheme.Default,
+            ThemeOption.Light => ElementTheme.Light,
+            ThemeOption.Dark => ElementTheme.Dark,
+            _ => throw new ArgumentOutOfRangeException(nameof(themeOption), themeOption, null),
+        };
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Factories\MediaViewModelFactory.cs" />
     <Compile Include="Factories\StorageItemViewModelFactory.cs" />
     <Compile Include="Helpers\CollectionExtensions.cs" />
+    <Compile Include="Helpers\EnumExtensions.cs" />
     <Compile Include="Helpers\FilesHelpers.cs" />
     <Compile Include="Helpers\LanguageHelper.cs" />
     <Compile Include="Helpers\LastPositionTracker.cs" />

--- a/Screenbox.Core/ViewModels/CommonViewModel.cs
+++ b/Screenbox.Core/ViewModels/CommonViewModel.cs
@@ -18,6 +18,7 @@ using Windows.UI.Xaml.Controls;
 namespace Screenbox.Core.ViewModels
 {
     public sealed partial class CommonViewModel : ObservableRecipient,
+        IRecipient<SettingsChangedMessage>,
         IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>,
         IRecipient<PropertyChangedMessage<PlayerVisibilityState>>
     {
@@ -51,6 +52,15 @@ namespace Screenbox.Core.ViewModels
 
             // Activate the view model's messenger
             IsActive = true;
+        }
+
+        public void Receive(SettingsChangedMessage message)
+        {
+            if (message.SettingsName == nameof(SettingsPageViewModel.Theme) &&
+                Window.Current.Content is Frame rootFrame)
+            {
+                rootFrame.RequestedTheme = _settingsService.Theme.ToElementTheme();
+            }
         }
 
         public void Receive(PropertyChangedMessage<NavigationViewDisplayMode> message)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -37,7 +37,6 @@ namespace Screenbox.Core.ViewModels
         IRecipient<PlaylistCurrentItemChangedMessage>,
         IRecipient<ShowPlayPauseBadgeMessage>,
         IRecipient<OverrideControlsHideDelayMessage>,
-        IRecipient<SettingsChangedMessage>,
         IRecipient<PropertyChangedMessage<LivelyWallpaperModel?>>,
         IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>
     {
@@ -105,15 +104,6 @@ namespace Screenbox.Core.ViewModels
         {
             if (message.NewValue == null) return;
             ShowVisualizer = AudioOnly && !string.IsNullOrEmpty(message.NewValue.Path);
-        }
-
-        public void Receive(SettingsChangedMessage message)
-        {
-            if (message.SettingsName == nameof(SettingsPageViewModel.Theme) &&
-                Window.Current.Content is Frame rootFrame)
-            {
-                rootFrame.RequestedTheme = _settingsService.Theme.ToElementTheme();
-            }
         }
 
         public void Receive(TogglePlayerVisibilityMessage message)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -37,6 +37,7 @@ namespace Screenbox.Core.ViewModels
         IRecipient<PlaylistCurrentItemChangedMessage>,
         IRecipient<ShowPlayPauseBadgeMessage>,
         IRecipient<OverrideControlsHideDelayMessage>,
+        IRecipient<SettingsChangedMessage>,
         IRecipient<PropertyChangedMessage<LivelyWallpaperModel?>>,
         IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>
     {
@@ -50,7 +51,6 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private WindowViewMode _viewMode;
         [ObservableProperty] private NavigationViewDisplayMode _navigationViewDisplayMode;
         [ObservableProperty] private MediaViewModel? _media;
-        [ObservableProperty] private ElementTheme _actualTheme;
         [ObservableProperty] private bool _showVisualizer;
 
         [ObservableProperty]
@@ -105,6 +105,15 @@ namespace Screenbox.Core.ViewModels
         {
             if (message.NewValue == null) return;
             ShowVisualizer = AudioOnly && !string.IsNullOrEmpty(message.NewValue.Path);
+        }
+
+        public void Receive(SettingsChangedMessage message)
+        {
+            if (message.SettingsName == nameof(SettingsPageViewModel.Theme) &&
+                Window.Current.Content is Frame rootFrame)
+            {
+                rootFrame.RequestedTheme = _settingsService.Theme.ToElementTheme();
+            }
         }
 
         public void Receive(TogglePlayerVisibilityMessage message)

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -49,7 +49,6 @@ namespace Screenbox.Core.ViewModels
         private readonly DeviceWatcher? _portableStorageDeviceWatcher;
         private static string? _originalGlobalArguments;
         private static bool? _originalAdvancedMode;
-        private int _originalTheme;
         private StorageLibrary? _videosLibrary;
         private StorageLibrary? _musicLibrary;
 
@@ -87,7 +86,6 @@ namespace Screenbox.Core.ViewModels
             _globalArguments = _settingsService.GlobalArguments;
             _originalAdvancedMode ??= _advancedMode;
             _originalGlobalArguments ??= _globalArguments;
-            _originalTheme = _theme;
             int maxVolume = _settingsService.MaxVolume;
             _volumeBoost = maxVolume switch
             {
@@ -104,7 +102,6 @@ namespace Screenbox.Core.ViewModels
         {
             _settingsService.Theme = (ThemeOption)value;
             Messenger.Send(new SettingsChangedMessage(nameof(Theme), typeof(SettingsPageViewModel)));
-            CheckForRelaunch();
         }
 
         partial void OnPlayerAutoResizeChanged(int value)
@@ -416,10 +413,8 @@ namespace Screenbox.Core.ViewModels
             // Require relaunch when advanced mode is on and global arguments have been changed
             bool whenOnAndChanged = AdvancedMode && argsChanged;
 
-            bool themeChanged = _originalTheme != Theme;
-
             // Combine everything
-            IsRelaunchRequired = whenOn || whenOff || whenOnAndChanged || themeChanged;
+            IsRelaunchRequired = whenOn || whenOff || whenOnAndChanged;
         }
     }
 }

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -78,7 +78,7 @@ namespace Screenbox.Core.ViewModels
             _playerShowControls = _settingsService.PlayerShowControls;
             _useIndexer = _settingsService.UseIndexer;
             _showRecent = _settingsService.ShowRecent;
-            _theme = (int)_settingsService.Theme;
+            _theme = ((int)_settingsService.Theme + 2) % 3;
             _enqueueAllFilesInFolder = _settingsService.EnqueueAllFilesInFolder;
             _searchRemovableStorage = _settingsService.SearchRemovableStorage;
             _advancedMode = _settingsService.AdvancedMode;
@@ -100,7 +100,9 @@ namespace Screenbox.Core.ViewModels
 
         partial void OnThemeChanged(int value)
         {
-            _settingsService.Theme = (ThemeOption)value;
+            // The recommended theme option order is Light, Dark, System
+            // So we need to map the value to the correct ThemeOption
+            _settingsService.Theme = (ThemeOption)((value + 1) % 3);
             Messenger.Send(new SettingsChangedMessage(nameof(Theme), typeof(SettingsPageViewModel)));
         }
 

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -9,7 +9,6 @@ using Microsoft.AppCenter.Crashes;
 using Microsoft.Extensions.DependencyInjection;
 using Screenbox.Controls;
 using Screenbox.Core;
-using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Services;
@@ -83,14 +82,6 @@ namespace Screenbox
 
             IServiceProvider services = ConfigureServices();
             CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default.ConfigureServices(services);
-
-            var settings = services.GetRequiredService<ISettingsService>();
-            if (settings.Theme != ThemeOption.Auto)
-            {
-                RequestedTheme = settings.Theme == ThemeOption.Light
-                    ? ApplicationTheme.Light
-                    : ApplicationTheme.Dark;
-            }
         }
 
         public static FlowDirection GetFlowDirection()
@@ -305,6 +296,9 @@ namespace Screenbox
                 {
                     rootFrame.FlowDirection = FlowDirection.RightToLeft;
                 }
+
+                var settings = CommunityToolkit.Mvvm.DependencyInjection.Ioc.Default.GetRequiredService<ISettingsService>();
+                rootFrame.RequestedTheme = settings.Theme.ToElementTheme();
             }
 
             return rootFrame;

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -653,7 +653,7 @@
 
                 <VisualState x:Name="AudioOnly">
                     <VisualState.Setters>
-                        <Setter Target="LayoutRoot.RequestedTheme" Value="{x:Bind ViewModel.ActualTheme, Mode=OneWay}" />
+                        <Setter Target="LayoutRoot.RequestedTheme" Value="Default" />
                         <Setter Target="HeaderBackground.Opacity" Value="0" />
                         <Setter Target="BackgroundElement.Visibility" Value="Visible" />
                         <Setter Target="VideoView.Opacity" Value="0" />
@@ -703,7 +703,7 @@
 
                 <VisualState x:Name="AudioWithVisualizer">
                     <VisualState.Setters>
-                        <Setter Target="LayoutRoot.RequestedTheme" Value="{x:Bind ViewModel.ActualTheme, Mode=OneWay}" />
+                        <Setter Target="LayoutRoot.RequestedTheme" Value="Default" />
                         <Setter Target="HeaderBackground.Opacity" Value="1" />
                         <Setter Target="BackgroundElement.Visibility" Value="Collapsed" />
                         <Setter Target="LivelyWallpaperPlayer.Visibility" Value="Visible" />
@@ -742,7 +742,7 @@
                     <VisualTransition GeneratedDuration="0:0:0.24" To="AudioOnly">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="RequestedTheme">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Bind ViewModel.ActualTheme, Mode=OneWay}" />
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="Default" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="AlbumArtPanel" Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
@@ -761,7 +761,7 @@
                     <VisualTransition GeneratedDuration="0:0:0.24" To="AudioWithVisualizer">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="RequestedTheme">
-                                <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Bind ViewModel.ActualTheme, Mode=OneWay}" />
+                                <DiscreteObjectKeyFrame KeyTime="0" Value="Default" />
                             </ObjectAnimationUsingKeyFrames>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="AlbumArtPanel" Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -3,7 +3,6 @@
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
-using CommunityToolkit.WinUI.Helpers;
 using Screenbox.Controls;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Services;
@@ -44,7 +43,6 @@ namespace Screenbox.Pages
         private const VirtualKey CommaKey = (VirtualKey)188;
 
         private readonly DispatcherQueueTimer _delayFlyoutOpenTimer;
-        private readonly ThemeListener _themeListener;
         private CancellationTokenSource? _animationCancellationTokenSource;
         private bool _startup;
 
@@ -53,13 +51,9 @@ namespace Screenbox.Pages
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<PlayerPageViewModel>();
             _delayFlyoutOpenTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-            _themeListener = new ThemeListener();
-            _themeListener.ThemeChanged += ThemeListenerOnThemeChanged;
 
             RegisterSeekBarPointerHandlers();
             UpdatePreviewType();
-            ViewModel.ActualTheme = ActualTheme;
-            UpdateBackgroundAcrylicOpacity(ActualTheme);
 
             CoreApplicationViewTitleBar coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
             LeftPaddingColumn.Width = new GridLength(coreTitleBar.SystemOverlayLeftInset);
@@ -82,15 +76,13 @@ namespace Screenbox.Pages
                 PlayQueueFlyout.Hide();
         }
 
-        private void ThemeListenerOnThemeChanged(ThemeListener sender)
-        {
-            ViewModel.ActualTheme = ActualTheme;
-        }
-
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // Default content state
-            VisualStateManager.GoToState(this, "Video", false);
+            UpdateBackgroundAcrylicOpacity(ActualTheme);
+
+            // DO NOT SET CONTENT VISUAL STATE HERE
+            // It will cause element theme to not propagate correctly
+            // VisualStateManager.GoToState(this, "Video", false);
 
             if (e.Parameter is true)
             {

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -256,8 +256,8 @@
                     </ctc:SettingsExpander.Items>
                 </ctc:SettingsExpander>
 
-                <!--  General section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
+                <!--  Personalization section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPersonalization}" />
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
@@ -271,11 +271,14 @@
                                 <TextBlock Text="{x:Bind Converter={StaticResource ResourceNameToResourceStringConverter}}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
-                        <x:String>Auto</x:String>
-                        <x:String>Light</x:String>
-                        <x:String>Dark</x:String>
+                        <x:String>ThemeAuto</x:String>
+                        <x:String>ThemeLight</x:String>
+                        <x:String>ThemeDark</x:String>
                     </ComboBox>
                 </ctc:SettingsCard>
+
+                <!--  General section  -->
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -271,9 +271,11 @@
                                 <TextBlock Text="{x:Bind Converter={StaticResource ResourceNameToResourceStringConverter}}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
-                        <x:String>ThemeAuto</x:String>
+                        <!--  The app settings guidelines recommend theme options to follow this order.  -->
+                        <!--  https://learn.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings#color-mode-settings  -->
                         <x:String>ThemeLight</x:String>
                         <x:String>ThemeDark</x:String>
+                        <x:String>ThemeAuto</x:String>
                     </ComboBox>
                 </ctc:SettingsCard>
 

--- a/Screenbox/Strings/en-US/Resources.generated.cs
+++ b/Screenbox/Strings/en-US/Resources.generated.cs
@@ -1988,71 +1988,6 @@ namespace Screenbox.Strings{
         }
         #endregion
 
-        #region SettingsThemeSelectionHeader
-        /// <summary>
-        ///   Looks up a localized string similar to: Theme Selection
-        /// </summary>
-        public static string SettingsThemeSelectionHeader
-        {
-            get
-            {
-                return _resourceLoader.GetString("SettingsThemeSelectionHeader");
-            }
-        }
-        #endregion
-
-        #region SettingsThemeSelectionDescription
-        /// <summary>
-        ///   Looks up a localized string similar to: Theme Selection
-        /// </summary>
-        public static string SettingsThemeSelectionDescription
-        {
-            get
-            {
-                return _resourceLoader.GetString("SettingsThemeSelectionDescription");
-            }
-        }
-        #endregion
-
-        #region Auto
-        /// <summary>
-        ///   Looks up a localized string similar to: Theme Selection - Auto
-        /// </summary>
-        public static string Auto
-        {
-            get
-            {
-                return _resourceLoader.GetString("Auto");
-            }
-        }
-        #endregion
-
-        #region Light
-        /// <summary>
-        ///   Looks up a localized string similar to: Theme Selection - Light
-        /// </summary>
-        public static string Light
-        {
-            get
-            {
-                return _resourceLoader.GetString("Light");
-            }
-        }
-        #endregion
-
-        #region Dark
-        /// <summary>
-        ///   Looks up a localized string similar to: Theme Selection - Dark
-        /// </summary>
-        public static string Dark
-        {
-            get
-            {
-                return _resourceLoader.GetString("Dark");
-            }
-        }
-        #endregion
-
         #region SettingsAutoResizeHeader
         /// <summary>
         ///   Looks up a localized string similar to: Auto resize
@@ -3157,6 +3092,84 @@ namespace Screenbox.Strings{
             }
         }
         #endregion
+
+        #region ThemeAuto
+        /// <summary>
+        ///   Looks up a localized string similar to: Use system setting
+        /// </summary>
+        public static string ThemeAuto
+        {
+            get
+            {
+                return _resourceLoader.GetString("ThemeAuto");
+            }
+        }
+        #endregion
+
+        #region ThemeDark
+        /// <summary>
+        ///   Looks up a localized string similar to: Dark
+        /// </summary>
+        public static string ThemeDark
+        {
+            get
+            {
+                return _resourceLoader.GetString("ThemeDark");
+            }
+        }
+        #endregion
+
+        #region ThemeLight
+        /// <summary>
+        ///   Looks up a localized string similar to: Light
+        /// </summary>
+        public static string ThemeLight
+        {
+            get
+            {
+                return _resourceLoader.GetString("ThemeLight");
+            }
+        }
+        #endregion
+
+        #region SettingsThemeSelectionDescription
+        /// <summary>
+        ///   Looks up a localized string similar to: Change the app's overall color scheme
+        /// </summary>
+        public static string SettingsThemeSelectionDescription
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsThemeSelectionDescription");
+            }
+        }
+        #endregion
+
+        #region SettingsThemeSelectionHeader
+        /// <summary>
+        ///   Looks up a localized string similar to: App theme
+        /// </summary>
+        public static string SettingsThemeSelectionHeader
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsThemeSelectionHeader");
+            }
+        }
+        #endregion
+
+        #region SettingsCategoryPersonalization
+        /// <summary>
+        ///   Looks up a localized string similar to: Personalization
+        /// </summary>
+        public static string SettingsCategoryPersonalization
+        {
+            get
+            {
+                return _resourceLoader.GetString("SettingsCategoryPersonalization");
+            }
+        }
+        #endregion
     }
 
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("DotNetPlus.ReswPlus", "2.1.3")]
@@ -3404,8 +3417,12 @@ namespace Screenbox.Strings{
             FailedToLoadVisualNotificationTitle,
             SettingsEnqueueAllFilesInFolderDescription,
             SettingsEnqueueAllFilesInFolderHeader,
+            ThemeAuto,
+            ThemeDark,
+            ThemeLight,
             SettingsThemeSelectionDescription,
             SettingsThemeSelectionHeader,
+            SettingsCategoryPersonalization,
         }
 
         private static ResourceLoader _resourceLoader;

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -893,19 +893,22 @@
   <data name="SettingsEnqueueAllFilesInFolderHeader" xml:space="preserve">
     <value>Add all files in folder to queue</value>
   </data>
-  <data name="Auto" xml:space="preserve">
-    <value>Auto</value>
+  <data name="ThemeAuto" xml:space="preserve">
+    <value>Use system setting</value>
   </data>
-  <data name="Dark" xml:space="preserve">
+  <data name="ThemeDark" xml:space="preserve">
     <value>Dark</value>
   </data>
-  <data name="Light" xml:space="preserve">
+  <data name="ThemeLight" xml:space="preserve">
     <value>Light</value>
   </data>
   <data name="SettingsThemeSelectionDescription" xml:space="preserve">
-    <value>Select a theme to match your Windows settings or choose a custom one</value>
+    <value>Change the app's overall color scheme</value>
   </data>
   <data name="SettingsThemeSelectionHeader" xml:space="preserve">
-    <value>Theme</value>
+    <value>App theme</value>
+  </data>
+  <data name="SettingsCategoryPersonalization" xml:space="preserve">
+    <value>Personalization</value>
   </data>
 </root>


### PR DESCRIPTION
Closes #539 #361

Move the theme change setting to its own category on the settings page. Changing the theme on the settings page takes effect immediately without requiring an app restart.

I also fixed an issue with the `PlayerPage` theme propagation, where the page would not respect the theme requested by the parent.

https://github.com/user-attachments/assets/3eb10a55-53d9-42bc-b57d-4d08db4bb152
