### PR TITLE
refactor: main page view model gamepad key handling logic

### DIFF
--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -87,47 +87,8 @@ namespace Screenbox.Pages
 
         protected override void OnKeyDown(KeyRoutedEventArgs e)
         {
-            // All Gamepad keys are in the range of [195, 218]
-            if (ViewModel.IsPlaylistEmpty() || (int)e.Key < 195 || (int)e.Key > 218)
-            {
-                base.OnKeyDown(e);
-                return;
-            }
-
-            switch (e.Key)
-            {
-                case VirtualKey.GamepadRightThumbstickLeft:
-                case VirtualKey.GamepadLeftShoulder:
-                    ViewModel.Seek(TimeSpan.FromMilliseconds(-5000));
-                    break;
-                case VirtualKey.GamepadRightThumbstickRight:
-                case VirtualKey.GamepadRightShoulder:
-                    ViewModel.Seek(TimeSpan.FromMilliseconds(5000));
-                    break;
-                case VirtualKey.GamepadLeftTrigger when ViewModel.PlayerVisible:
-                    ViewModel.Seek(TimeSpan.FromMilliseconds(-30_000));
-                    break;
-                case VirtualKey.GamepadRightTrigger when ViewModel.PlayerVisible:
-                    ViewModel.Seek(TimeSpan.FromMilliseconds(30_000));
-                    break;
-                case VirtualKey.GamepadRightThumbstickUp:
-                    ViewModel.ChangeVolume(2);
-                    break;
-                case VirtualKey.GamepadRightThumbstickDown:
-                    ViewModel.ChangeVolume(-2);
-                    break;
-                case VirtualKey.GamepadX:
-                    ViewModel.TogglePlayPause();
-                    break;
-                case VirtualKey.GamepadView:
-                    ViewModel.TogglePlayerVisibility();
-                    break;
-                default:
-                    base.OnKeyDown(e);
-                    return;
-            }
-
-            e.Handled = true;
+            e.Handled = ViewModel.ProcessGamepadKeyDown(e.Key);
+            base.OnKeyDown(e);
         }
 
         public void GoBack()


### PR DESCRIPTION
Moves the Gamepad key handling logic from `MainPageViewModel.ProcessGamepadKeyDown` to `MainPage.xaml.cs.OnKeyDown`.
Adds new helper methods to replace the previous monolithic key handling method, and also removes the `PlayerVisible` restriction from the `GamepadView` action (toggle the player visibility).