### PR TITLE
chore: refactor volume control glyph and pointer wheel event

### DIFF
--- a/Screenbox.Core/ViewModels/VolumeViewModel.cs
+++ b/Screenbox.Core/ViewModels/VolumeViewModel.cs
@@ -1,15 +1,12 @@
 ﻿#nullable enable
 
 using System;
-using Windows.System;
-using Windows.UI.Input;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
+using Windows.System;
 
 namespace Screenbox.Core.ViewModels
 {
@@ -52,18 +49,8 @@ namespace Screenbox.Core.ViewModels
 
         public void Receive(ChangeVolumeRequestMessage message)
         {
-            Volume = message.IsOffset ?
-                Math.Clamp(Volume + message.Value, 0, MaxVolume) :
-                Math.Clamp(message.Value, 0, MaxVolume);
+            SetVolume(message.Value, message.IsOffset);
             message.Reply(Volume);
-        }
-
-        public void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
-        {
-            PointerPoint? pointer = e.GetCurrentPoint((UIElement)sender);
-            int mouseWheelDelta = pointer.Properties.MouseWheelDelta;
-            int volumeChange = mouseWheelDelta > 0 ? 5 : -5;
-            Volume = Math.Clamp(Volume + volumeChange, 0, MaxVolume);
         }
 
         partial void OnVolumeChanged(int value)
@@ -97,6 +84,17 @@ namespace Screenbox.Core.ViewModels
             {
                 _dispatcherQueue.TryEnqueue(() => sender.IsMuted = IsMute);
             }
+        }
+
+        /// <summary>
+        /// Sets the volume to a specified value or adjusts it by a given amount.
+        /// </summary>
+        /// <param name="value">The target volume to set or the offset amount to adjust.</param>
+        /// <param name="isOffset">If <see langword="true"/>, adjusts the current volume by the specified <paramref name="value"/>;
+        /// otherwise, sets the volume directly. The default value is <see langword="false"/>.</param>
+        public void SetVolume(int value, bool isOffset = false)
+        {
+            Volume = Math.Clamp(isOffset ? Volume + value : value, 0, MaxVolume);
         }
     }
 }

--- a/Screenbox.Core/ViewModels/VolumeViewModel.cs
+++ b/Screenbox.Core/ViewModels/VolumeViewModel.cs
@@ -21,7 +21,6 @@ namespace Screenbox.Core.ViewModels
         [ObservableProperty] private int _maxVolume;
         [ObservableProperty] private int _volume;
         [ObservableProperty] private bool _isMute;
-        [ObservableProperty] private string _volumeGlyph;
         private IMediaPlayer? _mediaPlayer;
         private readonly DispatcherQueue _dispatcherQueue;
         private readonly ISettingsService _settingsService;
@@ -32,7 +31,6 @@ namespace Screenbox.Core.ViewModels
             _volume = settingsService.PersistentVolume;
             _maxVolume = settingsService.MaxVolume;
             _isMute = _volume == 0;
-            _volumeGlyph = GetVolumeGlyph();
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
             // View model doesn't receive any messages
@@ -75,7 +73,6 @@ namespace Screenbox.Core.ViewModels
             // bool stayMute = IsMute && newValue - _mediaPlayer.Volume < 0.005;
             _mediaPlayer.Volume = newValue;
             if (value > 0) IsMute = false;
-            VolumeGlyph = GetVolumeGlyph();
             _settingsService.PersistentVolume = value;
         }
 
@@ -83,7 +80,6 @@ namespace Screenbox.Core.ViewModels
         {
             if (_mediaPlayer == null) return;
             _mediaPlayer.IsMuted = value;
-            VolumeGlyph = GetVolumeGlyph();
         }
 
         private void OnVolumeChanged(IMediaPlayer sender, object? args)
@@ -101,15 +97,6 @@ namespace Screenbox.Core.ViewModels
             {
                 _dispatcherQueue.TryEnqueue(() => sender.IsMuted = IsMute);
             }
