### PR TITLE
chore: refactor PlaylistView selection handling

### DIFF
--- a/Screenbox.Core/ViewModels/CommonViewModel.cs
+++ b/Screenbox.Core/ViewModels/CommonViewModel.cs
@@ -1,5 +1,8 @@
 ﻿#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -8,12 +11,10 @@ using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -128,6 +129,29 @@ namespace Screenbox.Core.ViewModels
             {
                 Messenger.Send(new ErrorMessage(
                     _resourceService.GetString(ResourceName.FailedToOpenFilesNotificationTitle), e.Message));
+            }
+        }
+
+        /// <summary>
+        /// Toggles the selection state of all items in the specified <see cref="ListViewBase"/>.
+        /// </summary>
+        /// <param name="listViewBase">The list that contains the items to change the selection state.</param>
+        [RelayCommand]
+        private void ToggleListViewBaseItemSelection(ListViewBase? listViewBase)
+        {
+            if (listViewBase == null) return;
+            if (listViewBase.SelectionMode == ListViewSelectionMode.Multiple ||
+                listViewBase.SelectionMode == ListViewSelectionMode.Extended)
+            {
+                var allItemsRange = new ItemIndexRange(0, (uint)listViewBase.Items.Count);
+                if (listViewBase.SelectedItems.Count != listViewBase.Items.Count)
+                {
+                    listViewBase.SelectRange(allItemsRange);
+                }
+                else
+                {
+                    listViewBase.DeselectRange(allItemsRange);
+                }
             }
         }
     }

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -226,7 +226,8 @@
                             d:Content="11 items selected"
                             AutomationProperties.HelpText="{x:Bind system:Convert.ToString(SelectionCheckBox.Content), Mode=OneWay}"
                             AutomationProperties.Name="{x:Bind strings:Resources.SelectAll}"
-                            Click="SelectionCheckBox_OnClick"
+                            Command="{x:Bind Common.ToggleListViewBaseItemSelectionCommand}"
+                            CommandParameter="{x:Bind Path=PlaylistListView}"
                             Content="{x:Bind strings:Resources.ItemsSelected(ViewModel.SelectionCount), Mode=OneWay}"
                             ToolTipService.ToolTip="{x:Bind GetSelectionCheckBoxToolTip(SelectionCheckBox.IsChecked), Mode=OneWay}" />
                         <TextBlock Padding="{x:Bind Path=SelectionCheckBox.Padding, Converter={StaticResource TopBottomThicknessFilterConverter}}" Text="•" />

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -48,18 +48,6 @@ namespace Screenbox.Controls
             await PlaylistListView.SmoothScrollIntoViewWithItemAsync(ViewModel.Playlist.CurrentItem, ScrollItemPlacement.Center);
         }
 
-        private void SelectionCheckBox_OnClick(object sender, RoutedEventArgs e)
-        {
-            if (SelectionCheckBox.IsChecked ?? false)
-            {
-                PlaylistListView.SelectAll();
-            }
-            else
-            {
-                PlaylistListView.SelectedItems.Clear();
-            }
-        }
-
         private void PlaylistListView_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             SelectionCheckBox.IsChecked = PlaylistListView.SelectedItems.Count == ViewModel.Playlist.Items.Count;

--- a/Screenbox/Controls/PlaylistView.xaml.cs
+++ b/Screenbox/Controls/PlaylistView.xaml.cs
@@ -128,17 +128,18 @@ namespace Screenbox.Controls
 
         private void SelectDeselectAllKeyboardAccelerator_OnInvoked(Windows.UI.Xaml.Input.KeyboardAccelerator sender, Windows.UI.Xaml.Input.KeyboardAcceleratorInvokedEventArgs args)
         {
-            if (PlaylistListView.Items.Count > 0)
+            if (ViewModel.HasItems)
             {
-                if (PlaylistListView.SelectedItems.Count != ViewModel.Playlist.Items.Count)
+                var itemsRange = new ItemIndexRange(0, (uint)ViewModel.Playlist.Items.Count);
+                if (ViewModel.SelectionCount != ViewModel.Playlist.Items.Count)
                 {
-                    MultiSelectToggle.IsChecked = true;
-                    PlaylistListView.SelectRange(new ItemIndexRange(0, (uint)PlaylistListView.Items.Count));
+                    ViewModel.EnableMultiSelect = true;
+                    PlaylistListView.SelectRange(itemsRange);
                     args.Handled = true;
                 }
                 else
                 {
-                    PlaylistListView.DeselectRange(new ItemIndexRange(0, (uint)PlaylistListView.Items.Count));
+                    PlaylistListView.DeselectRange(itemsRange);
                     args.Handled = true;
                 }
             }


### PR DESCRIPTION
Replaces the `SelectionCheckBox` click event with a re-usable command.