### PR TITLE
fix: app theme combobox popup position

### DIFF
--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -273,7 +273,10 @@
                     Header="{strings:Resources Key=SettingsThemeSelectionHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource FiltersGlyph}}">
-                    <ComboBox MinWidth="150" SelectedIndex="{x:Bind ViewModel.Theme, Mode=TwoWay}">
+                    <ComboBox
+                        MinWidth="150"
+                        PlaceholderText="{x:Bind strings:Resources.ThemeAuto}"
+                        SelectedIndex="{x:Bind ViewModel.Theme, Mode=TwoWay}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate x:DataType="x:String">
                                 <TextBlock Text="{x:Bind Converter={StaticResource ResourceNameToResourceStringConverter}}" />


### PR DESCRIPTION
Under certain conditions, right-aligned `ComboBox` opens the popup selection in the wrong position microsoft/microsoft-ui-xaml#9567. As a workaround, setting the placeholder text to the longest item string resolves the issue.

I'm not sure how to handle the Language `ComboBox`. While we could set the placeholder to the longest item (ar-SA), it would make the popup unnecessarily wide for most users, since we aren't force installing all languages.

**Before:**

https://github.com/user-attachments/assets/cfa54228-41a0-4ff5-b2e5-c2db73549d3e

**After:**

https://github.com/user-attachments/assets/50e69939-19da-4cf4-8381-d38f950ba7dc
