### PR TITLE
fix: add to playlist button chevron position

### DIFF
--- a/Screenbox/Controls/PlayQueueControl.xaml
+++ b/Screenbox/Controls/PlayQueueControl.xaml
@@ -234,12 +234,12 @@
                 <AppBarButton
                     x:Name="AddToPlaylistSelectionButton"
                     Icon="Add"
-                    IsEnabled="{x:Bind ViewModel.SelectionCount, Converter={StaticResource DoubleToBoolConverter}, Mode=OneWay}"
                     Label="{strings:Resources Key=AddToPlaylist}">
                     <AppBarButton.Resources>
                         <Visibility x:Key="AppBarButtonHasFlyoutChevronVisibility">Visible</Visibility>
                         <x:String x:Key="AppBarButtonFlyoutGlyph">&#xE972;</x:String>
                         <x:Double x:Key="AppBarButtonSubItemChevronFontSize">12</x:Double>
+                        <Thickness x:Key="AppBarButtonSubItemChevronMargin">-8,18,8,0</Thickness>
                         <Thickness x:Key="AppBarButtonSubItemChevronLabelOnRightMargin">-7,18,12,0</Thickness>
                     </AppBarButton.Resources>
                     <AppBarButton.Flyout>


### PR DESCRIPTION
| Before | After |
|-|-|
|<img width="884" height="444" alt="Captura de Ecrã (13)" src="https://github.com/user-attachments/assets/1c7286ca-b914-453e-811b-45b7bf510bba" />|<img width="884" height="444" alt="Captura de Ecrã (18)" src="https://github.com/user-attachments/assets/785be075-89fc-4aba-995f-a14cc65e390a" />|

This also fixes the chevron position when the button is in the overflow state (I have no clue why it toggles between the two chevrons). However, the only dependable solution is to keep the button always enabled. There were a few possible fixes, but each came with its own drawbacks, and keeping the button always enabled was the least nonsensical.

https://github.com/user-attachments/assets/41c0adb1-811f-4d7f-af80-038cb4ae6ce7

