### PR TITLE
refactor: control visibility logic for open popups

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -59,7 +59,6 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     [ObservableProperty] private NavigationViewDisplayMode _navigationViewDisplayMode;
     [ObservableProperty] private MediaViewModel? _media;
     [ObservableProperty] private bool _showVisualizer;
-    [ObservableProperty] private bool _keyTipsVisible;
 
     [ObservableProperty]
     [NotifyPropertyChangedRecipients]
@@ -613,18 +612,6 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
         if (value != PlayerVisibilityState.Visible) ControlsHidden = false;
     }
 
-    partial void OnKeyTipsVisibleChanged(bool value)
-    {
-        if (value)
-        {
-            ControlsHidden = false;
-        }
-        else
-        {
-            DelayHideControls();
-        }
-    }
-
     [RelayCommand]
     public void GoBack()
     {
@@ -664,7 +651,7 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     {
         bool shouldCheckPlaying = _settingsService.PlayerShowControls && !IsPlaying;
         if (PlayerVisibility != PlayerVisibilityState.Visible || shouldCheckPlaying ||
-            SeekBarPointerInteracting || AudioOnly || ControlsHidden || KeyTipsVisible) return false;
+            SeekBarPointerInteracting || AudioOnly || ControlsHidden) return false;
 
         if (!skipFocusCheck)
         {
@@ -688,7 +675,7 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
 
     private void DelayHideControls()
     {
-        if (PlayerVisibility != PlayerVisibilityState.Visible || AudioOnly || KeyTipsVisible) return;
+        if (PlayerVisibility != PlayerVisibilityState.Visible || AudioOnly) return;
 
         int delayInSeconds = _settingsService.PlayerControlsHideDelay;
         _controlsVisibilityTimer.Debounce(() => TryHideControls(), TimeSpan.FromSeconds(delayInSeconds));

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -59,8 +59,6 @@ public sealed partial class PlayerPage : Page
 
         INavigationService navigationService = Ioc.Default.GetRequiredService<INavigationService>();   // For navigation events
         navigationService.Navigated += NavigationServiceOnNavigated;
-
-        AccessKeyManager.IsDisplayModeEnabledChanged += AccessKeyManager_OnIsDisplayModeEnabledChanged;
     }
     private void NavigationServiceOnNavigated(object sender, EventArgs e)
     {
@@ -162,11 +160,6 @@ public sealed partial class PlayerPage : Page
         // Left padding should only be set if we pin flow direction on the title bar.
         // LeftPaddingColumn.Width = new GridLength(sender.SystemOverlayLeftInset);
         RightPaddingColumn.Width = new GridLength(Math.Max(sender.SystemOverlayLeftInset, sender.SystemOverlayRightInset));
-    }
-
-    private void AccessKeyManager_OnIsDisplayModeEnabledChanged(object sender, object args)
-    {
-        ViewModel.KeyTipsVisible = AccessKeyManager.IsDisplayModeEnabled;
     }
 
     private void BackgroundElementOnSizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
Improves and simplifies control visibility logic for open popups by using `VisualTreeHelper.GetOpenPopups` instead of `Flyout` detection. This ensures that controls stay visible whenever any popup (including tool tips) is open, and eliminates the need for the `KeyTipsVisible` logic entirely.