### PR TITLE
feat: drag and drop anywhere to play

### DIFF
--- a/Screenbox.Core/Messages/DragDropMessage.cs
+++ b/Screenbox.Core/Messages/DragDropMessage.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Screenbox.Core.Messages;
+public class DragDropMessage
+{
+    public DataPackageView Data { get; }
+
+    public DragDropMessage(DataPackageView data)
+    {
+        Data = data;
+    }
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Messages\ClearPlaylistMessage.cs" />
     <Compile Include="Messages\CloseNotificationMessage.cs" />
     <Compile Include="Messages\CriticalErrorMessage.cs" />
+    <Compile Include="Messages\DragDropMessage.cs" />
     <Compile Include="Messages\ErrorMessage.cs" />
     <Compile Include="Messages\MediaLoadFailedNotificationMessage.cs" />
     <Compile Include="Messages\MediaPlayerChangedMessage.cs" />

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -1,5 +1,10 @@
 ﻿#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -7,16 +12,9 @@ using Screenbox.Core.Factories;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Threading.Tasks;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.Storage.AccessCache;
 using Windows.UI.Core;
-using Windows.UI.Xaml;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -58,35 +56,6 @@ namespace Screenbox.Core.ViewModels
         public async void OnLoaded()
         {
             await UpdateContentAsync();
-        }
-
-        public async Task OnDrop(DragEventArgs e)
-        {
-            try
-            {
-                if (e.DataView.Contains(StandardDataFormats.StorageItems))
-                {
-                    IReadOnlyList<IStorageItem>? items = await e.DataView.GetStorageItemsAsync();
-                    if (items.Count > 0)
-                    {
-                        Messenger.Send(new PlayFilesMessage(items));
-                        return;
-                    }
-                }
-
-                if (e.DataView.Contains(StandardDataFormats.WebLink))
-                {
-                    Uri? uri = await e.DataView.GetWebLinkAsync();
-                    if (uri.IsFile)
-                    {
-                        Messenger.Send(new PlayMediaMessage(uri));
-                    }
-                }
-            }
-            catch (Exception exception)
-            {
-                Messenger.Send(new MediaLoadFailedNotificationMessage(exception.Message, string.Empty));
-            }
         }
 
         [RelayCommand]

--- a/Screenbox.Core/ViewModels/MainPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MainPageViewModel.cs
@@ -123,33 +123,9 @@ namespace Screenbox.Core.ViewModels
             args.Handled = true;
         }
 
-        public async Task OnDropAsync(DataPackageView data)
+        public void OnDrop(DataPackageView data)
         {
-            try
-            {
-                if (data.Contains(StandardDataFormats.StorageItems))
-                {
-                    IReadOnlyList<IStorageItem>? items = await data.GetStorageItemsAsync();
-                    if (items.Count > 0)
-                    {
-                        Messenger.Send(new PlayFilesMessage(items));
-                        return;
-                    }
-                }
-
-                if (data.Contains(StandardDataFormats.WebLink))
-                {
-                    Uri? uri = await data.GetWebLinkAsync();
-                    if (uri.IsFile)
-                    {
-                        Messenger.Send(new PlayMediaMessage(uri));
-                    }
-                }
-            }
-            catch (Exception exception)
-            {
-                Messenger.Send(new MediaLoadFailedNotificationMessage(exception.Message, string.Empty));
-            }
+            Messenger.Send(new DragDropMessage(data));
         }
 
         public void AutoSuggestBox_OnTextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -37,6 +37,7 @@ namespace Screenbox.Core.ViewModels
         IRecipient<PlaylistCurrentItemChangedMessage>,
         IRecipient<ShowPlayPauseBadgeMessage>,
         IRecipient<OverrideControlsHideDelayMessage>,
+        IRecipient<DragDropMessage>,
         IRecipient<PropertyChangedMessage<LivelyWallpaperModel?>>,
         IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>
     {
@@ -98,6 +99,11 @@ namespace Screenbox.Core.ViewModels
 
             // Activate the view model's messenger
             IsActive = true;
+        }
+
+        public async void Receive(DragDropMessage message)
+        {
+            await OnDropAsync(message.Data);
         }
 
         public void Receive(PropertyChangedMessage<LivelyWallpaperModel?> message)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -12,9 +15,6 @@ using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.Media.Playback;
@@ -192,13 +192,13 @@ namespace Screenbox.Core.ViewModels
             OverrideControlsDelayHide(message.Delay);
         }
 
