### PR TITLE
Feature: Enqueue in recent played

### DIFF
--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -177,7 +177,7 @@ namespace Screenbox.Core.ViewModels
         }
 
         [RelayCommand]
-        private void Play(MediaViewModel media)
+        private async Task Play(MediaViewModel media)
         {
             if (media.IsMediaActive)
             {
@@ -185,7 +185,17 @@ namespace Screenbox.Core.ViewModels
             }
             else
             {
-                Messenger.Send(new PlayMediaMessage(media, false));
+                // If the recent item is a StorageFile, use PlayFilesMessage so the playlist can be
+                // populated with neighboring files (based on settings) and Next/Previous can work.
+                if (media.Source is StorageFile file)
+                {
+                    var query = await _filesService.GetNeighboringFilesQueryAsync(file);
+                    Messenger.Send(new PlayFilesMessage(new IStorageItem[] { file }, query));
+                }
+                else
+                {
+                    Messenger.Send(new PlayMediaMessage(media, false));
+                }
             }
         }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I'm often frustrated when I resume watching a show from the Recently Played section, because Screenbox only plays that single file instead of continuing to the next episode in the same folder. This makes it inconvenient to binge or watch multiple episodes in sequence without manually returning to the folder each time.

**Describe the solution you'd like**
When a user resumes playback from Recently Played, Screenbox should detect other playable files in the same folder and queue them automatically. After finishing the current file, playback should continue with the next file in order.
Optionally, there could be a setting like:

“Play next file in folder when resuming from Recently Played.”

**Describe alternatives you've considered**
Currently, the only workaround is to manually navigate to the folder and start playback from there to get sequential playback. This works, but it breaks the convenience of using the Recently Played shortcut.

**Additional context**
This feature would greatly improve the experience when watching TV series or multi-part videos, allowing smoother and more intuitive playback.
