### PR TITLE
fix: UI not interactable when launching from explorer

### DIFF
--- a/Screenbox/Controls/NavigationViewEx.cs
+++ b/Screenbox/Controls/NavigationViewEx.cs
@@ -254,10 +254,7 @@ public sealed partial class NavigationViewEx : NavigationView
                 }
 
                 var autoSuggestBox = AutoSuggestBox;
-                if (autoSuggestBox != null)
-                {
-                    autoSuggestBox.Focus(FocusState.Programmatic);
-                }
+                autoSuggestBox?.Focus(FocusState.Programmatic);
 
                 e.Handled = true;
                 return;
@@ -403,6 +400,7 @@ public sealed partial class NavigationViewEx : NavigationView
         {
             Grid.SetColumn(_overlayRoot, 0);
             Grid.SetColumnSpan(_overlayRoot, 2);
+            UpdateOverlayLightDismissLayerVisibility();
             return;
         }
 


### PR DESCRIPTION
`LightDismissLayer` in `NavigationViewEx` is visible in this path, blocking all UI interactions.

https://github.com/user-attachments/assets/e88f597f-87af-4bad-9a6d-01fa96a5b839

