### PR TITLE
feat: clear search box with Escape key

### DIFF
--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -230,8 +230,12 @@
                     <AutoSuggestBox.KeyboardAccelerators>
                         <KeyboardAccelerator
                             Key="F"
-                            Invoked="NavViewSearchBoxKeyboardAcceleratorFocus_OnInvoked"
+                            Invoked="NavViewSearchBoxFocusKeyboardAccelerator_OnInvoked"
                             Modifiers="Control" />
+                        <KeyboardAccelerator
+                            Key="Escape"
+                            Invoked="NavViewSearchBoxClearKeyboardAccelerator_OnInvoked"
+                            ScopeOwner="{x:Bind NavViewSearchBox}" />
                     </AutoSuggestBox.KeyboardAccelerators>
                 </AutoSuggestBox>
             </muxc:NavigationView.AutoSuggestBox>

--- a/Screenbox/Pages/MainPage.xaml.cs
+++ b/Screenbox/Pages/MainPage.xaml.cs
@@ -353,18 +353,19 @@ namespace Screenbox.Pages
             }
         }
 
-        /// <summary>
-        /// Give the <see cref="NavViewSearchBox"/> text entry box focus ("Focused" visual state) through the keyboard shortcut combination.
-        /// </summary>
-        private void NavViewSearchBoxKeyboardAcceleratorFocus_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private void NavViewSearchBoxFocusKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
             NavViewSearchBox.Focus(FocusState.Keyboard);
             args.Handled = true;
         }
 
-        /// <summary>
-        /// Give the <see cref="NavViewSearchBox"/> text entry box focus ("Focused" visual state) through the access key combination.
-        /// </summary
+        private void NavViewSearchBoxClearKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            ViewModel.SearchQuery = string.Empty;
+            ViewModel.SearchSuggestions.Clear();
+            args.Handled = true;
+        }
+
         private void NavViewSearchBox_OnAccessKeyInvoked(UIElement sender, AccessKeyInvokedEventArgs args)
         {
             NavViewSearchBox.Focus(FocusState.Keyboard);


### PR DESCRIPTION
- Adds a new keyboard shortcut (Escape key) to clear the search box and its suggestions
- Renames the focus keyboard accelerator event handler from `NavViewSearchBoxKeyboardAcceleratorFocus_OnInvoked` to `NavViewSearchBoxFocusKeyboardAccelerator_OnInvoked` for consistency (Control+Action+Event)

Not perfect, as it often eats the first press of the Escape key.