### PR TITLE
chore: update wack runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,9 +122,7 @@ jobs:
 
   wack:
     needs: build
-    # wack gives faulty results on Windows 2022 as of 2024-11-13
-    # https://github.com/actions/runner-images/releases/tag/win22%2F20241113.3
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Bump wack job runner from `windows-2019` to `windows-latest`