-        }
-
-        private string GetVolumeGlyph()
-        {
-            if (IsMute) return "\ue74f";
-            if (Volume < 25) return "\ue992";
-            if (Volume < 50) return "\ue993";
-            if (Volume < 75) return "\ue994";
-            return "\ue995";
         }
     }
 }

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -449,7 +449,7 @@
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="Collapsed">
-                <FontIcon Glyph="{x:Bind VolumeControl.ViewModel.VolumeGlyph, Mode=OneWay}" MirroredWhenRightToLeft="True" />
+                <FontIcon Glyph="{x:Bind helpers:GlyphConvert.ToVolumeGlyph(VolumeControl.ViewModel.IsMute, VolumeControl.ViewModel.Volume), Mode=OneWay}" MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="M" />
                 </Button.KeyboardAccelerators>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -144,7 +144,7 @@
                     KeyTipPlacementMode="Left"
                     Text="{x:Bind strings:Resources.PlaybackSpeed}">
                     <MenuFlyoutSubItem.Icon>
-                        <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind helpers:GlyphConvert.ToSpeedGlyph(ViewModel.PlaybackSpeed), Mode=OneWay}" />
+                        <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind converters:GlyphConverter.ToSpeedGlyph(ViewModel.PlaybackSpeed), Mode=OneWay}" />
                     </MenuFlyoutSubItem.Icon>
                     <muxc:RadioMenuFlyoutItem
                         x:Name="PlaybackSpeed025MenuItem"
@@ -381,7 +381,7 @@
                 AutomationProperties.Name="{x:Bind PlayPauseButton.(controls:AcceleratorService.ToolTip), Mode=OneWay}"
                 Command="{x:Bind ViewModel.PlayPauseCommand}"
                 Style="{StaticResource PlayerButtonStyle}">
-                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind helpers:GlyphConvert.ToPlayPauseGlyph(ViewModel.IsPlaying), Mode=OneWay}" />
+                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind converters:GlyphConverter.ToPlayPauseGlyph(ViewModel.IsPlaying), Mode=OneWay}" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="P" Invoked="{x:Bind ViewModel.PlayPauseKeyboardAccelerator_OnInvoked}" />
                     <KeyboardAccelerator Key="K" Invoked="{x:Bind ViewModel.PlayPauseKeyboardAccelerator_OnInvoked}" />
@@ -449,7 +449,7 @@
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="Collapsed">
-                <FontIcon Glyph="{x:Bind helpers:GlyphConvert.ToVolumeGlyph(VolumeControl.ViewModel.IsMute, VolumeControl.ViewModel.Volume), Mode=OneWay}" MirroredWhenRightToLeft="True" />
+                <FontIcon Glyph="{x:Bind converters:GlyphConverter.ToVolumeGlyph(VolumeControl.ViewModel.IsMute, VolumeControl.ViewModel.Volume), Mode=OneWay}" MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="M" />
                 </Button.KeyboardAccelerators>
@@ -470,7 +470,7 @@
                 IsChecked="{x:Bind ViewModel.Playlist.ShuffleMode, Mode=TwoWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerToggleButtonStyle}">
-                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind helpers:GlyphConvert.ToShuffleGlyph(ViewModel.Playlist.ShuffleMode), Mode=OneWay}" />
+                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind converters:GlyphConverter.ToShuffleGlyph(ViewModel.Playlist.ShuffleMode), Mode=OneWay}" />
                 <ToggleButton.KeyboardAccelerators>
                     <KeyboardAccelerator Key="S" Modifiers="Control" />
                 </ToggleButton.KeyboardAccelerators>
@@ -486,7 +486,7 @@
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 IsThreeState="True"
                 Style="{StaticResource PlayerToggleButtonStyle}">
-                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind helpers:GlyphConvert.ToRepeatGlyph(ViewModel.Playlist.RepeatMode), Mode=OneWay}" />
+                <FontIcon FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}" Glyph="{x:Bind converters:GlyphConverter.ToRepeatGlyph(ViewModel.Playlist.RepeatMode), Mode=OneWay}" />
                 <ToggleButton.KeyboardAccelerators>
                     <KeyboardAccelerator Key="R" Modifiers="Control" />
                 </ToggleButton.KeyboardAccelerators>

--- a/Screenbox/Controls/VolumeControl.xaml
+++ b/Screenbox/Controls/VolumeControl.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Screenbox.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:converters="using:Screenbox.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     d:DesignHeight="40"
@@ -48,7 +48,7 @@
             controls:AcceleratorService.ToolTip="{x:Bind strings:Resources.MuteToggle(ViewModel.IsMute), Mode=OneWay}"
             d:Style="{StaticResource SmallPlayerToggleButtonStyle}"
             AccessKey="{strings:KeyboardResources Key=PlayerMuteKey}"
