### PR TITLE
style: add ListView style and improve the extension

### DIFF
--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -290,8 +290,6 @@
             Grid.Row="1"
             Margin="{StaticResource TopMediumMargin}"
             Padding="{x:Bind Padding, Mode=OneWay}"
-            extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-            extensions:ListViewExtensions.ItemMargin="0,2,0,2"
             ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"
             AllowDrop="True"
@@ -300,11 +298,11 @@
             DragOver="PlaylistListView_OnDragOver"
             Drop="PlaylistListView_OnDrop"
             IsItemClickEnabled="True"
-            ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Playlist.Items}"
             KeyboardAcceleratorPlacementMode="Hidden"
             SelectionChanged="PlaylistListView_OnSelectionChanged"
-            SelectionMode="Extended">
+            SelectionMode="Extended"
+            Style="{StaticResource MediaListViewStyle}">
             <ListView.Resources>
                 <x:Boolean x:Key="ListViewItemSelectionIndicatorVisualEnabled">False</x:Boolean>
             </ListView.Resources>

--- a/Screenbox/Controls/PlaylistView.xaml
+++ b/Screenbox/Controls/PlaylistView.xaml
@@ -7,7 +7,7 @@
     xmlns:ctAnimations="using:CommunityToolkit.WinUI.Animations"
     xmlns:ctConverters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"

--- a/Screenbox/Extensions/ApplicationViewExtensions.cs
+++ b/Screenbox/Extensions/ApplicationViewExtensions.cs
@@ -1,7 +1,16 @@
-﻿using Windows.UI.ViewManagement;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Source: https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/main/Microsoft.Toolkit.Uwp.UI/Extensions/ApplicationViewExtensions.cs
+
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Controls;
 
 namespace Screenbox.Extensions;
