### PR TITLE
chore: minor improvements to the ThicknessFilterConverter

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -40,14 +40,14 @@
                     <!--<converters:ThicknessFilterConverter x:Key="BottomOnlyThicknessFilterConverter" Filter="Bottom" />-->
                     <!--<converters:ThicknessFilterConverter x:Key="LeftRightThicknessFilterConverter" Filter="Left,Right" />-->
                     <converters:ThicknessFilterConverter x:Key="TopBottomThicknessFilterConverter" Filter="Top,Bottom" />
-                    <!--<converters:ThicknessFilterConverter x:Key="TopLeftThicknessFilterConverter" Filter="Top,Left" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="TopLeftThicknessFilterConverter" Filter="Left,Top" />-->
                     <!--<converters:ThicknessFilterConverter x:Key="TopRightThicknessFilterConverter" Filter="Top,Right" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="BottomLeftThicknessFilterConverter" Filter="Bottom,Left" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="BottomRightThicknessFilterConverter" Filter="Bottom,Right" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightTopThicknessFilterConverter" Filter="Left,Right,Top" />-->
-                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightBottomThicknessFilterConverter" Filter="Left,Right,Bottom" />-->
-                    <converters:ThicknessFilterConverter x:Key="TopBottomLeftThicknessFilterConverter" Filter="Top,Bottom,Left" />
-                    <converters:ThicknessFilterConverter x:Key="TopBottomRightThicknessFilterConverter" Filter="Top,Bottom,Right" />
+                    <!--<converters:ThicknessFilterConverter x:Key="BottomLeftThicknessFilterConverter" Filter="Left,Bottom" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="BottomRightThicknessFilterConverter" Filter="Right,Bottom" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightAndTopThicknessFilterConverter" Filter="Left,Top,Right" />-->
+                    <!--<converters:ThicknessFilterConverter x:Key="LeftRightAndBottomThicknessFilterConverter" Filter="Left,Right,Bottom" />-->
+                    <converters:ThicknessFilterConverter x:Key="TopBottomAndLeftThicknessFilterConverter" Filter="Left,Top,Bottom" />
+                    <converters:ThicknessFilterConverter x:Key="TopBottomAndRightThicknessFilterConverter" Filter="Top,Right,Bottom" />
                     <ctConverters:BoolNegationConverter x:Key="BoolNegationConverter" />
                     <ctConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
                     <ctConverters:StringVisibilityConverter x:Key="StringVisibilityConverter" />