-            AutomationProperties.Name="{Binding ElementName=VolumeToggleButton, Path=(ToolTipService.ToolTip), Mode=OneWay}"
+            AutomationProperties.Name="{x:Bind strings:Resources.MuteToggle(ViewModel.IsMute), Mode=OneWay}"
             IsChecked="{x:Bind ViewModel.IsMute, Mode=TwoWay}"
             Style="{x:Bind VolumeToggleButtonStyle, Mode=OneWay}">
             <FontIcon
@@ -80,7 +80,7 @@
             AutomationProperties.Name="{strings:Resources Key=VolumeSliderTooltip}"
             IsThumbToolTipEnabled="{x:Bind ShowValueText, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             Maximum="{x:Bind ViewModel.MaxVolume, Mode=OneWay}"
-            PointerWheelChanged="{x:Bind ViewModel.OnPointerWheelChanged}"
+            PointerWheelChanged="VolumeSlider_OnPointerWheelChanged"
             Value="{x:Bind ViewModel.Volume, Mode=TwoWay}" />
 
         <TextBlock

--- a/Screenbox/Controls/VolumeControl.xaml
+++ b/Screenbox/Controls/VolumeControl.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Screenbox.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     d:DesignHeight="40"
@@ -52,7 +53,7 @@
             Style="{x:Bind VolumeToggleButtonStyle, Mode=OneWay}">
             <FontIcon
                 d:Glyph="&#xE994;"
-                Glyph="{x:Bind ViewModel.VolumeGlyph, Mode=OneWay}"
+                Glyph="{x:Bind helpers:GlyphConvert.ToVolumeGlyph(ViewModel.IsMute, ViewModel.Volume), Mode=OneWay}"
                 MirroredWhenRightToLeft="True" />
             <ToggleButton.KeyboardAccelerators>
                 <KeyboardAccelerator Key="M" />

--- a/Screenbox/Controls/VolumeControl.xaml
+++ b/Screenbox/Controls/VolumeControl.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:helpers="using:Screenbox.Helpers"
+    xmlns:converters="using:Screenbox.Converters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     d:DesignHeight="40"
@@ -53,7 +53,7 @@
             Style="{x:Bind VolumeToggleButtonStyle, Mode=OneWay}">
             <FontIcon
                 d:Glyph="&#xE994;"
-                Glyph="{x:Bind helpers:GlyphConvert.ToVolumeGlyph(ViewModel.IsMute, ViewModel.Volume), Mode=OneWay}"
+                Glyph="{x:Bind converters:GlyphConverter.ToVolumeGlyph(ViewModel.IsMute, ViewModel.Volume), Mode=OneWay}"
                 MirroredWhenRightToLeft="True" />
             <ToggleButton.KeyboardAccelerators>
                 <KeyboardAccelerator Key="M" />

--- a/Screenbox/Controls/VolumeControl.xaml.cs
+++ b/Screenbox/Controls/VolumeControl.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿#nullable enable
+
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
 using Windows.UI.Xaml;
@@ -15,14 +17,17 @@ namespace Screenbox.Controls
         /// Identifies the <see cref="VolumeToggleButtonStyle"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty VolumeToggleButtonStyleProperty = DependencyProperty.Register(
-            nameof(VolumeToggleButtonStyle), typeof(Style), typeof(VolumeControl), new PropertyMetadata(null, OnVolumeToggleButtonStylePropertyChanged));
+            nameof(VolumeToggleButtonStyle),
+            typeof(Style),
+            typeof(VolumeControl),
+            new PropertyMetadata(null, OnVolumeToggleButtonStylePropertyChanged));
 
         /// <summary>
         /// Gets or sets the Style that defines the look of the volume toggle button.
         /// </summary>
-        public Style VolumeToggleButtonStyle
+        public Style? VolumeToggleButtonStyle
         {
-            get { return (Style)GetValue(VolumeToggleButtonStyleProperty); }
+            get { return (Style?)GetValue(VolumeToggleButtonStyleProperty); }
             set { SetValue(VolumeToggleButtonStyleProperty, value); }
         }
 
