### PR TITLE
fix: crash by VLC CLI help text not splitting properly on SettingsPage

### DIFF
--- a/Screenbox/Controls/SetOptionsDialog.xaml.cs
+++ b/Screenbox/Controls/SetOptionsDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Screenbox.Helpers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -30,11 +29,10 @@ public sealed partial class SetOptionsDialog : ContentDialog
         OptionTextBoxPlaceholder = global ? "--option=value" : ":option=value";
         Options = existingOptions;
         OptionsTextBox.Text = Options;
-        VlcCommandLineHelpTextParts = new string[2];
-        string[] parts = Strings.Resources.VlcCommandLineHelpText
-            .Split("{0}", StringSplitOptions.RemoveEmptyEntries)
-            .Select(s => s.Trim()).ToArray();
-        Array.Copy(parts, VlcCommandLineHelpTextParts, VlcCommandLineHelpTextParts.Length);
+        var helpText = Strings.Resources.VlcCommandLineHelpText;
+        VlcCommandLineHelpTextParts = helpText.Contains("{0}")
+            ? helpText.Split("{0}").Select(s => s.Trim()).Take(2).ToArray()
+            : new[] { helpText, string.Empty };
 
         if (global)
         {

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Numerics;
+﻿using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
 using Screenbox.Helpers;
@@ -28,11 +26,10 @@ namespace Screenbox.Pages
             DataContext = Ioc.Default.GetRequiredService<SettingsPageViewModel>();
             Common = Ioc.Default.GetRequiredService<CommonViewModel>();
 
-            VlcCommandLineHelpTextParts = new string[2];
-            string[] parts = Strings.Resources.VlcCommandLineHelpText
-                .Split("{0}", StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim()).ToArray();
-            Array.Copy(parts, VlcCommandLineHelpTextParts, VlcCommandLineHelpTextParts.Length);
+            var helpText = Strings.Resources.VlcCommandLineHelpText;
+            VlcCommandLineHelpTextParts = helpText.Contains("{0}")
+                ? helpText.Split("{0}").Select(s => s.Trim()).Take(2).ToArray()
+                : new[] { helpText, string.Empty };
 
             // Set the "System default" language option string
             var systemLanguageOption = ViewModel.AvailableLanguages[0];


### PR DESCRIPTION
VLC CLI help text always expects two elements. But when the template is at the beginning or end of the string, the help text is split into only one part, throwing an exception. This pull request refactors how the application splits and handles the VLC command line help text in both the `SetOptionsDialog` and `SettingsPage` components. The new logic is more robust, handling cases where the expected delimiter (`{0}`) might not be present.