### PR TITLE
fix: forward frame stepping position sync

### DIFF
--- a/Screenbox.Core/Playback/VlcMediaPlayer.cs
+++ b/Screenbox.Core/Playback/VlcMediaPlayer.cs
@@ -515,7 +515,7 @@ namespace Screenbox.Core.Playback
         public void StepForwardOneFrame()
         {
             VlcPlayer.NextFrame();
-            var newValue = TimeSpan.FromMilliseconds(VlcPlayer.Time);
+            var newValue = TimeSpan.FromTicks(VlcPlayer.Time * TimeSpan.TicksPerMillisecond);
             if (newValue != _position)
             {
                 var oldValue = _position;


### PR DESCRIPTION
`StepForwardOneFrame` now checks for position changes after advancing a frame and raises the `PositionChanged` event if the time has changed. Close #787.