### PR TITLE
style: fix playlist page header text overlap

### DIFF
--- a/Screenbox/Pages/PlaylistsPage.xaml
+++ b/Screenbox/Pages/PlaylistsPage.xaml
@@ -79,15 +79,25 @@
             Grid.Row="0"
             MinHeight="{StaticResource PageHeaderMinHeight}"
             Margin="{StaticResource BottomMediumMargin}"
-            Padding="{StaticResource ContentPagePadding}">
+            Padding="{StaticResource ContentPagePadding}"
+            ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
             <TextBlock
                 x:Name="HeaderText"
+                Grid.Column="0"
                 Style="{StaticResource TitleMediumTextBlockStyle}"
-                Text="{strings:Resources Key=Playlists}" />
+                Text="{strings:Resources Key=Playlists}"
+                TextWrapping="NoWrap" />
+
             <Button
                 x:Name="HeaderCreateButton"
-                HorizontalAlignment="Right"
+                Grid.Column="1"
                 VerticalAlignment="Top"
+                AutomationProperties.Name="{x:Bind strings:Resources.NewPlaylist}"
                 Click="HeaderCreateButton_OnClick">
                 <StackPanel Orientation="Horizontal">
                     <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE710;" />
@@ -135,6 +145,8 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="HeaderGrid.Padding" Value="{StaticResource ContentPageMinimalPadding}" />
+                        <Setter Target="HeaderCreateButton.(ToolTipService.ToolTip)" Value="{x:Bind strings:Resources.NewPlaylist}" />
+                        <Setter Target="HeaderCreateButtonText.Visibility" Value="Collapsed" />
                         <Setter Target="PlaylistsGridView.Padding" Value="{StaticResource GridViewContentPageMinimalPadding}" />
                     </VisualState.Setters>
                 </VisualState>


### PR DESCRIPTION
Also improves the accessibility of the `HeaderCreateButton`.

https://github.com/user-attachments/assets/7a4a7201-484b-4038-8a33-be55cf0d5ecc