--- a/Screenbox/Converters/ThicknessFilterConverter.cs
+++ b/Screenbox/Converters/ThicknessFilterConverter.cs
@@ -113,104 +113,13 @@ public sealed partial class ThicknessFilterConverter : DependencyObject, IValueC
     {
         var result = thickness;
 
-        switch (filterKind)
+        if (filterKind is not ThicknessFilterKinds.None)
         {
-            case ThicknessFilterKinds.None:
-                //result.Left = thickness.Left;
-                //result.Top = thickness.Top;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Left:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                result.Right = 0;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Top:
-                result.Left = 0;
-                //result.Top = thickness.Top;
-                result.Right = 0;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top:
-                //result.Left = thickness.Left;
-                //result.Top = thickness.Top;
-                result.Right = 0;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Right:
-                result.Left = 0;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Right:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Right:
-                result.Left = 0;
-                //result.Top = thickness.Top;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Right:
-                //result.Left = thickness.Left;
-                //result.Top = thickness.Top;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKinds.Bottom:
-                result.Left = 0;
-                result.Top = 0;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Bottom:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Bottom:
-                result.Left = 0;
-                //result.Top = thickness.Top;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Bottom:
-                //result.Left = thickness.Left;
-                //result.Top = thickness.Top;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
-                result.Left = 0;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
-                result.Left = 0;
-                //result.Top = thickness.Top;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
-                //result.Left = thickness.Left;
-                //result.Top = thickness.Top;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
+            return new Thickness(
+                filterKind.HasFlag(ThicknessFilterKinds.Left) ? result.Left : 0,
+                filterKind.HasFlag(ThicknessFilterKinds.Top) ? result.Top : 0,
+                filterKind.HasFlag(ThicknessFilterKinds.Right) ? result.Right : 0,
+                filterKind.HasFlag(ThicknessFilterKinds.Bottom) ? result.Bottom : 0);
         }
 
         return result;

--- a/Screenbox/Converters/ThicknessFilterConverter.cs
+++ b/Screenbox/Converters/ThicknessFilterConverter.cs
@@ -7,175 +7,206 @@ using Windows.UI.Xaml.Data;
 namespace Screenbox.Converters;
 
 /// <summary>
-/// An <see cref="IValueConverter"/> that takes an existing <see cref="Thickness"/> struct and returns a new one,
-/// using filters to keep only the specified fields and setting all others to 0.
-/// <example>For example:
+/// Defines constants that specify the filter type for a <see cref="ThicknessFilterConverter"/> instance.
+/// <para>This enumeration supports a bitwise combination of its member values.</para>
+/// </summary>
+/// <remarks>This enumeration is used by the <see cref="ThicknessFilterConverter.Filter"/> property.</remarks>
+[Flags]
+public enum ThicknessFilterKinds
+{
+    /// <summary>
+    /// No filter applied.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Filters Left value, sets Top, Right and Bottom to 0.
+    /// </summary>
+    Left = 1,
+
+    /// <summary>
+    /// Filters Top value, sets Left, Right and Bottom to 0.
+    /// </summary>
+    Top = 2,
+
+    /// <summary>
+    /// Filters Right value, sets Left, Top and Bottom to 0.
+    /// </summary>
+    Right = 4,
+
+    /// <summary>
+    /// Filters Bottom value, sets Left, Top and Right to 0.
+    /// </summary>
+    Bottom = 8,
+}
+
+/// <summary>
+/// Converts an existing <see cref="Thickness"/> struct to a new <see cref="Thickness"/> struct,
+/// with filters applied to extract only the specified fields, leaving the others set to 0.
+/// </summary>
+/// <remarks>
+/// Use the <see cref="ThicknessFilterConverter"/> with a Binding/x:Bind or TemplateBinding
+/// to create a new <see cref="Thickness"/> struct from an existing one.
+/// </remarks>
+/// <example>
+/// The following example shows how to use the <see cref="ThicknessFilterConverter"/> element.
 /// <code lang="xaml">
 /// &lt;ControlTemplate TargetType="Button"&gt;
 ///     &lt;Grid&gt;
 ///         &lt;Grid.Resources&gt;
-///             &lt;local:ThicknessFilterConverter x:Name="TopThicknessFilterConverter" Filter="Top" /&gt;
+///             &lt;local:ThicknessFilterConverter x:Name="VerticalThicknessFilterConverter" Filter="Top,Bottom" /&gt;
 ///         &lt;/Grid.Resources&gt;
 ///         &lt;Border Background="{TemplateBinding Background}"
-///                 BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopThicknessFilterConverter}}"
+///                 BorderBrush="{TemplateBinding BorderBrush}"
+///                 BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource VerticalThicknessFilterConverter}}"
 ///                 Padding="{TemplateBinding Padding}" /&gt;
 ///     &lt;/Grid&gt;
 /// &lt;/ControlTemplate&gt;
-/// 
+/// </code>
+/// <code lang="xaml">
 /// &lt;Grid&gt;
 ///     &lt;Grid.Resources&gt;
-///         &lt;local:ThicknessFilterConverter x:Name="TopThicknessFilterConverter" Filter="Top" /&gt;
+///         &lt;local:ThicknessFilterConverter x:Name="VerticalThicknessFilterConverter" Filter="Top,Bottom" /&gt;
 ///         &lt;Thickness x:Key="ExampleBorderThickness"&gt;1,1,1,1&lt;/Thickness&gt;
 ///     &lt;/Grid.Resources&gt;
-///     &lt;Border Background="Blue"
-///             BorderThickness="{Binding Source={StaticResource ExampleBorderThickness}, Converter={StaticResource TopThicknessFilterConverter}}" /&gt;
+///     &lt;Border Background="DarkBlue"
+///             BorderBrush="Cyan"
+///             BorderThickness="{Binding Source={StaticResource ExampleBorderThickness}, Converter={StaticResource VerticalThicknessFilterConverter}}" /&gt;
 /// &lt;/Grid&gt;
 /// </code>
-/// results in the BorderThickness of the <c>Border</c> having the value "0,1,0,0".
+/// <code lang="cs">
+/// var myBorder = new Border();
+/// var exampleThickness = new Thickness(1, 1, 1, 1);
+/// 
+/// // Create the converter instance and the filter type.
+/// var thicknessConverter = new ThicknessFilterConverter();
+/// var thicknessFilter = ThicknessFilterKinds.Top | ThicknessFilterKinds.Bottom;
+///
+/// // Attach the converter to the target. For example:
+/// myBorder.BorderThickness = thicknessConverter.Convert(exampleThickness, thicknessFilter);
+/// </code>
 /// </example>
-/// </summary>
-public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
+public sealed partial class ThicknessFilterConverter : DependencyObject, IValueConverter
 {
-    /// <summary>
-    /// Specifies the filter type used in a <see cref="ThicknessFilterConverter"/> instance.
-    /// This <see cref="Enum"/> supports a bitwise combination of its member values.
-    /// </summary>
-    [Flags]
-    public enum ThicknessFilterKind
-    {
-        /// <summary>
-        /// No filter applied.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// Filters Left value.
-        /// </summary>
-        Left = 1,
-
-        /// <summary>
-        /// Filters Top value.
-        /// </summary>
-        Top = 2,
-
-        /// <summary>
-        /// Filters Right value.
-        /// </summary>
-        Right = 4,
-
-        /// <summary>
-        /// Filters Bottom value.
-        /// </summary>
-        Bottom = 8
-    }
-
     /// <summary>
     /// Identifies the <see cref="Filter"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
-        nameof(Filter), typeof(ThicknessFilterKind), typeof(ThicknessFilterConverter), new PropertyMetadata(null));
+        nameof(Filter), typeof(ThicknessFilterKinds), typeof(ThicknessFilterConverter), new PropertyMetadata(null));
 
     /// <summary>
     /// Gets or sets the type of the filter applied to the <see cref="ThicknessFilterConverter"/>.
     /// </summary>
