### PR TITLE
fix: InfoBar shadow artifact

### DIFF
--- a/Screenbox/Controls/NotificationView.xaml.cs
+++ b/Screenbox/Controls/NotificationView.xaml.cs
@@ -17,7 +17,6 @@ namespace Screenbox.Controls
         {
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<NotificationViewModel>();
-            InfoBar.Translation = new Vector3(0, 0, 16);
         }
 
         private InfoBarSeverity ConvertInfoBarSeverity(NotificationLevel level)

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -325,8 +325,7 @@
                     MaxWidth="400"
                     Margin="10,0,10,16"
                     HorizontalAlignment="Right"
-                    VerticalAlignment="Bottom"
-                    Shadow="{StaticResource ElevationThemeShadow}" />
+                    VerticalAlignment="Bottom" />
             </Grid>
 
             <interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -606,8 +606,7 @@
             IsClosable="False"
             IsOpen="{x:Bind ViewModel.IsRelaunchRequired, Mode=OneWay}"
             Message="{strings:Resources Key=RelaunchForChangesMessage}"
-            Severity="Warning"
-            Shadow="{StaticResource ElevationThemeShadow}">
+            Severity="Warning">
             <muxc:InfoBar.Transitions>
                 <TransitionCollection>
                     <RepositionThemeTransition />

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -27,7 +27,6 @@ namespace Screenbox.Pages
             this.InitializeComponent();
             DataContext = Ioc.Default.GetRequiredService<SettingsPageViewModel>();
             Common = Ioc.Default.GetRequiredService<CommonViewModel>();
-            PendingChangesInfoBar.Translation = new Vector3(0, 0, 16);
 
             VlcCommandLineHelpTextParts = new string[2];
             string[] parts = Strings.Resources.VlcCommandLineHelpText


### PR DESCRIPTION
Fixes #654. InfoBar doesn't play nice with ThemeShadow, so I removed it entirely. Alternatively, we could apply the ThemeShadow property only when `InfoBar.IsOpen="True"`.

Before|After
-|-
<img width="1128" height="160" alt="Home page with the InfoBar shadow clipping" src="https://github.com/user-attachments/assets/b03f8484-d9e9-473b-a2e7-bd5605375997" />|<img width="1128" height="160" alt="Home page without the InfoBar shadow clipping" src="https://github.com/user-attachments/assets/4d5c7b17-5ede-48da-a048-ceef41446b34" />
<img width="1128" height="160" alt="Settings page with the InfoBar shadow clipping" src="https://github.com/user-attachments/assets/8c3a5f85-beec-4573-ba5d-855b1d4e0b84" />|<img width="1128" height="160" alt="Settings page without the InfoBar shadow" src="https://github.com/user-attachments/assets/99360fe9-1338-44e2-8dfc-7950e7a1dc2d" />


