### PR TITLE
chore: refactor and add comments to thickness converter

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -38,16 +38,16 @@
                     <!--<converters:ThicknessFilterConverter x:Key="TopOnlyThicknessFilterConverter" Filter="Top" />-->
                     <!--<converters:ThicknessFilterConverter x:Key="RightOnlyThicknessFilterConverter" Filter="Right" />-->
                     <!--<converters:ThicknessFilterConverter x:Key="BottomOnlyThicknessFilterConverter" Filter="Bottom" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightBottomThicknessFilterConverter" Filter="LeftRightBottom" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightTopThicknessFilterConverter" Filter="LeftRightTop" />-->
-                    <converters:ThicknessFilterConverter x:Key="TopBottomRightThicknessFilterConverter" Filter="TopBottomRight" />
-                    <converters:ThicknessFilterConverter x:Key="TopBottomLeftThicknessFilterConverter" Filter="TopBottomLeft" />
-                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightThicknessFilterConverter" Filter="LeftRight" />-->
-                    <converters:ThicknessFilterConverter x:Key="TopBottomThicknessFilterConverter" Filter="TopBottom" />
-                    <!--<converters:ThicknessFilterConverter x:Key="TopLeftThicknessFilterConverter" Filter="TopLeft" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="TopRightThicknessFilterConverter" Filter="TopRight" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="BottomLeftThicknessFilterConverter" Filter="BottomLeft" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="BottomRightThicknessFilterConverter" Filter="BottomRight" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightThicknessFilterConverter" Filter="Left,Right" />-->
+                    <converters:ThicknessFilterConverter x:Key="TopBottomThicknessFilterConverter" Filter="Top,Bottom" />
+                    <!--<converters:ThicknessFilterConverter x:Key="TopLeftThicknessFilterConverter" Filter="Top,Left" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="TopRightThicknessFilterConverter" Filter="Top,Right" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="BottomLeftThicknessFilterConverter" Filter="Bottom,Left" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="BottomRightThicknessFilterConverter" Filter="Bottom,Right" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightTopThicknessFilterConverter" Filter="Left,Right,Top" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightBottomThicknessFilterConverter" Filter="Left,Right,Bottom" />-->
+                    <converters:ThicknessFilterConverter x:Key="TopBottomLeftThicknessFilterConverter" Filter="Top,Bottom,Left" />
+                    <converters:ThicknessFilterConverter x:Key="TopBottomRightThicknessFilterConverter" Filter="Top,Bottom,Right" />
                     <ctConverters:BoolNegationConverter x:Key="BoolNegationConverter" />
                     <ctConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
                     <ctConverters:StringVisibilityConverter x:Key="StringVisibilityConverter" />

--- a/Screenbox/Converters/ThicknessFilterConverter.cs
+++ b/Screenbox/Converters/ThicknessFilterConverter.cs
@@ -1,10 +1,43 @@
-﻿// Source (Inspired by and ported to C#): https://github.com/microsoft/microsoft-ui-xaml/pull/6829
+﻿// Source (inspired by and ported to C#): https://github.com/microsoft/microsoft-ui-xaml/pull/6829
 
 using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 
 namespace Screenbox.Converters;
+
+/// <summary>
+/// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
+/// This <see cref="Enum"/> supports a bitwise combination of its member values.
+/// </summary>
+[Flags]
+public enum ThicknessFilterKind
+{
+    /// <summary>
+    /// No filter applied.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Filters Left value.
+    /// </summary>
+    Left = 1,
+
+    /// <summary>
+    /// Filters Top value.
+    /// </summary>
+    Top = 2,
+
+    /// <summary>
+    /// Filters Right value.
+    /// </summary>
+    Right = 4,
+
+    /// <summary>
+    /// Filters Bottom value.
+    /// </summary>
+    Bottom = 8
+}
 
 /// <summary>
 /// An <see cref="IValueConverter"/> that takes an existing <see cref="Thickness"/> struct and returns a new one,
