### PR TITLE
feat: add FolderViewPage items screen reader support

### DIFF
--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -7,9 +7,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactions="using:Screenbox.Controls.Interactions"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:pages="using:Screenbox.Pages"
     xmlns:storage="using:Windows.Storage"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
@@ -112,8 +112,9 @@
                 <DataTemplate x:DataType="viewModels:StorageItemViewModel">
                     <controls:CommonGridViewItem
                         Width="{StaticResource WideGridViewItemWidth}"
+                        AutomationProperties.Name="{x:Bind pages:FolderViewPage.GetAutomationName(IsFile, Name, CaptionText, ItemCount), Mode=OneWay}"
                         CanPlay="{x:Bind IsFile}"
-                        Caption="{x:Bind local:FolderViewPage.GetCaptionText(IsFile, CaptionText, ItemCount), Mode=OneWay}"
+                        Caption="{x:Bind pages:FolderViewPage.GetCaptionText(IsFile, CaptionText, ItemCount), Mode=OneWay}"
                         IsPlaying="{Binding Media.IsPlaying, FallbackValue=False}"
                         ThumbnailHeight="{StaticResource WideGridViewItemThumbnailHeight}"
                         ThumbnailSource="{x:Bind Media.Thumbnail, Mode=OneWay, FallbackValue={x:Null}}">

--- a/Screenbox/Pages/FolderViewPage.xaml.cs
+++ b/Screenbox/Pages/FolderViewPage.xaml.cs
@@ -63,6 +63,13 @@ namespace Screenbox.Pages
             ViewModel.OnNavigatedFrom();
         }
 
+        private static string GetAutomationName(bool isFile, string name, string fileInfo, uint itemsCount)
+        {
+            return isFile
+                ? $"{Strings.Resources.File}; {name}, {fileInfo}"
+                : $"{Strings.Resources.Folder}, {name}; {Strings.Resources.ItemsCount(itemsCount)}";
+        }
+
         private static string GetCaptionText(bool isFile, string fileInfo, uint itemCount) =>
             isFile ? fileInfo : Strings.Resources.ItemsCount(itemCount);
 

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -968,4 +968,7 @@
   <data name="LanguageSystemDefault" xml:space="preserve">
     <value>Use system language</value>
   </data>
+  <data name="Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
 </root>


### PR DESCRIPTION
Continuation of #684. Items from the `StorageViewModel` are now announced correctly.