### PR TITLE
feat: implement video scaling options

### DIFF
--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -755,7 +755,7 @@
       <Version>0.3.1.5</Version>
     </PackageReference>
     <PackageReference Include="LibVLC.UWP">
-      <Version>3.0.20-2405070635</Version>
+      <Version>3.0.21-2505100334</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>5.5.0</Version>

--- a/Screenbox/packages.lock.json
+++ b/Screenbox/packages.lock.json
@@ -66,9 +66,9 @@
       },
       "LibVLC.UWP": {
         "type": "Direct",
-        "requested": "[3.0.20-2405070635, )",
-        "resolved": "3.0.20-2405070635",
-        "contentHash": "h3mBtHTXgahhNAPpQIwBlHUBE2AmRIbXHX8+2c3WLXhLD/V/w/bFau3aurbbLlcaK8fcpiVoHOOyFd5gOomyNQ=="
+        "requested": "[3.0.21-2505100334, )",
+        "resolved": "3.0.21-2505100334",
+        "contentHash": "WKuSawM0xm72DaqyD3k84eKb+IYmsaOwsNdZ4LJK06ei6VsWk9gdzN8gAxggeD/5mCdFy1qC9Q5bcW3JjIkk4Q=="
       },
       "Microsoft.AppCenter.Analytics": {
         "type": "Direct",


### PR DESCRIPTION
This PR adds the option to customize how video scaling is handled and officially adds support for NVIDIA Super Resolution to Screenbox.

Built on top of the work from https://github.com/huynhsontung/libvlc-nuget/pull/21

Fixes #549 
Potentially related to #602 