### PR TITLE
style: update player page to show window deactivation status

### DIFF
--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -15,6 +15,7 @@
     xmlns:media="using:Microsoft.UI.Xaml.Media"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
+    xmlns:triggers="using:Screenbox.Triggers"
     xmlns:ui="using:CommunityToolkit.WinUI"
     d:DesignHeight="720"
     d:DesignWidth="1280"
@@ -567,7 +568,7 @@
                     <TextBlock
                         x:Name="TitleBarSubtitleTextBlock"
                         d:Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-                        Opacity="{ThemeResource TextFillColorSecondaryOpacity}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         OpticalMarginAlignment="TrimSideBearings"
                         Style="{StaticResource BodyTextBlockStyle}"
                         Text="{x:Bind ViewModel.Media.AltCaption, Mode=OneWay, FallbackValue={}}"
@@ -977,6 +978,18 @@
                 <VisualState x:Name="HiddenNormalMargin">
                     <VisualState.Setters>
                         <Setter Target="LayoutRoot.Margin" Value="12,0,12,-1" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+
+            <VisualStateGroup x:Name="WindowActivationGroup">
+                <VisualState x:Name="Deactivated">
+                    <VisualState.StateTriggers>
+                        <triggers:WindowActivationModeTrigger ActivationMode="Deactivated" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="TitleBarTitleTextBlock.Foreground" Value="{StaticResource TextFillColorTertiaryBrush}" />
+                        <Setter Target="TitleBarSubtitleTextBlock.Foreground" Value="{StaticResource TextFillColorTertiaryBrush}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -988,8 +988,11 @@
                         <triggers:WindowActivationModeTrigger ActivationMode="Deactivated" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="TitleBarTitleTextBlock.Foreground" Value="{StaticResource TextFillColorTertiaryBrush}" />
-                        <Setter Target="TitleBarSubtitleTextBlock.Foreground" Value="{StaticResource TextFillColorTertiaryBrush}" />
+                        <Setter Target="BackButton.Opacity" Value="{ThemeResource TextFillColorTertiaryOpacity}" />
+                        <Setter Target="PlayQueueButton.Opacity" Value="{ThemeResource TextFillColorTertiaryOpacity}" />
+                        <Setter Target="TitleBarTitleTextBlock.Foreground" Value="{ThemeResource TextFillColorTertiaryBrush}" />
+                        <Setter Target="TitleBarSubtitleTextBlock.Foreground" Value="{ThemeResource TextFillColorTertiaryBrush}" />
+                        <Setter Target="LivelyOptionsButton.Opacity" Value="{ThemeResource TextFillColorTertiaryOpacity}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Triggers/WindowActivationModeTrigger.cs
+++ b/Screenbox/Triggers/WindowActivationModeTrigger.cs
@@ -1,95 +1,93 @@
 ﻿#nullable enable
 
+using CommunityToolkit.WinUI.Helpers;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 
 namespace Screenbox.Triggers;
 
 /// <summary>
-/// Represents a declarative rule that applies visual states based on the <see cref="CoreWindow.ActivationMode"/> property.
+/// Represents a declarative rule that applies visual states based on the
+/// <see cref="CoreWindow.ActivationMode"/> property.
 /// </summary>
 /// <remarks>
-/// Use WindowActivationModeTriggers to create rules that automatically triggers a VisualState change when
-/// the window is a specified activation state. When you use WindowActivationModeTriggers in your XAML markup,
-/// you don't need to handle the <see cref="CoreWindow.Activated"/> event and call <see cref="VisualStateManager.GoToState"/> in your code.
+/// Use WindowActivationModeTriggers to create rules that automatically triggers a
+/// <see cref="VisualState"/> change when the window is a specified activation state.
+/// When you use WindowActivationModeTriggers in your XAML markup, you don't need
+/// to handle the <see cref="CoreWindow.Activated"/> event and call
+/// <see cref="VisualStateManager.GoToState"/> in your code.
 /// </remarks>
 /// <example>