+
+/// <summary>
+/// Provides attached properties for interacting with the <see cref="Windows.UI.ViewManagement.ApplicationView"/> on a window (app view).
+/// </summary>
 public static class ApplicationViewExtensions
 {
     /// <summary>

--- a/Screenbox/Extensions/ApplicationViewExtensions.cs
+++ b/Screenbox/Extensions/ApplicationViewExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Controls;
 
-namespace Screenbox.Controls.Extensions;
+namespace Screenbox.Extensions;
 public static class ApplicationViewExtensions
 {
     /// <summary>

--- a/Screenbox/Extensions/CommandBarExtensions.cs
+++ b/Screenbox/Extensions/CommandBarExtensions.cs
@@ -2,7 +2,7 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Screenbox.Controls.Extensions;
+namespace Screenbox.Extensions;
 
 /// <summary>
 /// Provides attached dependency properties for the <see cref="CommandBar"/> control.

--- a/Screenbox/Extensions/ListViewExtensions.cs
+++ b/Screenbox/Extensions/ListViewExtensions.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 
-namespace Screenbox.Controls.Extensions
+namespace Screenbox.Extensions
 {
     public static class ListViewExtensions
     {

--- a/Screenbox/Extensions/ListViewExtensions.cs
+++ b/Screenbox/Extensions/ListViewExtensions.cs
@@ -3,63 +3,254 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 
-namespace Screenbox.Extensions
+namespace Screenbox.Extensions;
+
+/// <summary>
+/// Provides attached dependency properties for the <see cref="ListViewBase"/> control.
+/// </summary>
+public static class ListViewExtensions
 {
-    public static class ListViewExtensions
+    private static readonly bool IsApiContract13Present = Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 13);
+
+    /// <summary>
+    /// Identifies the attached dependency property that specifies the <see cref="CornerRadius"/> for the items in a <see cref="ListViewBase"/>.
+    /// </summary>
+    public static readonly DependencyProperty ItemCornerRadiusProperty = DependencyProperty.RegisterAttached(
+        "ItemCornerRadius", typeof(CornerRadius), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemCornerRadiusPropertyChanged));
+
+    /// <summary>
+    /// Gets the value of the ItemCornerRadius attached property from the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
+    /// <returns>The current value of the ItemCornerRadius attached property on the specified <see cref="ListViewBase"/>.</returns>
+    public static CornerRadius GetItemCornerRadius(ListViewBase element)
     {
-        public static readonly DependencyProperty ItemCornerRadiusProperty = DependencyProperty.RegisterAttached(
-            "ItemCornerRadius",
-            typeof(CornerRadius),
-            typeof(ListViewExtensions),
-            new PropertyMetadata(default(CornerRadius), OnAttachedPropertyChanged));
+        return (CornerRadius)element.GetValue(ItemCornerRadiusProperty);
+    }
 
-        public static readonly DependencyProperty ItemMarginProperty = DependencyProperty.RegisterAttached(
-            "ItemMargin",
-            typeof(Thickness),
-            typeof(ListViewExtensions),
-            new PropertyMetadata(default(Thickness), OnAttachedPropertyChanged));
+    /// <summary>
+    /// Sets the value of the ItemCornerRadius attached property on the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
+    /// <param name="value">The new value to set the property to.</param>
+    public static void SetItemCornerRadius(ListViewBase element, CornerRadius value)
+    {
+        element.SetValue(ItemCornerRadiusProperty, value);
+    }
 
-        public static void SetItemMargin(DependencyObject element, Thickness value)
+    /// <summary>
+    /// Identifies the attached dependency property that specifies the margin between items in a <see cref="ListViewBase"/>.
+    /// </summary>
+    public static readonly DependencyProperty ItemMarginProperty = DependencyProperty.RegisterAttached(
+        "ItemMargin", typeof(Thickness), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemMarginPropertyChanged));
+
+    /// <summary>
+    /// Gets the value of the ItemMargin attached property from the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
+    /// <returns>The current value of the ItemMargin attached property on the specified <see cref="ListViewBase"/>.</returns>
+    public static Thickness GetItemMargin(ListViewBase element)
+    {
+        return (Thickness)element.GetValue(ItemMarginProperty);
+    }
+
+    /// <summary>
+    /// Sets the value of the ItemMargin attached property on the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
+    /// <param name="value">The new value to set the property to.</param>
+    public static void SetItemMargin(ListViewBase element, Thickness value)
+    {
+        element.SetValue(ItemMarginProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the attached dependency property that specifies the minimum height for items in a <see cref="ListView"/>.
+    /// </summary>
+    public static readonly DependencyProperty ItemMinHeightProperty = DependencyProperty.RegisterAttached(
+        "ItemMinHeight", typeof(double), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemMinHeightPropertyChanged));
+
+    /// <summary>
+    /// Gets the value of the ItemMinHeight attached property from the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
+    /// <returns>The current value of the ItemMinHeight attached property on the specified <see cref="ListViewBase"/>.</returns>
+    public static double GetItemMinHeight(ListViewBase element)
+    {
+        return (double)element.GetValue(ItemMinHeightProperty);
+    }
+
+    /// <summary>
+    /// Sets the value of the ItemMinHeight attached property on the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
+    /// <param name="value">The new value to set the property to.</param>
+    public static void SetItemMinHeight(ListViewBase element, double value)
+    {
+        element.SetValue(ItemMinHeightProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the attached dependency property that specifies whether focus can be constrained to the items in a <see cref="ListViewBase"/>.
+    /// </summary>
+    public static readonly DependencyProperty ItemIsFocusEngagementEnabledProperty = DependencyProperty.RegisterAttached(
+        "ItemIsFocusEngagementEnabled", typeof(bool), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemIsFocusEngagementEnabledPropertyChanged));
+
+    /// <summary>
+    /// Gets the value of the ItemIsFocusEngagementEnabled attached property from the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
+    /// <returns>The current value of the ItemIsFocusEngagementEnabled attached property on the specified <see cref="ListViewBase"/>.</returns>
+    public static bool GetItemIsFocusEngagementEnabled(ListViewBase element)
+    {
+        return (bool)element.GetValue(ItemIsFocusEngagementEnabledProperty);
+    }
+
+    /// <summary>
+    /// Sets the value of the ItemIsFocusEngagementEnabled attached property on the specified <see cref="ListViewBase"/>.
+    /// </summary>
+    /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
+    /// <param name="value">The new value to set the property to.</param>
+    public static void SetItemIsFocusEngagementEnabled(ListViewBase element, bool value)
+    {
+        element.SetValue(ItemIsFocusEngagementEnabledProperty, value);
+    }
+
+    private static void OnListViewBaseUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is ListViewBase listViewBase)
         {
-            element.SetValue(ItemMarginProperty, value);
+            listViewBase.ContainerContentChanging -= ItemCornerRadiusOnContainerContentChanging;
+            listViewBase.ContainerContentChanging -= ItemMarginOnContainerContentChanging;
+            listViewBase.ContainerContentChanging -= ItemMinHeightOnContainerContentChanging;
+            listViewBase.ContainerContentChanging -= ItemIsFocusEngagementEnabledOnContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
         }
+    }
 
-        public static Thickness GetItemMargin(DependencyObject element)
+    private static void OnItemCornerRadiusPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        if (sender is ListViewBase listViewBase)
         {
-            return (Thickness)element.GetValue(ItemMarginProperty);
-        }
+            listViewBase.ContainerContentChanging -= ItemCornerRadiusOnContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
-        public static void SetItemCornerRadius(DependencyObject element, CornerRadius value)
-        {
-            element.SetValue(ItemCornerRadiusProperty, value);
-        }
-
-        public static CornerRadius GetItemCornerRadius(DependencyObject element)
-        {
-            return (CornerRadius)element.GetValue(ItemCornerRadiusProperty);
-        }
-
-        private static void OnAttachedPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is not ListViewBase listView) return;
-            listView.ContainerContentChanging -= ListViewOnContainerContentChanging;
-            listView.ContainerContentChanging += ListViewOnContainerContentChanging;
-        }
-
-        private static void ListViewOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
-        {
-            if (args.Phase > 0 || args.InRecycleQueue) return;
-            CornerRadius cornerRadius = GetItemCornerRadius(sender);
-            Thickness margin = GetItemMargin(sender);
-            if (args.ItemContainer.FindDescendant<ListViewItemPresenter>() is { } presenter)
+            if (ItemCornerRadiusProperty != null)
             {
-                presenter.CornerRadius = cornerRadius;
-            }
-
-            if (args.ItemContainer.FindDescendant<Border>() is { } border)
-            {
-                border.Margin = margin;
+                listViewBase.ContainerContentChanging += ItemCornerRadiusOnContainerContentChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
             }
         }