@@ -48,7 +53,7 @@ namespace Screenbox.Controls
         {
             if (d is VolumeControl control && control.VolumeToggleButton != null)
             {
-                control.VolumeToggleButton.Style = (Style)e.NewValue;
+                control.VolumeToggleButton.Style = (Style?)e.NewValue;
             }
         }
 

--- a/Screenbox/Controls/VolumeControl.xaml.cs
+++ b/Screenbox/Controls/VolumeControl.xaml.cs
@@ -1,8 +1,9 @@
 ﻿using System.ComponentModel;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -14,12 +15,11 @@ namespace Screenbox.Controls
         /// Identifies the <see cref="VolumeToggleButtonStyle"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty VolumeToggleButtonStyleProperty = DependencyProperty.Register(
-            nameof(VolumeToggleButtonStyle), typeof(Style), typeof(VolumeControl), new PropertyMetadata((Style)Application.Current.Resources["DefaultToggleButtonStyle"]));
+            nameof(VolumeToggleButtonStyle), typeof(Style), typeof(VolumeControl), new PropertyMetadata(null, OnVolumeToggleButtonStylePropertyChanged));
 
         /// <summary>
         /// Gets or sets the Style that defines the look of the volume toggle button.
         /// </summary>
-        /// <returns>The Style that defines the look of the volume toggle button. The default is DefaultToggleButtonStyle.</returns>
         public Style VolumeToggleButtonStyle
         {
             get { return (Style)GetValue(VolumeToggleButtonStyleProperty); }
@@ -44,12 +44,28 @@ namespace Screenbox.Controls
             ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
         }
 
+        private static void OnVolumeToggleButtonStylePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is VolumeControl control && control.VolumeToggleButton != null)
+            {
+                control.VolumeToggleButton.Style = (Style)e.NewValue;
+            }
+        }
+
         private void ViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(VolumeViewModel.MaxVolume))
             {
                 UpdateIndicatorBoostWidth();
             }
+        }
+
+        private void VolumeSlider_OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+        {
+            var pointer = e.GetCurrentPoint((UIElement)sender);
+            int mouseWheelDelta = pointer.Properties.MouseWheelDelta;
+            int volumeChange = mouseWheelDelta > 0 ? 5 : -5;
+            ViewModel.SetVolume(volumeChange, true);
         }
 
         private void VolumeControl_OnSizeChanged(object sender, SizeChangedEventArgs e)

--- a/Screenbox/Converters/GlyphConverter.cs
+++ b/Screenbox/Converters/GlyphConverter.cs
@@ -20,9 +20,14 @@ public static partial class GlyphConverter
     /// </returns>
     public static string ToShuffleGlyph(bool value)
     {
+        const string ShuffleGlyph = "\uE8B1";
+        const string ShuffleOffGlyph = "\U000F002A";
+        const string ShuffleGlyphMirrored = "\U000F0021";
+        const string ShuffleOffGlyphMirrored = "\U000F002B";
+
         return value
-            ? (GlobalizationHelper.IsRightToLeftLanguage ? "\U000F0021" : "\uE8B1")
-            : (GlobalizationHelper.IsRightToLeftLanguage ? "\U000F002B" : "\U000F002A");
+            ? (GlobalizationHelper.IsRightToLeftLanguage ? ShuffleGlyphMirrored : ShuffleGlyph)
+            : (GlobalizationHelper.IsRightToLeftLanguage ? ShuffleOffGlyphMirrored : ShuffleOffGlyph);
     }
 
     /// <summary>
