### PR TITLE
fix: Sentry error reporting for unhandled exceptions

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -319,7 +319,7 @@
       <Version>3.2.30</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>5.1.1</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="TagLibSharp">
       <Version>2.3.0</Version>

--- a/Screenbox.Core/packages.lock.json
+++ b/Screenbox.Core/packages.lock.json
@@ -105,9 +105,9 @@
       },
       "Sentry": {
         "type": "Direct",
-        "requested": "[5.1.1, )",
-        "resolved": "5.1.1",
-        "contentHash": "FvdRStUwxXtt9g4fHaGQ5/a9otA6RiLznyTdkyCzIoUbOupwS4WNGF8CGvqDJifkltCJZj+4J8K4/f2RqFVuzg==",
+        "requested": "[5.5.0, )",
+        "resolved": "5.5.0",
+        "contentHash": "6LHLNBTtAOiYpGRCk2Z9637HU1jg82XXmKSVomt62h6p29pf8vS57n1En4naYQmJqkjU9TRf/9xHlv+n5vOSmA==",
         "dependencies": {
           "System.Reflection.Metadata": "5.0.0",
           "System.Text.Json": "6.0.10"

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -774,7 +774,7 @@
       <Version>3.0.20-2405070635</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>5.1.1</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -138,9 +138,9 @@
       },
       "Sentry": {
         "type": "Direct",
-        "requested": "[5.1.1, )",
-        "resolved": "5.1.1",
-        "contentHash": "FvdRStUwxXtt9g4fHaGQ5/a9otA6RiLznyTdkyCzIoUbOupwS4WNGF8CGvqDJifkltCJZj+4J8K4/f2RqFVuzg==",
+        "requested": "[5.5.0, )",
+        "resolved": "5.5.0",
+        "contentHash": "6LHLNBTtAOiYpGRCk2Z9637HU1jg82XXmKSVomt62h6p29pf8vS57n1En4naYQmJqkjU9TRf/9xHlv+n5vOSmA==",
         "dependencies": {
           "System.Reflection.Metadata": "5.0.0",
           "System.Text.Json": "6.0.10"
@@ -534,7 +534,7 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.2, )",
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.14, )",
           "Microsoft.UI.Xaml": "[2.8.7, )",
-          "Sentry": "[5.1.1, )",
+          "Sentry": "[5.5.0, )",
           "TagLibSharp": "[2.3.0, )",
           "protobuf-net": "[3.2.30, )"
         }


### PR DESCRIPTION
Use `CoreApplication.UnhandledErrorDetected` instead of `Application.UnhandledException` to retain more information in the Exception.

Modifying Sentry SDK configuration to use an updated release version format and tag device family information. This change unifies the release versioning for both PC and Xbox versions.