+    }
+
+    private static void ItemCornerRadiusOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.Phase > 0 || args.InRecycleQueue) return;
+        var presenter = args.ItemContainer.FindDescendant<ListViewItemPresenter>();
+        if (presenter != null)
+        {
+            presenter.CornerRadius = GetItemCornerRadius(sender);
+        }
+    }
+
+    private static void OnItemMarginPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        if (sender is ListViewBase listViewBase)
+        {
+            listViewBase.ContainerContentChanging -= ItemMarginOnContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
+
+            if (ItemMarginProperty != null)
+            {
+                listViewBase.ContainerContentChanging += ItemMarginOnContainerContentChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
+            }
+        }
+    }
+
+    private static void ItemMarginOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.Phase > 0 || args.InRecycleQueue) return;
+        if (!IsApiContract13Present)
+        {
+            // In Windows 10, the ListViewItemPresenter doesn't have an inner Border element,
+            // resulting in the margin being applied at the ListViewItem container level.
+            // This introduces an inactive hit-test region around the visual bounds of the item.
+            args.ItemContainer.Margin = GetItemMargin(sender);
+        }
+        else
+        {
+            // The ListViewItemPresenter in Windows 11 appears to have an inner Border element,
+            // likely intended to visually separate items while adhering to the minimum
+            // touch target size guidelines of 40x40 effective pixels.
+            //
+            //  __________________________
+            // | Border     2px           |
+            // |      ______________      |
+            // |     |     36px     |     |
+            // | 4px |    Content   | 4px |
+            // |     |______________|     |
+            // |            2px           |
+            // |__________________________|
+            //
+            var border = args.ItemContainer.FindDescendant<Border>();
+            if (border != null)
+            {
+                border.Margin = GetItemMargin(sender);
+            }
+        }
+    }
+
+    private static void OnItemMinHeightPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        if (sender is ListViewBase listViewBase)
+        {
+            listViewBase.ContainerContentChanging -= ItemMinHeightOnContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
+
+            if (ItemMinHeightProperty != null)
+            {
+                listViewBase.ContainerContentChanging += ItemMinHeightOnContainerContentChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
+            }
+        }
+    }
+
+    private static void ItemMinHeightOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.Phase > 0 || args.InRecycleQueue) return;
+        if (!IsApiContract13Present && ItemMarginProperty != null)
+        {
+            var margin = GetItemMargin(sender);
+            double offsetMargin = margin.Top + margin.Bottom;
+
+            // Adjustment required to accommodate the added item container margin.
+            args.ItemContainer.MinHeight = GetItemMinHeight(sender) - offsetMargin;
+        }
+        else
+        {
+            args.ItemContainer.MinHeight = GetItemMinHeight(sender);
+        }
+    }
+
+    private static void OnItemIsFocusEngagementEnabledPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+    {
+        if (sender is ListViewBase listViewBase)
+        {
+            listViewBase.ContainerContentChanging -= ItemIsFocusEngagementEnabledOnContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
+
+            if (ItemIsFocusEngagementEnabledProperty != null)
+            {
+                listViewBase.ContainerContentChanging += ItemIsFocusEngagementEnabledOnContainerContentChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
+            }
+        }
+    }
+
+    private static void ItemIsFocusEngagementEnabledOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+    {
+        if (args.Phase > 0 || args.InRecycleQueue) return;
+        args.ItemContainer.IsFocusEngagementEnabled = GetItemIsFocusEngagementEnabled(sender);
     }
 }