@@ -37,11 +42,18 @@ public static partial class GlyphConverter
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="repeatMode"/> is not one of the valid <see cref="MediaPlaybackAutoRepeatMode"/> value.</exception>
     public static string ToRepeatGlyph(MediaPlaybackAutoRepeatMode repeatMode)
     {
+        const string RepeatOffGlyph = "\uF5E7";
+        const string RepeatOneGlyph = "\uE8ED";
+        const string RepeatAllGlyph = "\uE8EE";
+        const string RepeatOffMirroredGlyph = "\U000F0127";
+        const string RepeatOneMirroredGlyph = "\U000F004D";
+        const string RepeatAllMirroredGlyph = "\U000F004E";
+
         return repeatMode switch
         {
-            MediaPlaybackAutoRepeatMode.None => GlobalizationHelper.IsRightToLeftLanguage ? "\U000F0127" : "\uF5E7",
-            MediaPlaybackAutoRepeatMode.List => GlobalizationHelper.IsRightToLeftLanguage ? "\U000F004E" : "\uE8EE",
-            MediaPlaybackAutoRepeatMode.Track => GlobalizationHelper.IsRightToLeftLanguage ? "\U000F004D" : "\uE8ED",
+            MediaPlaybackAutoRepeatMode.None => GlobalizationHelper.IsRightToLeftLanguage ? RepeatOffMirroredGlyph : RepeatOffGlyph,
+            MediaPlaybackAutoRepeatMode.Track => GlobalizationHelper.IsRightToLeftLanguage ? RepeatOneMirroredGlyph : RepeatOneGlyph,
+            MediaPlaybackAutoRepeatMode.List => GlobalizationHelper.IsRightToLeftLanguage ? RepeatAllMirroredGlyph : RepeatAllGlyph,
             _ => throw new ArgumentOutOfRangeException(nameof(repeatMode), repeatMode, null),
         };
     }
@@ -56,13 +68,25 @@ public static partial class GlyphConverter
     /// </returns>
     public static string ToSpeedGlyph(double speed)
     {
+        const string SpeedOffGlyph = "\uEC48";
+        const string SpeedLowGlyph = "\U000F00A4";
+        const string SpeedMediumGlyph = "\uEC49";
+        const string SpeedHighGlyph = "\uEC4A";
+        const string AutoRacingGlyph = "\uEB24";
+
+        const double VeryHighSpeed = 1.75;
+        const double NormalSpeed = 1.0;
+        const double VeryLowSpeed = 0.25;
+
+        const double Tolerance = 0.0001;
+
         return speed switch
         {
-            >= 1.75 => "\uEB24",
-            > 1.01 => "\uEC4A",
-            <= 0.25 => "\uEC48",
-            < 0.99 => "\U000F00A4",
-            _ => "\uEC49"
+            >= VeryHighSpeed - Tolerance => AutoRacingGlyph,
+            > NormalSpeed + Tolerance => SpeedHighGlyph,
+            >= NormalSpeed - Tolerance and <= NormalSpeed + Tolerance => SpeedMediumGlyph,
+            > VeryLowSpeed + Tolerance => SpeedLowGlyph,
+            _ => SpeedOffGlyph,
         };
     }
 
@@ -76,7 +100,10 @@ public static partial class GlyphConverter
     /// </returns>
     public static string ToRecentGlyph(bool value)
     {
-        return value ? "\U000F00F0" : "\U000F00F1";
+        const string RecentGlyph = "\U000F00F0";
+        const string RecentEmptyGlyph = "\U000F00F1";
+
+        return value ? RecentGlyph : RecentEmptyGlyph;
     }
 
     /// <summary>
@@ -89,7 +116,10 @@ public static partial class GlyphConverter
     /// </returns>
     public static string ToPlayPauseGlyph(bool value)
     {
-        return value ? "\uE769" : "\uE768";
+        const string PlayGlyph = "\uE768";
+        const string PauseGlyph = "\uE769";
+
+        return value ? PauseGlyph : PlayGlyph;
     }
 
     /// <summary>
@@ -102,7 +132,10 @@ public static partial class GlyphConverter
     /// </returns>
     public static string ToPlayPauseSolidGlyph(bool value)
     {
-        return value ? "\uE62E" : "\uF5B0";
+        const string PlaySolidGlyph = "\uF5B0";
+        const string PauseSolidGlyph = "\uE62E";
+
+        return value ? PauseSolidGlyph : PlaySolidGlyph;
     }
 
     /// <summary>

--- a/Screenbox/Converters/GlyphConverter.cs
+++ b/Screenbox/Converters/GlyphConverter.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using Screenbox.Helpers;
 using Windows.Media;
 
-namespace Screenbox.Helpers;
+namespace Screenbox.Converters;
 
 /// <summary>
 /// Provides <see langword="static"/> methods to convert value types to glyph codes.
 /// </summary>