-/// This example shows how to use the <see cref="VisualState.StateTriggers"/> property with an <see cref="WindowActivationModeTrigger"/>
-/// to create a declarative rule in XAML markup based on the activation state of the window.
-/// <code lang="xaml">
-/// &lt;Grid&gt;
-///     &lt;StackPanel&gt;
-///         &lt;TextBlock x:Name="FirstText"
-///                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-///                    Text="This is a block of text. It is the 1st text block." /&gt;
-///         &lt;TextBlock x:Name="LastText"
-///                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-///                    Text="This is a block of text. It is the 2nd text block." /&gt;
-///     &lt;/StackPanel&gt;
-///     &lt;VisualStateManager.VisualStateGroups&gt;
-///         &lt;VisualStateGroup&gt;
-///             &lt;VisualState&gt;
-///                 &lt;VisualState.StateTriggers&gt;
-///                     &lt;!-- VisualState to be triggered when the activation state of the window is Deactivated. --&gt;
-///                     &lt;local:WindowActivationModeTrigger ActivationMode="Deactivated" /&gt;
-///                 &lt;/VisualState.StateTriggers&gt;
-/// 
-///                 &lt;VisualState.Setters&gt;
-///                     &lt;Setter Target="FirstText.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" /&gt;
-///                     &lt;Setter Target="LastText.Opacity" Value="0.4" /&gt;
-///                 &lt;/VisualState.Setters&gt;
-///             &lt;/VisualState&gt;
-///         &lt;/VisualStateGroup&gt;
-///     &lt;/VisualStateManager.VisualStateGroups&gt;
-/// &lt;/Grid&gt;
-/// </code>
+/// This example shows how to use the <see cref="VisualState.StateTriggers"/> property
+/// with an <see cref="WindowActivationModeTrigger"/> to create a declarative rule in
+/// XAML markup based on the activation state of the window.
+/// <code lang="xml"><![CDATA[
+/// <Page>
+///     <Grid x:Name="LayoutRoot">
+///         <TextBlock x:Name="ExampleText" Text="Hello World!" />
+///         <VisualStateManager.VisualStateGroups>
+///             <VisualStateGroup>
+///                 <VisualState>
+///                     <VisualState.StateTriggers>
+///                         <!-- VisualState to be triggered when the activation state of the window is Deactivated. -->
+///                         <local:WindowActivationModeTrigger ActivationMode="Deactivated" />
+///                     </VisualState.StateTriggers>
+///                     <VisualState.Setters>
+///                         <Setter Target="LayoutRoot.Background" Value="Gray" />
+///                         <Setter Target="ExampleText.Opacity" Value="0.4" />
+///                     </VisualState.Setters>
+///                 </VisualState>
+///             </VisualStateGroup>
+///         </VisualStateManager.VisualStateGroups>
+///     </Grid>
+/// </Page>
+/// ]]></code>
 /// </example>
 [Windows.Foundation.Metadata.ContractVersion(typeof(Windows.Foundation.UniversalApiContract), 327680u)]
 public sealed class WindowActivationModeTrigger : StateTriggerBase
 {
-    private CoreWindow? _coreWindow;
+    private readonly CoreWindow _coreWindow;
+    private readonly WeakEventListener<WindowActivationModeTrigger, CoreWindow, WindowActivatedEventArgs> _weakEventListener;
 
     /// <summary>
     /// Identifies the <see cref="ActivationMode"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty ActivationModeProperty = DependencyProperty.Register(
-        nameof(ActivationMode), typeof(CoreWindowActivationMode), typeof(WindowActivationModeTrigger), new PropertyMetadata(CoreWindowActivationMode.None, OnActivationModePropertyChanged));
+        nameof(ActivationMode),
+        typeof(CoreWindowActivationMode),
+        typeof(WindowActivationModeTrigger),
+        new PropertyMetadata(CoreWindowActivationMode.None, (d, e) => ((WindowActivationModeTrigger)d).UpdateTrigger()));
 
     /// <summary>
-    /// Gets or sets the activation mode that indicates whether the trigger should be applied.
+    /// Gets or sets the activation mode at which the <see cref="VisualState"/>
+    /// should be applied.
     /// </summary>
+    /// <value>A value that indicates when the <see cref="VisualState"/> should
+    /// be applied. The default is <b>None</b>.</value>
     public CoreWindowActivationMode ActivationMode
     {
         get { return (CoreWindowActivationMode)GetValue(ActivationModeProperty); }
         set { SetValue(ActivationModeProperty, value); }
     }
 
-    private static void OnActivationModePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WindowActivationModeTrigger"/> class.
+    /// </summary>
+    public WindowActivationModeTrigger()
     {
-        if (d is WindowActivationModeTrigger trigger)
+        _coreWindow = Window.Current.CoreWindow;
+
+        _weakEventListener = new(this)
         {
-            trigger.UpdateActivatedEventHandler();
-            trigger.UpdateTrigger();
-        }
+            OnEventAction = (instance, sender, args) => CoreWindow_OnActivated(sender, args),
+            OnDetachAction = (weakEventListener) => _coreWindow.Activated -= weakEventListener.OnEvent
+        };
+
+        _coreWindow.Activated += _weakEventListener.OnEvent;
+        UpdateTrigger();
     }
 
-    private void UpdateActivatedEventHandler()
-    {
-        _coreWindow = Window.Current?.CoreWindow;
-
-        var coreWindow = _coreWindow;
-        if (coreWindow != null)
-        {
-            coreWindow.Activated -= OnActivated;
-
-            if (ActivationMode is not CoreWindowActivationMode.None)
-            {
-                coreWindow.Activated += OnActivated;
-            }
-        }
-    }
-
-    private void OnActivated(CoreWindow sender, WindowActivatedEventArgs args)
+    private void CoreWindow_OnActivated(CoreWindow sender, WindowActivatedEventArgs args)
     {
         UpdateTrigger();
     }

--- a/Screenbox/Triggers/WindowActivationModeTrigger.cs
+++ b/Screenbox/Triggers/WindowActivationModeTrigger.cs
@@ -79,7 +79,7 @@ public sealed class WindowActivationModeTrigger : StateTriggerBase
 
         _weakEventListener = new(this)
         {
-            OnEventAction = (instance, sender, args) => CoreWindow_OnActivated(sender, args),
+            OnEventAction = static (instance, sender, args) => instance.CoreWindow_OnActivated(sender, args),
             OnDetachAction = (weakEventListener) => _coreWindow.Activated -= weakEventListener.OnEvent
         };
 


### PR DESCRIPTION
Added Deactivated visual state to `PlayerPage.xaml` so when the window is deactivated, the title bar text colors are updated, especially important for the compact overlay mode.
I wonder if we should consider lowering the opacity of the top buttons and controls?


https://github.com/user-attachments/assets/69b7fcaf-6db9-46ba-9af6-5c60e86eaffc