--- a/Screenbox/Extensions/ListViewExtensions.cs
+++ b/Screenbox/Extensions/ListViewExtensions.cs
@@ -149,7 +149,8 @@ public static class ListViewExtensions
         var presenter = args.ItemContainer.FindDescendant<ListViewItemPresenter>();
         if (presenter != null)
         {
-            presenter.CornerRadius = GetItemCornerRadius(sender);
+            var cornerRadius = GetItemCornerRadius(sender);
+            presenter.CornerRadius = cornerRadius;
         }
     }
 
@@ -171,12 +172,13 @@ public static class ListViewExtensions
     private static void ItemMarginOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
         if (args.Phase > 0 || args.InRecycleQueue) return;
+        var margin = GetItemMargin(sender);
         if (!IsApiContract13Present)
         {
             // Due to the absence of a Border element in the Windows 10 ListViewItem,
             // margin must be set at the container level. This introduces an inactive
             // hit-test region around the visual bounds of the item.
-            args.ItemContainer.Margin = GetItemMargin(sender);
+            args.ItemContainer.Margin = margin;
         }
         else
         {
@@ -207,7 +209,7 @@ public static class ListViewExtensions
             var border = args.ItemContainer.FindDescendant<Border>();
             if (border != null)
             {
-                border.Margin = GetItemMargin(sender);
+                border.Margin = margin;
             }
         }
     }
@@ -230,6 +232,7 @@ public static class ListViewExtensions
     private static void ItemMinHeightOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
         if (args.Phase > 0 || args.InRecycleQueue) return;
+        var minHeight = GetItemMinHeight(sender);
         if (!IsApiContract13Present && ItemMarginProperty != null)
         {
             var margin = GetItemMargin(sender);
@@ -237,11 +240,11 @@ public static class ListViewExtensions
 
             // If a margin is applied to the container, we have to subtract the vertical values
             // from the minimum height to ensure it matches the Windows 11 ListViewItem dimensions.
-            args.ItemContainer.MinHeight = GetItemMinHeight(sender) - offsetMargin;
+            args.ItemContainer.MinHeight = minHeight - offsetMargin;
         }
         else
         {
-            args.ItemContainer.MinHeight = GetItemMinHeight(sender);
+            args.ItemContainer.MinHeight = minHeight;
         }
     }
 

--- a/Screenbox/Extensions/ListViewExtensions.cs
+++ b/Screenbox/Extensions/ListViewExtensions.cs
@@ -18,16 +18,19 @@ public static class ListViewExtensions
     /// Identifies the attached dependency property that specifies the <see cref="CornerRadius"/> of <see cref="ListViewBase"/> item.
     /// </summary>
     public static readonly DependencyProperty ItemCornerRadiusProperty = DependencyProperty.RegisterAttached(
-        "ItemCornerRadius", typeof(CornerRadius), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemCornerRadiusPropertyChanged));
+        "ItemCornerRadius",
+        typeof(CornerRadius?),
+        typeof(ListViewExtensions),
+        new PropertyMetadata(null, OnItemCornerRadiusPropertyChanged));
 
     /// <summary>
     /// Gets the value of the ItemCornerRadius attached property from the specified <see cref="ListViewBase"/>.
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
     /// <returns>The current value of the ItemCornerRadius attached property on the specified <see cref="ListViewBase"/>.</returns>
-    public static CornerRadius GetItemCornerRadius(ListViewBase element)
+    public static CornerRadius? GetItemCornerRadius(ListViewBase element)
     {
-        return (CornerRadius)element.GetValue(ItemCornerRadiusProperty);
+        return (CornerRadius?)element.GetValue(ItemCornerRadiusProperty);
     }
 
     /// <summary>
@@ -35,7 +38,7 @@ public static class ListViewExtensions
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
     /// <param name="value">The new value to set the property to.</param>
-    public static void SetItemCornerRadius(ListViewBase element, CornerRadius value)
+    public static void SetItemCornerRadius(ListViewBase element, CornerRadius? value)
     {
         element.SetValue(ItemCornerRadiusProperty, value);
     }
@@ -44,16 +47,19 @@ public static class ListViewExtensions
     /// Identifies the attached dependency property that specifies the margin of the <see cref="ListViewBase"/> item.
     /// </summary>
     public static readonly DependencyProperty ItemMarginProperty = DependencyProperty.RegisterAttached(
-        "ItemMargin", typeof(Thickness), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemMarginPropertyChanged));
+        "ItemMargin",
+        typeof(Thickness?),
+        typeof(ListViewExtensions),
+        new PropertyMetadata(null, OnItemMarginPropertyChanged));
 
     /// <summary>
     /// Gets the value of the ItemMargin attached property from the specified <see cref="ListViewBase"/>.
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
     /// <returns>The current value of the ItemMargin attached property on the specified <see cref="ListViewBase"/>.</returns>