-public static partial class GlyphConvert
+public static partial class GlyphConverter
 {
     /// <summary>
     /// Gets the shuffle glyph code based on a boolean condition.

--- a/Screenbox/Helpers/GlyphConvert.cs
+++ b/Screenbox/Helpers/GlyphConvert.cs
@@ -103,4 +103,32 @@ public static partial class GlyphConvert
     {
         return value ? "\uE62E" : "\uF5B0";
     }
+
+    /// <summary>
+    /// Gets the volume glyph code based on mute state and volume value.
+    /// </summary>
+    /// <param name="isMute">A <see cref="bool"/> that specifies if the player is muted.</param>
+    /// <param name="volume">An <see cref="int"/> that specifies the player's volume.</param>
+    /// <returns>
+    /// <strong>Mute</strong> glyph code <see cref="string"/> if <paramref name="isMute"/> is <see langword="true"/>;
+    /// otherwise, a glyph code representing the volume level.
+    /// </returns>
+    public static string ToVolumeGlyph(bool isMute, int volume)
+    {
+        const string MuteGlyph = "\uE74F";
+        const string Volume0Glyph = "\uE992";
+        const string Volume1Glyph = "\uE993";
+        const string Volume2Glyph = "\uE994";
+        const string Volume3Glyph = "\uE995";
+
+        if (isMute) return MuteGlyph;
+
+        return volume switch
+        {
+            < 25 => Volume0Glyph,
+            < 50 => Volume1Glyph,
+            < 75 => Volume2Glyph,
+            _ => Volume3Glyph
+        };
+    }
 }

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -82,13 +82,6 @@
                     <StaticResource x:Key="PlayerControlsBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
-
-            <ctConverters:BoolToObjectConverter
-                x:Key="PlayPauseSolidGlyphConverter"
-                FalseValue="{StaticResource PauseSolidGlyph}"
-                TrueValue="{StaticResource PlaySolidGlyph}" />
-
-            <ThemeShadow x:Name="SharedShadow" />
         </ResourceDictionary>
     </Page.Resources>
 
@@ -574,7 +567,7 @@
                 FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                 FontSize="{StaticResource TitleTextBlockFontSize}"
                 Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                Glyph="{x:Bind ViewModel.IsPlayingBadge, Converter={StaticResource PlayPauseSolidGlyphConverter}, Mode=OneWay}" />
+                Glyph="{x:Bind converters:GlyphConverter.ToPlayPauseSolidGlyph(ViewModel.IsPlayingBadge), Mode=OneWay}" />
         </Border>
 
         <muxc:ProgressRing

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -317,7 +317,7 @@
                     <ctc:SettingsExpander.HeaderIcon>
                         <FontIcon
                             FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
-                            Glyph="{x:Bind helpers:GlyphConvert.ToRecentGlyph(ViewModel.ShowRecent), Mode=OneWay}"
+                            Glyph="{x:Bind converters:GlyphConverter.ToRecentGlyph(ViewModel.ShowRecent), Mode=OneWay}"
                             MirroredWhenRightToLeft="True" />
                     </ctc:SettingsExpander.HeaderIcon>
                     <interactivity:Interaction.Behaviors>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -229,6 +229,7 @@
     </Compile>
     <Compile Include="Converters\DefaultStringConverter.cs" />
     <Compile Include="Converters\FirstOrDefaultConverter.cs" />
+    <Compile Include="Converters\GlyphConverter.cs" />
     <Compile Include="Converters\HumanizedDurationConverter.cs" />
     <Compile Include="Converters\LanguageLayoutDirectionToFlowDirectionConverter.cs" />
     <Compile Include="Converters\MediaGlyphConverter.cs" />
@@ -240,7 +241,6 @@
     <Compile Include="Converters\ToggleButtonCheckToRepeatModeConverter.cs" />
     <Compile Include="Helpers\DeviceInfoHelper.cs" />
     <Compile Include="Helpers\GlobalizationHelper.cs" />
-    <Compile Include="Helpers\GlyphConvert.cs" />
     <Compile Include="Helpers\TitleBarHelper.cs" />
     <Compile Include="Pages\AlbumDetailsPage.xaml.cs">
       <DependentUpon>AlbumDetailsPage.xaml</DependentUpon>


### PR DESCRIPTION
- Renamed and moved `GlyphConvert`
- Moved volume glyph from `VolumeViewModel` to `GlyphConverter`
- Moved volume `OnPointerWheelChanged` from `VolumeViewModel` to the control view