### PR TITLE
fix(l10n): minor grammar fix for some privacy-related strings

### DIFF
--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -946,10 +946,10 @@
     <value>Personalization</value>
   </data>
   <data name="SettingsRestorePlaybackPositionHeader" xml:space="preserve">
-    <value>Resume previous session</value>
+    <value>Always resume previous session</value>
   </data>
   <data name="SettingsRestorePlaybackPositionDescription" xml:space="preserve">
-    <value>Automatically resume media playback from your last stopped position when opening a file</value>
+    <value>Automatically resume media playback from last stopped position when opening a file</value>
   </data>
   <data name="SettingsVideoUpscalingHeader" xml:space="preserve">
     <value>Video upscaling method</value>
@@ -1052,7 +1052,7 @@
     <value>Playback position history</value>
   </data>
   <data name="SettingsSavePlaybackPositionDescription" xml:space="preserve">
-    <value>Store my playback position history on this device to enable quick media resumption</value>
+    <value>Store my playback position history on this device to enable quick session resumption</value>
   </data>
   <data name="SettingsClearPlaybackPositionHeader" xml:space="preserve">
     <value>Clear device playback position history</value>


### PR DESCRIPTION
Rephrased some UI strings in the privacy settings for better flow.

Fixed the `SettingsSavePlaybackPositionDescription` text, which was using both first person and second person in the same sentence. Thank you, @shahdanturung from Crowdin, for pointing this out.