### PR TITLE
fix: date formatting used when saving snapshot files

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -415,7 +415,7 @@ namespace Screenbox.Core.ViewModels
                 StorageFolder destFolder =
                     await defaultSaveFolder.CreateFolderAsync("Screenbox",
                         CreationCollisionOption.OpenIfExists);
-                return await file.CopyAsync(destFolder, $"Screenbox_{DateTime.Now:yyyymmdd_HHmmss}{file.FileType}",
+                return await file.CopyAsync(destFolder, $"Screenbox_{DateTime.Now:yyyyMMdd_HHmmss}{file.FileType}",
                     NameCollisionOption.GenerateUniqueName);
             }
             finally

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -415,7 +415,7 @@ namespace Screenbox.Core.ViewModels
                 StorageFolder destFolder =
                     await defaultSaveFolder.CreateFolderAsync("Screenbox",
                         CreationCollisionOption.OpenIfExists);
-                return await file.CopyAsync(destFolder, $"Screenbox_{DateTime.Now:yyyyMMdd_HHmmss}{file.FileType}",
+                return await file.CopyAsync(destFolder, $"Screenbox_{DateTimeOffset.Now:yyyyMMdd_HHmmss}{file.FileType}",
                     NameCollisionOption.GenerateUniqueName);
             }
             finally


### PR DESCRIPTION
This pull request updates the file naming logic when saving snapshots in the media player controls. The main change corrects the timestamp format used in the filename to ensure dates are saved in the proper format.

* Snapshot saving logic:
  * In `PlayerControlsViewModel.cs`, the file naming pattern in `SaveSnapshotInternalAsync` now uses `DateTimeOffset.Now:yyyyMMdd_HHmmss` instead of `DateTime.Now:yyyymmdd_HHmmss`, fixing the date format and ensuring the filename reflects the correct date and time.