-    public static Thickness GetItemMargin(ListViewBase element)
+    public static Thickness? GetItemMargin(ListViewBase element)
     {
-        return (Thickness)element.GetValue(ItemMarginProperty);
+        return (Thickness?)element.GetValue(ItemMarginProperty);
     }
 
     /// <summary>
@@ -61,7 +67,7 @@ public static class ListViewExtensions
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
     /// <param name="value">The new value to set the property to.</param>
-    public static void SetItemMargin(ListViewBase element, Thickness value)
+    public static void SetItemMargin(ListViewBase element, Thickness? value)
     {
         element.SetValue(ItemMarginProperty, value);
     }
@@ -70,16 +76,19 @@ public static class ListViewExtensions
     /// Identifies the attached dependency property that specifies the minimum height of the <see cref="ListView"/> item.
     /// </summary>
     public static readonly DependencyProperty ItemMinHeightProperty = DependencyProperty.RegisterAttached(
-        "ItemMinHeight", typeof(double), typeof(ListViewExtensions), new PropertyMetadata(default(double), OnItemMinHeightPropertyChanged));
+        "ItemMinHeight",
+        typeof(double?),
+        typeof(ListViewExtensions),
+        new PropertyMetadata(null, OnItemMinHeightPropertyChanged));
 
     /// <summary>
     /// Gets the value of the ItemMinHeight attached property from the specified <see cref="ListViewBase"/>.
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
     /// <returns>The current value of the ItemMinHeight attached property on the specified <see cref="ListViewBase"/>.</returns>
-    public static double GetItemMinHeight(ListViewBase element)
+    public static double? GetItemMinHeight(ListViewBase element)
     {
-        return (double)element.GetValue(ItemMinHeightProperty);
+        return (double?)element.GetValue(ItemMinHeightProperty);
     }
 
     /// <summary>
@@ -87,7 +96,7 @@ public static class ListViewExtensions
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
     /// <param name="value">The new value to set the property to.</param>
-    public static void SetItemMinHeight(ListViewBase element, double value)
+    public static void SetItemMinHeight(ListViewBase element, double? value)
     {
         element.SetValue(ItemMinHeightProperty, value);
     }
@@ -96,16 +105,19 @@ public static class ListViewExtensions
     /// Identifies the attached dependency property that specifies whether focus can be constrained to the items in a <see cref="ListViewBase"/>.
     /// </summary>
     public static readonly DependencyProperty ItemIsFocusEngagementEnabledProperty = DependencyProperty.RegisterAttached(
-        "ItemIsFocusEngagementEnabled", typeof(bool), typeof(ListViewExtensions), new PropertyMetadata(null, OnItemIsFocusEngagementEnabledPropertyChanged));
+        "ItemIsFocusEngagementEnabled",
+        typeof(bool?),
+        typeof(ListViewExtensions),
+        new PropertyMetadata(null, OnItemIsFocusEngagementEnabledPropertyChanged));
 
     /// <summary>
     /// Gets the value of the ItemIsFocusEngagementEnabled attached property from the specified <see cref="ListViewBase"/>.
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> from which the property value is read.</param>
     /// <returns>The current value of the ItemIsFocusEngagementEnabled attached property on the specified <see cref="ListViewBase"/>.</returns>
-    public static bool GetItemIsFocusEngagementEnabled(ListViewBase element)
+    public static bool? GetItemIsFocusEngagementEnabled(ListViewBase element)
     {
-        return (bool)element.GetValue(ItemIsFocusEngagementEnabledProperty);
+        return (bool?)element.GetValue(ItemIsFocusEngagementEnabledProperty);
     }
 
     /// <summary>
@@ -113,7 +125,7 @@ public static class ListViewExtensions
     /// </summary>
     /// <param name="element">The <see cref="ListViewBase"/> on which to set the property value.</param>
     /// <param name="value">The new value to set the property to.</param>
-    public static void SetItemIsFocusEngagementEnabled(ListViewBase element, bool value)
+    public static void SetItemIsFocusEngagementEnabled(ListViewBase element, bool? value)
     {
         element.SetValue(ItemIsFocusEngagementEnabledProperty, value);
     }
@@ -137,7 +149,7 @@ public static class ListViewExtensions
             listViewBase.ContainerContentChanging -= ItemCornerRadiusOnContainerContentChanging;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
