### PR TITLE
fix: handle total chapters duration different from media duration

### DIFF
--- a/Screenbox/Controls/ChapterProgressBar.xaml.cs
+++ b/Screenbox/Controls/ChapterProgressBar.xaml.cs
@@ -1,13 +1,12 @@
 ﻿#nullable enable
 
-using CommunityToolkit.WinUI;
-using Screenbox.Core.Services;
-using Screenbox.Core.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Linq;
+using CommunityToolkit.WinUI;
+using Screenbox.Core.Services;
+using Screenbox.Core.ViewModels;
 using Windows.Media.Core;
 using Windows.System;
 using Windows.UI.Xaml;

--- a/Screenbox/Controls/ChapterProgressBar.xaml.cs
+++ b/Screenbox/Controls/ChapterProgressBar.xaml.cs
@@ -124,14 +124,14 @@ namespace Screenbox.Controls
             {
                 foreach (ChapterViewModel item in ProgressItems)
                 {
-                    item.Width = GetItemWidth(item.Maximum - item.Minimum);
+                    item.Width = GetItemWidth(item.Maximum - item.Minimum, ProgressItems.Count);
                 }
             }
         }
 
         private void ChaptersOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            _chaptersUpdateTimer.Debounce(PopulateProgressItems, TimeSpan.FromMilliseconds(50));
+            _chaptersUpdateTimer.Debounce(PopulateProgressItems, TimeSpan.FromMilliseconds(100));
         }
 
         private void UpdateProgress()
@@ -218,7 +218,6 @@ namespace Screenbox.Controls
                         {
                             Minimum = lastChapterEndTime.TotalMilliseconds,
                             Maximum = cue.StartTime.TotalMilliseconds,
-                            Width = GetItemWidth(gap.TotalMilliseconds)
                         };
 
                         ProgressItems.Add(gapChapter);
@@ -231,7 +230,6 @@ namespace Screenbox.Controls
                     {
                         Minimum = startTime,
                         Maximum = endTime,
-                        Width = GetItemWidth(endTime - startTime)
                     };
 
                     ProgressItems.Add(chapter);
@@ -245,11 +243,16 @@ namespace Screenbox.Controls
                     {
                         Minimum = lastChapterEndTime.TotalMilliseconds,
                         Maximum = Maximum,
-                        Width = GetItemWidth(Maximum - lastChapterEndTime.TotalMilliseconds)
                     };
 
                     ProgressItems.Add(gapChapter);
                     LogService.Log("Chapters duration does not match with media length.");
+                }
+
+                // Update the width of each chapter
+                foreach (ChapterViewModel item in ProgressItems)
+                {
+                    item.Width = GetItemWidth(item.Maximum - item.Minimum, ProgressItems.Count);
                 }
             }
             else
@@ -263,9 +266,9 @@ namespace Screenbox.Controls
             }
         }
 
-        private double GetItemWidth(double durationMs)
+        private double GetItemWidth(double durationMs, int chapterCount)
         {
-            double availableWidth = ActualWidth - Spacing * (Chapters?.Count ?? 0);
+            double availableWidth = ActualWidth - Spacing * chapterCount;
             return Maximum > 0 ? durationMs / Maximum * availableWidth : 0;
         }
     }

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -444,9 +444,9 @@
     <None Include="Secrets.cs.template" />
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="Strings\en-US\KeyboardResources.resw"/>
+    <PRIResource Include="Strings\en-US\KeyboardResources.resw" />
     <PRIResource Include="Strings\en-US\ManifestResources.resw" />
-    <PRIResource Include="Strings\en-US\Resources.resw"/>
+    <PRIResource Include="Strings\en-US\Resources.resw" />
     <PRIResource Include="Strings\ar-SA\KeyboardResources.resw" />
     <PRIResource Include="Strings\ar-SA\ManifestResources.resw" />
     <PRIResource Include="Strings\ar-SA\Resources.resw" />


### PR DESCRIPTION
Potentially fixes #591 

Handle cases where there are gaps between chapters which leads to the chapter progress bar length does not match the seek bar length.