@@ -37,87 +70,6 @@ namespace Screenbox.Converters;
 public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
 {
     /// <summary>
-    /// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
-    /// </summary>
-    public enum ThicknessFilterKind
-    {
-        /// <summary>
-        /// No filter applied.
-        /// </summary>
-        None,
-
-        /// <summary>
-        /// Filters Left value, sets Top, Right and Bottom to 0.
-        /// </summary>
-        Left,
-
-        /// <summary>
-        /// Filters Top value, sets Left, Right and Bottom to 0.
-        /// </summary>
-        Top,
-
-        /// <summary>
-        /// Filters Right value, sets Left, Top, and Bottom to 0.
-        /// </summary>
-        Right,
-
-        /// <summary>
-        /// Filters Bottom value, sets Left, Top, and Right to 0.
-        /// </summary>
-        Bottom,
-
-        /// <summary>
-        /// Filters Left and Right values, sets Top and Bottom to 0.
-        /// </summary>
-        LeftRight,
-
-        /// <summary>
-        /// Filters Top and Bottom values, sets Left and Right to 0.
-        /// </summary>
-        TopBottom,
-
-        /// <summary>
-        /// Filters Left and Top values, sets Right and Bottom to 0.
-        /// </summary>
-        TopLeft,
-
-        /// <summary>
-        /// Filters Top and Right values, sets Left and Bottom to 0.
-        /// </summary>
-        TopRight,
-
-        /// <summary>
-        /// Filters Left and Bottom values, sets Top and Right to 0.
-        /// </summary>
-        BottomLeft,
-
-        /// <summary>
-        /// Filters Bottom and Right values, sets Left and Top to 0.
-        /// </summary>
-        BottomRight,
-
-        /// <summary>
-        /// Filters Left, Top, and Right values, set Bottom to 0.
-        /// </summary>
-        LeftRightTop,
-
-        /// <summary>
-        /// Filters Left, Right, and Bottom values, set Top to 0.
-        /// </summary>
-        LeftRightBottom,
-
-        /// <summary>
-        /// Filters Left, Top, and Bottom values, set Right to 0.
-        /// </summary>
-        TopBottomLeft,
-
-        /// <summary>
-        /// Filters Top, Right, and Bottom values, set Left to 0.
-        /// </summary>
-        TopBottomRight
-    }
-
-    /// <summary>
     /// Identifies the <see cref="Filter"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
@@ -136,7 +88,7 @@ public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
     /// Extracts, using filters, the specified fields from a <see cref="Thickness"/> struct.
     /// </summary>
     /// <param name="thickness">The <see cref="Thickness"/> to convert.</param>
-    /// <param name="filterKind">An <see cref="enum"/> that defines the filter type.</param>
+    /// <param name="filterKind">An <see cref="Enum"/> that defines the filter type.</param>
     /// <returns>A <see cref="Thickness"/> with only the fields specified by the filter, while the rest are set to 0.</returns>
     public Thickness ExtractThickness(Thickness thickness, ThicknessFilterKind filterKind)
     {
@@ -168,61 +120,61 @@ public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
                 result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.LeftRight:
+            case ThicknessFilterKind.Left | ThicknessFilterKind.Right:
                 //result.Left = thickness.Left;
                 result.Top = 0;
                 //result.Right = thickness.Right;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.TopBottom:
+            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom:
                 result.Left = 0;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.TopLeft:
+            case ThicknessFilterKind.Top | ThicknessFilterKind.Left:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.TopRight:
+            case ThicknessFilterKind.Top | ThicknessFilterKind.Right:
                 result.Left = 0;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.BottomLeft:
+            case ThicknessFilterKind.Bottom | ThicknessFilterKind.Left:
                 //result.Left = thickness.Left;
                 result.Top = 0;
                 result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.BottomRight:
+            case ThicknessFilterKind.Bottom | ThicknessFilterKind.Right:
                 result.Left = 0;
                 result.Top = 0;
                 //result.Right = thickness.Right;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.LeftRightTop:
+            case ThicknessFilterKind.Left | ThicknessFilterKind.Right | ThicknessFilterKind.Top:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.LeftRightBottom:
+            case ThicknessFilterKind.Left | ThicknessFilterKind.Right | ThicknessFilterKind.Bottom:
                 //result.Left = thickness.Left;
                 result.Top = 0;
                 //result.Right = thickness.Right;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.TopBottomLeft:
+            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom | ThicknessFilterKind.Left:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.TopBottomRight:
+            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom | ThicknessFilterKind.Right:
                 result.Left = 0;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;

--- a/Screenbox/Converters/ThicknessFilterConverter.cs
+++ b/Screenbox/Converters/ThicknessFilterConverter.cs
@@ -1,5 +1,4 @@
-﻿// Converter ported to C#.
-// Source: https://github.com/microsoft/microsoft-ui-xaml/pull/6829
+﻿// Source (Inspired by and ported to C#): https://github.com/microsoft/microsoft-ui-xaml/pull/6829
 
 using System;
 using Windows.UI.Xaml;
@@ -8,46 +7,143 @@ using Windows.UI.Xaml.Data;
 namespace Screenbox.Converters;
 
 /// <summary>
-/// Value converter that takes a <see cref="Thickness"/> value and returns a modified value.
-/// Can be used to convert a <see cref="Thickness"/>, side, or edge value to zero.
+/// An <see cref="IValueConverter"/> that takes an existing <see cref="Thickness"/> struct and returns a new one,
+/// using filters to keep only the specified fields and setting all others to 0.
+/// <example>For example:
+/// <code lang="xaml">
+/// &lt;ControlTemplate TargetType="Button"&gt;
+///     &lt;Grid&gt;
+///         &lt;Grid.Resources&gt;
+///             &lt;local:ThicknessFilterConverter x:Name="TopThicknessFilterConverter" Filter="Top" /&gt;
+///         &lt;/Grid.Resources&gt;
+///         &lt;Border Background="{TemplateBinding Background}"
+///                 BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopThicknessFilterConverter}}"
+///                 Padding="{TemplateBinding Padding}" /&gt;
+///     &lt;/Grid&gt;
+/// &lt;/ControlTemplate&gt;
+/// 
+/// &lt;Grid&gt;
+///     &lt;Grid.Resources&gt;
+///         &lt;local:ThicknessFilterConverter x:Name="TopThicknessFilterConverter" Filter="Top" /&gt;
+///         &lt;Thickness x:Key="ExampleBorderThickness"&gt;1,1,1,1&lt;/Thickness&gt;
+///     &lt;/Grid.Resources&gt;
+///     &lt;Border Background="Blue"
+///             BorderThickness="{Binding Source={StaticResource ExampleBorderThickness}, Converter={StaticResource TopThicknessFilterConverter}}" /&gt;
+/// &lt;/Grid&gt;
+/// </code>
+/// results in the BorderThickness of the <c>Border</c> having the value "0,1,0,0".
+/// </example>
 /// </summary>
-public class ThicknessFilterConverter : IValueConverter
+public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
 {
+    /// <summary>
+    /// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
+    /// </summary>
     public enum ThicknessFilterKind
     {
+        /// <summary>
+        /// No filter applied.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Filters Left value, sets Top, Right and Bottom to 0.
+        /// </summary>
         Left,
+
+        /// <summary>
+        /// Filters Top value, sets Left, Right and Bottom to 0.
+        /// </summary>
         Top,
+
+        /// <summary>
+        /// Filters Right value, sets Left, Top, and Bottom to 0.
+        /// </summary>
         Right,
+
+        /// <summary>
+        /// Filters Bottom value, sets Left, Top, and Right to 0.
+        /// </summary>
         Bottom,
+
+        /// <summary>
+        /// Filters Left and Right values, sets Top and Bottom to 0.
+        /// </summary>
         LeftRight,
+
+        /// <summary>
+        /// Filters Top and Bottom values, sets Left and Right to 0.
+        /// </summary>
         TopBottom,
+
+        /// <summary>
+        /// Filters Left and Top values, sets Right and Bottom to 0.
+        /// </summary>
         TopLeft,
+
+        /// <summary>
+        /// Filters Top and Right values, sets Left and Bottom to 0.
+        /// </summary>
         TopRight,
+
+        /// <summary>
+        /// Filters Left and Bottom values, sets Top and Right to 0.
+        /// </summary>
         BottomLeft,
+
+        /// <summary>
+        /// Filters Bottom and Right values, sets Left and Top to 0.
+        /// </summary>
         BottomRight,
+
+        /// <summary>
+        /// Filters Left, Top, and Right values, set Bottom to 0.
+        /// </summary>
         LeftRightTop,
+
+        /// <summary>
+        /// Filters Left, Right, and Bottom values, set Top to 0.
+        /// </summary>
         LeftRightBottom,
+
+        /// <summary>
+        /// Filters Left, Top, and Bottom values, set Right to 0.
+        /// </summary>
         TopBottomLeft,
-        TopBottomRight,
+
+        /// <summary>
+        /// Filters Top, Right, and Bottom values, set Left to 0.
+        /// </summary>
+        TopBottomRight
     }
 
     /// <summary>
-    /// Identifies the <see cref="FilterProperty"/> property.
+    /// Identifies the <see cref="Filter"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
         nameof(Filter), typeof(ThicknessFilterKind), typeof(ThicknessFilterConverter), new PropertyMetadata(null));
 
-    public ThicknessFilterKind Filter { get; set; } = ThicknessFilterKind.None;
+    /// <summary>
+    /// Gets or sets the type of the filter applied to the <see cref="ThicknessFilterConverter"/>.
+    /// </summary>
+    public ThicknessFilterKind Filter
+    {
+        get { return (ThicknessFilterKind)GetValue(FilterProperty); }
+        set { SetValue(FilterProperty, value); }
+    }
 
-    public Thickness ExcludeConvert(Thickness thickness, ThicknessFilterKind filterKind)
+    /// <summary>
+    /// Extracts, using filters, the specified fields from a <see cref="Thickness"/> struct.
+    /// </summary>
+    /// <param name="thickness">The <see cref="Thickness"/> to convert.</param>
+    /// <param name="filterKind">An <see cref="enum"/> that defines the filter type.</param>
+    /// <returns>A <see cref="Thickness"/> with only the fields specified by the filter, while the rest are set to 0.</returns>
+    public Thickness ExtractThickness(Thickness thickness, ThicknessFilterKind filterKind)
     {
         Thickness result = thickness;
 
         switch (filterKind)
         {
-            case ThicknessFilterKind.None:
-                break;
             case ThicknessFilterKind.Left:
                 //result.Left = thickness.Left;
                 result.Top = 0;
@@ -137,11 +233,19 @@ public class ThicknessFilterConverter : IValueConverter
         return result;
     }
 
+    /// <summary>
+    /// Converts the source <see cref="Thickness"/> by extracting only the fields specified by the <see cref="Filter"/> and setting the others to 0.
+    /// </summary>
+    /// <param name="value">The source <see cref="Thickness"/> being passed to the target.</param>
+    /// <param name="targetType">The type of the target property. Not used.</param>
+    /// <param name="parameter">An optional parameter to be used in the converter logic. Not used.</param>
+    /// <param name="language">The language of the conversion. Not used.</param>
+    /// <returns>The converted <see cref="Thickness"/> value to be passed to the target dependency property.</returns>
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         if (value is Thickness thickness)
         {
-            return ExcludeConvert(thickness, Filter);
+            return ExtractThickness(thickness, Filter);
         }
         else
         {
@@ -149,6 +253,15 @@ public class ThicknessFilterConverter : IValueConverter
         }
     }
 
+    /// <summary>
+    /// Not implemented.
+    /// </summary>
+    /// <param name="value">The target data being passed to the source.</param>
+    /// <param name="targetType">The type of the target property.</param>
+    /// <param name="parameter">An optional parameter to be used in the converter logic.</param>
+    /// <param name="language">The language of the conversion.</param>
+    /// <returns>The value to be passed to the source object.</returns>
+    /// <exception cref="NotImplementedException"></exception>
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
         throw new NotImplementedException();

--- a/Screenbox/Converters/ThicknessFilterConverter.cs
+++ b/Screenbox/Converters/ThicknessFilterConverter.cs
@@ -7,39 +7,6 @@ using Windows.UI.Xaml.Data;
 namespace Screenbox.Converters;
 
 /// <summary>
-/// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
-/// This <see cref="Enum"/> supports a bitwise combination of its member values.
-/// </summary>
-[Flags]
-public enum ThicknessFilterKind
-{
-    /// <summary>
-    /// No filter applied.
-    /// </summary>
-    None = 0,
-
-    /// <summary>
-    /// Filters Left value.
-    /// </summary>
-    Left = 1,
-
-    /// <summary>
-    /// Filters Top value.
-    /// </summary>
-    Top = 2,
-
-    /// <summary>
-    /// Filters Right value.
-    /// </summary>
-    Right = 4,
-
-    /// <summary>
-    /// Filters Bottom value.
-    /// </summary>
-    Bottom = 8
-}
-
-/// <summary>
 /// An <see cref="IValueConverter"/> that takes an existing <see cref="Thickness"/> struct and returns a new one,
 /// using filters to keep only the specified fields and setting all others to 0.
 /// <example>For example:
@@ -69,6 +36,39 @@ public enum ThicknessFilterKind
 /// </summary>
 public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
 {
+    /// <summary>
+    /// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
+    /// This <see cref="Enum"/> supports a bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    public enum ThicknessFilterKind
+    {
+        /// <summary>
+        /// No filter applied.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Filters Left value.
+        /// </summary>
+        Left = 1,
+
+        /// <summary>
+        /// Filters Top value.
+        /// </summary>
+        Top = 2,
+
+        /// <summary>
+        /// Filters Right value.
+        /// </summary>
+        Right = 4,
+
+        /// <summary>
+        /// Filters Bottom value.
+        /// </summary>
+        Bottom = 8
+    }
+
     /// <summary>
     /// Identifies the <see cref="Filter"/> dependency property.
     /// </summary>


### PR DESCRIPTION
Enhancements to `ThicknessFilterConverter`:
* Updated the `ThicknessFilterConverter` class to be sealed and inherit from `DependencyObject`. Added detailed XML documentation and an example to illustrate usage.
* Modified the `ThicknessFilterKind` enum to support bitwise combinations, allowing more flexible filtering. 
* Renamed the `ExcludeConvert` method to `ExtractThickness` and updated its logic to handle bitwise filter combinations.