-            if (ItemCornerRadiusProperty != null)
+            if (GetItemCornerRadius(listViewBase) != null)
             {
                 listViewBase.ContainerContentChanging += ItemCornerRadiusOnContainerContentChanging;
                 listViewBase.Unloaded += OnListViewBaseUnloaded;
@@ -152,7 +164,7 @@ public static class ListViewExtensions
             listViewBase.ContainerContentChanging -= ItemMarginOnContainerContentChanging;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
-            if (ItemMarginProperty != null)
+            if (GetItemMargin(listViewBase) != null)
             {
                 listViewBase.ContainerContentChanging += ItemMarginOnContainerContentChanging;
                 listViewBase.Unloaded += OnListViewBaseUnloaded;
@@ -167,7 +179,7 @@ public static class ListViewExtensions
             listViewBase.ContainerContentChanging -= ItemMinHeightOnContainerContentChanging;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
-            if (ItemMinHeightProperty != null)
+            if (GetItemMinHeight(listViewBase) != null)
             {
                 listViewBase.ContainerContentChanging += ItemMinHeightOnContainerContentChanging;
                 listViewBase.Unloaded += OnListViewBaseUnloaded;
@@ -182,7 +194,7 @@ public static class ListViewExtensions
             listViewBase.ContainerContentChanging -= ItemIsFocusEngagementEnabledOnContainerContentChanging;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
-            if (ItemIsFocusEngagementEnabledProperty != null)
+            if (GetItemIsFocusEngagementEnabled(listViewBase) != null)
             {
                 listViewBase.ContainerContentChanging += ItemIsFocusEngagementEnabledOnContainerContentChanging;
                 listViewBase.Unloaded += OnListViewBaseUnloaded;
@@ -194,21 +206,16 @@ public static class ListViewExtensions
     private static void ItemCornerRadiusOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
         if (args.Phase > 0 || args.InRecycleQueue) return;
-
         var presenter = args.ItemContainer.FindDescendant<ListViewItemPresenter>();
-        if (presenter != null)
+        if (presenter != null && GetItemCornerRadius(sender) is { } cornerRadius)
         {
-            var cornerRadius = GetItemCornerRadius(sender);
             presenter.CornerRadius = cornerRadius;
         }
     }
 
     private static void ItemMarginOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
-        if (args.Phase > 0 || args.InRecycleQueue) return;
-
-        var margin = GetItemMargin(sender);
-
+        if (args.Phase > 0 || args.InRecycleQueue || GetItemMargin(sender) is not { } margin) return;
         if (IsApiContract13Present)
         {
             // The ListViewItem in Windows 11 appears to have a Border element with a margin of '4,2,4,2',
@@ -252,13 +259,9 @@ public static class ListViewExtensions
 
     private static void ItemMinHeightOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
-        if (args.Phase > 0 || args.InRecycleQueue) return;
-
-        double minHeight = GetItemMinHeight(sender);
-
-        if (!IsApiContract13Present && ItemMarginProperty != null)
+        if (args.Phase > 0 || args.InRecycleQueue || GetItemMinHeight(sender) is not { } minHeight) return;
+        if (!IsApiContract13Present && GetItemMargin(sender) is { } margin)
         {
-            var margin = GetItemMargin(sender);
             double offsetMargin = margin.Top + margin.Bottom;
             double normalizedMinHeight = minHeight - offsetMargin;
 
@@ -277,8 +280,7 @@ public static class ListViewExtensions
 
     private static void ItemIsFocusEngagementEnabledOnContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
     {
-        if (args.Phase > 0 || args.InRecycleQueue) return;
-
-        args.ItemContainer.IsFocusEngagementEnabled = GetItemIsFocusEngagementEnabled(sender);
+        if (args.Phase > 0 || args.InRecycleQueue || GetItemIsFocusEngagementEnabled(sender) is not { } isEnabled) return;
+        args.ItemContainer.IsFocusEngagementEnabled = isEnabled;
     }
 }

--- a/Screenbox/Extensions/SplitButtonExtensions.cs
+++ b/Screenbox/Extensions/SplitButtonExtensions.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Input;
 
 using SplitButton = Microsoft.UI.Xaml.Controls.SplitButton;
 
-namespace Screenbox.Controls.Extensions;
+namespace Screenbox.Extensions;
 
 /// <summary>
 /// Provides attached dependency properties for the buttons of the <see cref="SplitButton"/> control.

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -216,14 +216,12 @@
             x:Name="ItemList"
             Grid.Row="1"
             Padding="{StaticResource ContentPagePadding}"
-            extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-            extensions:ListViewExtensions.ItemMargin="0,2,0,2"
             ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind GetScrollbarVerticalMargin(Common.ScrollBarMargin), Mode=OneWay}"
             IsItemClickEnabled="True"
-            ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.SortedItems}"
-            SelectionMode="None">
+            SelectionMode="None"
+            Style="{StaticResource MediaListViewStyle}">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <controls:MediaListViewItem

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:Screenbox.Pages"

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -296,14 +296,12 @@
             x:Name="ItemList"
             Grid.Row="1"
             Padding="{StaticResource ContentPagePadding}"
-            extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-            extensions:ListViewExtensions.ItemMargin="0,2,0,2"
             ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind GetScrollbarVerticalMargin(Common.ScrollBarMargin), Mode=OneWay}"
             IsItemClickEnabled="True"
-            ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
             ItemsSource="{x:Bind AlbumSource.View}"
-            SelectionMode="None">
+            SelectionMode="None"
+            Style="{StaticResource MediaListViewStyle}">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <controls:MediaListViewItem

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:Screenbox.Pages"

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -5,7 +5,7 @@
     xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -88,17 +88,15 @@
         <ListView
             x:Name="ListView"
             Padding="{StaticResource ContentPagePadding}"
-            extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-            extensions:ListViewExtensions.ItemMargin="0,2,0,2"
             ui:ListViewExtensions.Command="{x:Bind ViewModel.ClickCommand}"
             ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"
             IsItemClickEnabled="True"
-            ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
             ItemTemplate="{StaticResource StorageItemListViewItemTemplate}"
             ItemsSource="{x:Bind ViewModel.Items}"
             Loaded="ListView_OnLoaded"
-            SelectionMode="None">
+            SelectionMode="None"
+            Style="{StaticResource MediaListViewStyle}">
             <ListView.Footer>
                 <Border Height="{x:Bind Common.FooterBottomPaddingHeight, Mode=OneWay}" />
             </ListView.Footer>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -6,7 +6,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -10,7 +10,7 @@
     xmlns:ctConverters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ctc="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/AlbumSearchResultPage.xaml
@@ -5,7 +5,6 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/ArtistSearchResultPage.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/Search/SearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SearchResultPage.xaml
@@ -5,7 +5,6 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -183,12 +182,11 @@
                     <ListView
                         x:Name="SongListView"
                         Padding="{StaticResource ContentPagePadding}"
-                        extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-                        extensions:ListViewExtensions.ItemMargin="0,2,0,2"
                         ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
-                        ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
+                        IsItemClickEnabled="True"
                         ItemsSource="{x:Bind ViewModel.Songs}"
-                        SelectionMode="None">
+                        SelectionMode="None"
+                        Style="{StaticResource MediaListViewStyle}">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <controls:MediaListViewItem PlayCommand="{Binding DataContext.PlaySongCommand, ElementName=SongListView}" />

--- a/Screenbox/Pages/Search/SearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SearchResultPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/Search/SongSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SongSearchResultPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/Search/SongSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SongSearchResultPage.xaml
@@ -5,7 +5,6 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -84,13 +83,12 @@
             Grid.Row="1"
             Margin="{StaticResource TopLargeMargin}"
             Padding="{StaticResource ContentPagePadding}"
-            extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-            extensions:ListViewExtensions.ItemMargin="0,2,0,2"
             ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
             ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"
-            ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
+            IsItemClickEnabled="True"
             ItemsSource="{x:Bind ViewModel.SearchResult.Songs, FallbackValue={x:Null}}"
-            SelectionMode="None">
+            SelectionMode="None"
+            Style="{StaticResource MediaListViewStyle}">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <controls:MediaListViewItem PlayCommand="{Binding DataContext.PlaySongCommand, ElementName=SongListView, FallbackValue={x:Null}}" />

--- a/Screenbox/Pages/Search/VideoSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/VideoSearchResultPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -5,7 +5,6 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -165,16 +164,14 @@
                 <ListView
                     x:Name="SongListView"
                     Padding="{StaticResource ContentPagePadding}"
-                    extensions:ListViewExtensions.ItemCornerRadius="{StaticResource MediaItemCornerRadius}"
-                    extensions:ListViewExtensions.ItemMargin="0,2,0,2"
                     ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
                     ui:ScrollViewerExtensions.VerticalScrollBarMargin="{x:Bind Common.ScrollBarMargin, Mode=OneWay}"
                     IsItemClickEnabled="True"
-                    ItemContainerStyle="{StaticResource MediaListViewItemStyle}"
                     ItemsSource="{x:Bind SongsSource.View, Mode=OneWay}"
                     Loaded="SongListView_OnLoaded"
                     ScrollViewer.IsVerticalScrollChainingEnabled="False"
-                    SelectionMode="None">
+                    SelectionMode="None"
+                    Style="{StaticResource MediaListViewStyle}">
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <controls:MediaListViewItem PlayCommand="{Binding DataContext.PlayCommand, ElementName=SongListView}" />

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -5,7 +5,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extensions="using:Screenbox.Controls.Extensions"
+    xmlns:extensions="using:Screenbox.Extensions"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -163,10 +163,6 @@
     </Compile>
     <Compile Include="Controls\CustomNavigationView.cs" />
     <Compile Include="Controls\CustomSlider.cs" />
-    <Compile Include="Controls\Extensions\ApplicationViewExtensions.cs" />
-    <Compile Include="Controls\Extensions\CommandBarExtensions.cs" />
-    <Compile Include="Controls\Extensions\ListViewExtensions.cs" />
-    <Compile Include="Controls\Extensions\SplitButtonExtensions.cs" />
     <Compile Include="Controls\Interactions\AdaptiveLayoutBreakpointsBehavior.cs" />
     <Compile Include="Controls\Interactions\AlternatingListViewBehavior.cs" />
     <Compile Include="Controls\Interactions\AutoFocusBehavior.cs" />
@@ -238,6 +234,10 @@
     <Compile Include="Converters\SearchItemGlyphConverter.cs" />
     <Compile Include="Converters\ThicknessFiltersConverter.cs" />
     <Compile Include="Converters\ToggleButtonCheckToRepeatModeConverter.cs" />
+    <Compile Include="Extensions\ApplicationViewExtensions.cs" />
+    <Compile Include="Extensions\CommandBarExtensions.cs" />
+    <Compile Include="Extensions\ListViewExtensions.cs" />
+    <Compile Include="Extensions\SplitButtonExtensions.cs" />
     <Compile Include="Helpers\DeviceInfoHelper.cs" />
     <Compile Include="Helpers\GlobalizationHelper.cs" />
     <Compile Include="Helpers\GlyphConvert.cs" />

--- a/Screenbox/Styles/ItemContainer.xaml
+++ b/Screenbox/Styles/ItemContainer.xaml
@@ -3,7 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contract13NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,13)"
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:extensions="using:Screenbox.Extensions">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -354,17 +355,24 @@
         </Setter>
     </contract13Present:Style>
 