-    public ThicknessFilterKind Filter
+    public ThicknessFilterKinds Filter
     {
-        get { return (ThicknessFilterKind)GetValue(FilterProperty); }
+        get { return (ThicknessFilterKinds)GetValue(FilterProperty); }
         set { SetValue(FilterProperty, value); }
     }
 
     /// <summary>
-    /// Extracts, using filters, the specified fields from a <see cref="Thickness"/> struct.
+    /// Extracts the specified fields from a <see cref="Thickness"/> struct.
     /// </summary>
-    /// <param name="thickness">The <see cref="Thickness"/> to convert.</param>
-    /// <param name="filterKind">An <see cref="Enum"/> that defines the filter type.</param>
+    /// <param name="thickness">The source <see cref="Thickness"/> to convert.</param>
+    /// <param name="filterKind">An enumeration that specifies the filter type.</param>
     /// <returns>A <see cref="Thickness"/> with only the fields specified by the filter, while the rest are set to 0.</returns>
-    public Thickness ExtractThickness(Thickness thickness, ThicknessFilterKind filterKind)
+    public Thickness Convert(Thickness thickness, ThicknessFilterKinds filterKind)
     {
-        Thickness result = thickness;
+        var result = thickness;
 
         switch (filterKind)
         {
-            case ThicknessFilterKind.Left:
+            case ThicknessFilterKinds.None:
+                //result.Left = thickness.Left;
+                //result.Top = thickness.Top;
+                //result.Right = thickness.Right;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Left:
                 //result.Left = thickness.Left;
                 result.Top = 0;
                 result.Right = 0;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.Top:
+            case ThicknessFilterKinds.Top:
                 result.Left = 0;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.Right:
-                result.Left = 0;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKind.Bottom:
-                result.Left = 0;
-                result.Top = 0;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKind.Left | ThicknessFilterKind.Right:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                result.Bottom = 0;
-                break;
-            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom:
-                result.Left = 0;
-                //result.Top = thickness.Top;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKind.Top | ThicknessFilterKind.Left:
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.Top | ThicknessFilterKind.Right:
+            case ThicknessFilterKinds.Right:
+                result.Left = 0;
+                result.Top = 0;
+                //result.Right = thickness.Right;
+                result.Bottom = 0;
+                break;
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Right:
+                //result.Left = thickness.Left;
+                result.Top = 0;
+                //result.Right = thickness.Right;
+                result.Bottom = 0;
+                break;
+            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Right:
                 result.Left = 0;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.Bottom | ThicknessFilterKind.Left:
-                //result.Left = thickness.Left;
-                result.Top = 0;
-                result.Right = 0;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKind.Bottom | ThicknessFilterKind.Right:
-                result.Left = 0;
-                result.Top = 0;
-                //result.Right = thickness.Right;
-                //result.Bottom = thickness.Bottom;
-                break;
-            case ThicknessFilterKind.Left | ThicknessFilterKind.Right | ThicknessFilterKind.Top:
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Right:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;
                 result.Bottom = 0;
                 break;
-            case ThicknessFilterKind.Left | ThicknessFilterKind.Right | ThicknessFilterKind.Bottom:
-                //result.Left = thickness.Left;
+            case ThicknessFilterKinds.Bottom:
+                result.Left = 0;
                 result.Top = 0;
-                //result.Right = thickness.Right;
+                result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom | ThicknessFilterKind.Left:
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Bottom:
+                //result.Left = thickness.Left;
+                result.Top = 0;
+                result.Right = 0;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Bottom:
+                result.Left = 0;
+                //result.Top = thickness.Top;
+                result.Right = 0;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Bottom:
                 //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 result.Right = 0;
                 //result.Bottom = thickness.Bottom;
                 break;
-            case ThicknessFilterKind.Top | ThicknessFilterKind.Bottom | ThicknessFilterKind.Right:
+            case ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
                 result.Left = 0;
+                result.Top = 0;
+                //result.Right = thickness.Right;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
+                //result.Left = thickness.Left;
+                result.Top = 0;
+                //result.Right = thickness.Right;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Top | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
+                result.Left = 0;
+                //result.Top = thickness.Top;
+                //result.Right = thickness.Right;
+                //result.Bottom = thickness.Bottom;
+                break;
+            case ThicknessFilterKinds.Left | ThicknessFilterKinds.Top | ThicknessFilterKinds.Right | ThicknessFilterKinds.Bottom:
+                //result.Left = thickness.Left;
                 //result.Top = thickness.Top;
                 //result.Right = thickness.Right;
                 //result.Bottom = thickness.Bottom;
@@ -197,12 +228,11 @@ public sealed class ThicknessFilterConverter : DependencyObject, IValueConverter
     {
         if (value is Thickness thickness)
         {
-            return ExtractThickness(thickness, Filter);
+            var filterType = Filter;
+            return Convert(thickness, filterType);
         }
-        else
-        {
-            return value;
-        }
+
+        return value;
     }
 
     /// <summary>

--- a/Screenbox/Styles/Button.xaml
+++ b/Screenbox/Styles/Button.xaml
@@ -534,7 +534,7 @@
                             contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
                             contract7Present:CornerRadius="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
                             Background="{TemplateBinding Background}"
-                            BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}">
+                            BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}">
                             <!--  Add brush transition to match the default button  -->
                             <contract7Present:Grid.BackgroundTransition>
                                 <contract7Present:BrushTransition Duration="0:0:0.083" />
