### PR TITLE
style: apply mica background only on Windows 11

### DIFF
--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -15,7 +15,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
-    muxc:BackdropMaterial.ApplyToRootOrPageBackground="True"
+    contract13NotPresent:Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     Loaded="MainPage_Loaded"
     mc:Ignorable="d">
 

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -43,6 +43,12 @@ namespace Screenbox.Pages
             CoreApplicationViewTitleBar coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
             coreTitleBar.ExtendViewIntoTitleBar = true;
 
+            // Enable mica background on Windows 11
+            if (Windows.Foundation.Metadata.ApiInformation.IsMethodPresent("Windows.UI.Composition.Compositor", "TryCreateBlurredWallpaperBackdropBrush"))
+            {
+                muxc.BackdropMaterial.SetApplyToRootOrPageBackground(this, true);
+            }
+
             LeftPaddingColumn.Width = new GridLength(coreTitleBar.SystemOverlayLeftInset);
             RightPaddingColumn.Width = new GridLength(coreTitleBar.SystemOverlayRightInset);
 


### PR DESCRIPTION
As Windows 10 does not support the [mica material](https://learn.microsoft.com/en-us/windows/apps/design/style/mica), limit its use to Windows 11 only, finally (hopeful) addressing #340