-        public async void OnDrop(object sender, DragEventArgs e)
+        public async Task OnDropAsync(DataPackageView data)
         {
             try
             {
-                if (e.DataView.Contains(StandardDataFormats.StorageItems))
+                if (data.Contains(StandardDataFormats.StorageItems))
                 {
-                    IReadOnlyList<IStorageItem>? items = await e.DataView.GetStorageItemsAsync();
+                    IReadOnlyList<IStorageItem>? items = await data.GetStorageItemsAsync();
                     if (items.Count > 0)
                     {
                         if (items.Count == 1 && items[0] is StorageFile file && file.IsSupportedSubtitle() &&
@@ -216,9 +216,9 @@ namespace Screenbox.Core.ViewModels
                     }
                 }
 
-                if (e.DataView.Contains(StandardDataFormats.WebLink))
+                if (data.Contains(StandardDataFormats.WebLink))
                 {
-                    Uri? uri = await e.DataView.GetWebLinkAsync();
+                    Uri? uri = await data.GetWebLinkAsync();
                     if (uri.IsFile)
                     {
                         Messenger.Send(new PlayMediaMessage(uri));

--- a/Screenbox.Core/ViewModels/PlaylistViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlaylistViewModel.cs
@@ -1,16 +1,16 @@
 ﻿#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.System;
 
@@ -52,11 +52,6 @@ namespace Screenbox.Core.ViewModels
             _hasItems = playlist.Items.Count > 0;
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             Playlist.Items.CollectionChanged += ItemsOnCollectionChanged;
-        }
-
-        public async Task EnqueuePlaylistAsync(IReadOnlyList<IStorageItem> items)
-        {
-            await Playlist.EnqueueAsync(items);
         }
 
         private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -1,12 +1,12 @@
 ﻿#nullable enable
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.WinUI;
-using Screenbox.Core.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.WinUI;
+using Screenbox.Core.ViewModels;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.UI.Xaml;
@@ -78,7 +78,7 @@ namespace Screenbox.Controls
             IReadOnlyList<IStorageItem>? items = await e.DataView.GetStorageItemsAsync();
             if (items?.Count > 0)
             {
-                await ViewModel.EnqueuePlaylistAsync(items);
+                await ViewModel.Playlist.EnqueueAsync(items);
             }
         }
 

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -100,11 +100,7 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <Grid
-        AllowDrop="True"
-        Background="Transparent"
-        DragOver="HomePage_OnDragOver"
-        Drop="HomePage_OnDrop">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/Screenbox/Pages/HomePage.xaml.cs
+++ b/Screenbox/Pages/HomePage.xaml.cs
@@ -2,7 +2,6 @@
 
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -31,17 +30,6 @@ namespace Screenbox.Pages
         {
             base.OnNavigatedTo(e);
             VisualStateManager.GoToState(this, ViewModel.HasRecentMedia ? "RecentMedia" : "Welcome", false);
-        }
-
-        private void HomePage_OnDragOver(object sender, DragEventArgs e)
-        {
-            e.AcceptedOperation = DataPackageOperation.Link;
-            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
-        }
-
-        private async void HomePage_OnDrop(object sender, DragEventArgs e)
-        {
-            await ViewModel.OnDrop(e);
         }
     }
 }

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -185,10 +185,13 @@
 
         <controls:CustomNavigationView
             x:Name="NavView"
+            AllowDrop="True"
             BackRequested="NavView_BackRequested"
             Canvas.ZIndex="0"
             CompactModeThresholdWidth="701"
             DisplayModeChanged="NavView_OnDisplayModeChanged"
+            DragOver="NavView_DragOver"
+            Drop="NavView_Drop"
             ExpandedModeThresholdWidth="1058"
             IsPaneOpen="{x:Bind ViewModel.IsPaneOpen, Mode=TwoWay}"
             IsSettingsVisible="False"

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -398,10 +398,10 @@ namespace Screenbox.Pages
             if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
         }
 
-        private async void NavView_Drop(object sender, DragEventArgs e)
+        private void NavView_Drop(object sender, DragEventArgs e)
         {
             e.Handled = true;
-            await ViewModel.OnDropAsync(e.DataView);
+            ViewModel.OnDrop(e.DataView);
         }
     }
 }

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -1,15 +1,16 @@
 ﻿#nullable enable
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Screenbox.Core;
-using Screenbox.Core.ViewModels;
-using Sentry;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Screenbox.Core;
+using Screenbox.Core.ViewModels;
+using Sentry;
 using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI;
 using Windows.UI.Core;
@@ -388,6 +389,19 @@ namespace Screenbox.Pages
         {
             NavViewSearchBox.Focus(FocusState.Keyboard);
             args.Handled = true;
+        }
+
+        private void NavView_DragOver(object sender, DragEventArgs e)
+        {
+            e.Handled = true;
+            e.AcceptedOperation = DataPackageOperation.Link;
+            if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
+        }
+
+        private async void NavView_Drop(object sender, DragEventArgs e)
+        {
+            e.Handled = true;
+            await ViewModel.OnDropAsync(e.DataView);
         }
     }
 }

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -24,7 +24,7 @@
     extensions:ApplicationViewExtensions.Title="{x:Bind ViewModel.Media.Name, Mode=OneWay, FallbackValue={}}"
     AllowDrop="True"
     DragOver="OnDragOver"
-    Drop="{x:Bind ViewModel.OnDrop}"
+    Drop="OnDrop"
     Loaded="OnLoaded"
     Loading="OnLoading"
     mc:Ignorable="d">

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -1,5 +1,8 @@
 ﻿#nullable enable
 
+using System;
+using System.ComponentModel;
+using System.Threading;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
@@ -7,9 +10,6 @@ using Screenbox.Controls;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
-using System;
-using System.ComponentModel;
-using System.Threading;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
@@ -480,8 +480,15 @@ namespace Screenbox.Pages
 
         private void OnDragOver(object sender, DragEventArgs e)
         {
+            e.Handled = true;
             e.AcceptedOperation = DataPackageOperation.Link;
             if (e.DragUIOverride != null) e.DragUIOverride.Caption = Strings.Resources.Play;
+        }
+
+        private async void OnDrop(object sender, DragEventArgs e)
+        {
+            e.Handled = true;
+            await ViewModel.OnDropAsync(e.DataView);
         }
     }
 }


### PR DESCRIPTION
Users can only drag and drop over the HomePage or the PlayerPage to play media. This PR allows users to drag and drop to play files almost anywhere on the app.