@@ -561,7 +561,7 @@
                             contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}"
                             contract7Present:CornerRadius="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource RightCornerRadiusFilterConverter}}"
                             Background="{TemplateBinding Background}"
-                            BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}">
+                            BorderThickness="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}">
                             <!--  Add a brush transition to match the default button  -->
                             <contract7Present:Grid.BackgroundTransition>
                                 <contract7Present:BrushTransition Duration="0:0:0.083" />
@@ -1116,8 +1116,8 @@
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundSecondary}" />
                                         <Setter Target="DividerBackgroundGrid.Background" Value="{ThemeResource SplitButtonBorderBrushDivider}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1132,8 +1132,8 @@
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundSecondaryPressed}" />
                                         <Setter Target="DividerBackgroundGrid.Background" Value="{ThemeResource SplitButtonBorderBrushDivider}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1148,8 +1148,8 @@
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundSecondaryPressed}" />
                                         <Setter Target="DividerBackgroundGrid.Background" Value="{ThemeResource SplitButtonBorderBrushDivider}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1166,8 +1166,8 @@
                                         <!--  Add a border to match default button style in high contrast  -->
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1186,8 +1186,8 @@
                                         <Setter Target="SecondaryBackgroundGrid.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}" />
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource ControlFillColorTransparentBrush}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1204,8 +1204,8 @@
                                         <!--  Add a border to match default button style in high contrast  -->
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -1224,8 +1224,8 @@
                                         <Setter Target="SecondaryBackgroundGrid.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}" />
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource ControlFillColorTransparentBrush}" />
                                         <!--  Work around for the background sizing issue, microsoft/microsoft-ui-xaml#6885  -->
-                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomLeftThicknessFilterConverter}}" />
-                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomRightThicknessFilterConverter}}" />
+                                        <Setter Target="PrimaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndLeftThicknessFilterConverter}}" />
+                                        <Setter Target="SecondaryBackgroundGrid.BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopBottomAndRightThicknessFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
Refactors the converter for improved usability (specially for C#) and simplicity.

- Moves the enum outside the class for improved usability
- Renames the enum to follow the naming [guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#naming-enumerations) by using the plural form
- Renames the `ExtractThickness` method to `Convert` for improved usability
- Simplifies the filtering logic by replacing the switch statement with the `HasFlag` method
- Small adjustments to the converter `XAML` resource names
- Improves and adds some comments remarks