### PR TITLE
ci(copilot): Update Copilot setup to use Windows host

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,6 +5,8 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:


### PR DESCRIPTION
Configure the Copilot setup steps to run on a Windows host, enabling Copilot to actually build the project.