-    <!--  ListViewItem featuring a larger MinHeight, vertical margin added between items given the absence of an inner border, and that requires focus engagement for improved gamepad interactivity and navigation  -->
+    <!--  ListView with increased item corner radii and no side margins  -->
+    <Style x:Key="MediaListViewStyle" TargetType="ListView">
+        <!--<Setter Property="extensions:ListViewExtensions.ItemMinHeight" Value="48" />-->
+        <Setter Property="extensions:ListViewExtensions.ItemMargin" Value="0,2,0,2" />
+        <Setter Property="extensions:ListViewExtensions.ItemCornerRadius" Value="{StaticResource MediaItemCornerRadius}" />
+        <!--<Setter Property="extensions:ListViewExtensions.ItemIsFocusEngagementEnabled" Value="True" />-->
+        <Setter Property="ItemContainerStyle" Value="{StaticResource MediaListViewItemStyle}" />
+    </Style>
+
+    <!--  ListViewItem with larger MinHeight and focus engagement requirement  -->
     <!--  https://learn.microsoft.com/en-us/windows/apps/design/input/gamepad-and-remote-interactions#focus-engagement  -->
     <contract13NotPresent:Style
         x:Key="MediaListViewItemStyle"
         BasedOn="{StaticResource DefaultListViewItemStyle}"
         TargetType="ListViewItem">
         <Setter Property="MinHeight" Value="44" />
-        <Setter Property="Margin" Value="0,2,0,2" />
         <Setter Property="IsFocusEngagementEnabled" Value="True" />
     </contract13NotPresent:Style>
-    <!--  ListViewItem featuring a larger MinHeight, and that requires focus engagement for improved gamepad interactivity and navigation  -->
     <contract13Present:Style
         x:Key="MediaListViewItemStyle"
         BasedOn="{StaticResource DefaultListViewItemStyle}"


### PR DESCRIPTION
This PR introduces a shared ListView style to enforce (and simplify) consistent UI across multiple XAML files. Certain properties remain in the container style and haven't been migrated yet, as they're still pending performance evaluation.

- Moves the extension files from the `Controls` directory to the project root
- Updates the `ApplicationViewExtensions` header to include the appropriate copyright notice
- Adds and improves the `ListViewExtensions` attached properties
- Adds a `MediaListViewStyle` to standardize the style
- Fixes the visual feedback on the search pages `ListView`
