### PR TITLE
style: minor playlist dialogs tweaks

### DIFF
--- a/Screenbox/Controls/CreatePlaylistDialog.xaml
+++ b/Screenbox/Controls/CreatePlaylistDialog.xaml
@@ -12,12 +12,10 @@
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
-    <StackPanel Spacing="8">
-        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{strings:Resources Key=PlaylistName}" />
-        <TextBox
-            x:Name="PlaylistNameTextBox"
-            MaxLength="100"
-            PlaceholderText="{strings:Resources Key=CreatePlaylistPlaceholder}"
-            TextChanged="PlaylistNameTextBox_OnTextChanged" />
-    </StackPanel>
+    <TextBox
+        x:Name="PlaylistNameTextBox"
+        MaxLength="100"
+        PlaceholderText="{x:Bind strings:Resources.CreatePlaylistPlaceholder}"
+        SelectedText="{x:Bind strings:Resources.NewPlaylistDefaultName}"
+        TextChanged="PlaylistNameTextBox_OnTextChanged" />
 </ContentDialog>

--- a/Screenbox/Controls/DeletePlaylistDialog.xaml
+++ b/Screenbox/Controls/DeletePlaylistDialog.xaml
@@ -7,11 +7,53 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
     Title="{strings:Resources Key=DeletePlaylist}"
-    DefaultButton="Close"
+    CloseButtonText="{strings:Resources Key=Cancel}"
+    PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
     PrimaryButtonText="{strings:Resources Key=Delete}"
-    SecondaryButtonText="{strings:Resources Key=Cancel}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
-    <TextBlock Text="{x:Bind strings:Resources.DeletePlaylistConfirmation(PlaylistName)}" />
+    <ContentDialog.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="DangerFillColorPrimaryBrush" Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorSecondaryBrush"
+                        Opacity="0.9"
+                        Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorTertiaryBrush"
+                        Opacity="0.8"
+                        Color="{StaticResource SystemFillColorCritical}" />
+
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="DangerFillColorPrimaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="DangerFillColorSecondaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="DangerFillColorTertiaryBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="DangerFillColorPrimaryBrush" Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorSecondaryBrush"
+                        Opacity="0.9"
+                        Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorTertiaryBrush"
+                        Opacity="0.8"
+                        Color="{StaticResource SystemFillColorCritical}" />
+
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="DangerFillColorPrimaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="DangerFillColorSecondaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="DangerFillColorTertiaryBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="SystemColorHighlightColorBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemColorButtonFaceColorBrush" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </ContentDialog.Resources>
+
+    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Bind strings:Resources.DeletePlaylistConfirmation(PlaylistName)}" />
 </ContentDialog>

--- a/Screenbox/Controls/RenamePlaylistDialog.xaml
+++ b/Screenbox/Controls/RenamePlaylistDialog.xaml
@@ -12,12 +12,9 @@
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
-    <StackPanel Spacing="8">
-        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{strings:Resources Key=PlaylistName}" />
-        <TextBox
-            x:Name="PlaylistNameTextBox"
-            MaxLength="100"
-            PlaceholderText="{strings:Resources Key=RenamePlaylistPlaceholder}"
-            TextChanged="PlaylistNameTextBox_OnTextChanged" />
-    </StackPanel>
+    <TextBox
+        x:Name="PlaylistNameTextBox"
+        MaxLength="100"
+        PlaceholderText="{x:Bind strings:Resources.RenamePlaylistPlaceholder}"
+        TextChanged="PlaylistNameTextBox_OnTextChanged" />
 </ContentDialog>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1017,8 +1017,8 @@
   <data name="Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="PlaylistName" xml:space="preserve">
-    <value>Playlist name</value>
+  <data name="NewPlaylistDefaultName" xml:space="preserve">
+    <value>Untitled playlist</value>
   </data>
   <data name="CreatePlaylistPlaceholder" xml:space="preserve">
     <value>Enter a name for this playlist</value>
@@ -1042,7 +1042,7 @@
     <value>Delete playlist</value>
   </data>
   <data name="DeletePlaylistConfirmation" xml:space="preserve">
-    <value>Are you sure you want to delete '{0}' playlist? This action cannot be undone.</value>
+    <value>Are you sure you want to delete '{0}' playlist? You cannot undo this action.</value>
     <comment>#Format[String playlistName]</comment>
   </data>
   <data name="SettingsSavePlaybackPositionHeader" xml:space="preserve">


### PR DESCRIPTION
- Removes labels and panels from create and rename playlist dialogs, leaving only the input `TextBox`. 

- Adds default name for new playlists. 

- Updates delete confirmation message, improves `DeletePlaylistDialog` style to highlight destructive action with critical color brushes and moves cancel action to `CloseButton`

<img width="900" height="400" alt="Delete playlist dialog" src="https://github.com/user-attachments/assets/e1cc87b2-a8b4-4011-b495-eb0bbc1e0bf2" />
