### PR TITLE
feat: enable .NET Native trimming

### DIFF
--- a/Screenbox.Core/Properties/Screenbox.Core.rd.xml
+++ b/Screenbox.Core/Properties/Screenbox.Core.rd.xml
@@ -29,5 +29,12 @@
 
   	<!-- add directives for your library here -->
 
+    <Namespace Name="ProtoBuf.Serializers" Dynamic="Required Public" />
+
+    <Type Name="ProtoBuf.Internal.Level300DefaultSerializer" Dynamic="Required All" />
+    <Type Name="ProtoBuf.Internal.Level300FixedSerializer" Dynamic="Required All" />
+
+    <Type Name="CommunityToolkit.Mvvm.Messaging.IMessengerExtensions" Dynamic="Required All" />
+
   </Library>
 </Directives>

--- a/Screenbox.Core/Properties/Screenbox.Core.rd.xml
+++ b/Screenbox.Core/Properties/Screenbox.Core.rd.xml
@@ -29,11 +29,6 @@
 
   	<!-- add directives for your library here -->
 
-    <Namespace Name="ProtoBuf.Serializers" Dynamic="Required Public" />
-
-    <Type Name="ProtoBuf.Internal.Level300DefaultSerializer" Dynamic="Required All" />
-    <Type Name="ProtoBuf.Internal.Level300FixedSerializer" Dynamic="Required All" />
-
     <Type Name="CommunityToolkit.Mvvm.Messaging.IMessengerExtensions" Dynamic="Required All" />
 
   </Library>

--- a/Screenbox.Lively/Properties/Screenbox.Lively.rd.xml
+++ b/Screenbox.Lively/Properties/Screenbox.Lively.rd.xml
@@ -29,5 +29,8 @@
 
   	<!-- add directives for your library here -->
 
+    <Namespace Name="Screenbox.Lively.Models" Serialize="All" />
+    <Namespace Name="System.Text.Json" Serialize="All" />
+
   </Library>
 </Directives>

--- a/Screenbox/Properties/Default.rd.xml
+++ b/Screenbox/Properties/Default.rd.xml
@@ -21,11 +21,37 @@
       An Assembly element with Name="*Application*" applies to all assemblies in
       the application package. The asterisks are not wildcards.
     -->
-    <Assembly Name="*Application*" Dynamic="Required All" />
+    <!--<Assembly Name="*Application*" Dynamic="Required All" />-->
     
     
     <!-- Add your application specific runtime directives here. -->
+    
+    <Namespace Name="ProtoBuf.Serializers" Dynamic="Required Public" />
+    <!--<Type Name="ProtoBuf.Serializers.EnumSerializerSByte`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerInt16`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerInt32`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerInt64`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerByte`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt16`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt32`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt64`1" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.ConcurrentDictionarySerializer`3" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.DictionarySerializer`2" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.DictionarySerializer`3" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.DictionaryOfIReadOnlyDictionarySerializer`2" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.ImmutableDictionarySerializer`2" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.ImmutableSortedDictionarySerializer`2" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.ImmutableIDictionarySerializer`2" Activate="Required Public" />
+    <Type Name="ProtoBuf.Serializers.ConcurrentBagSerializer`2" Activate="Required Public" />
+    ...-->
 
+    <!--<Namespace Name="ProtoBuf.Internal" Dynamic="Required All" />-->
+    <Type Name="ProtoBuf.Internal.Level300DefaultSerializer" Dynamic="Required All" />
+    <Type Name="ProtoBuf.Internal.Level300FixedSerializer" Dynamic="Required All" />
+    
+    <Type Name="CommunityToolkit.Mvvm.Messaging.IMessengerExtensions" Dynamic="Required All" />
 
+    <!-- Required for Lively Wallpaper. -->
+    <Namespace Name="System.Text.Json" Serialize="All" />
   </Application>
 </Directives>

--- a/Screenbox/Properties/Default.rd.xml
+++ b/Screenbox/Properties/Default.rd.xml
@@ -25,33 +25,7 @@
     
     
     <!-- Add your application specific runtime directives here. -->
-    
-    <Namespace Name="ProtoBuf.Serializers" Dynamic="Required Public" />
-    <!--<Type Name="ProtoBuf.Serializers.EnumSerializerSByte`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerInt16`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerInt32`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerInt64`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerByte`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt16`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt32`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.EnumSerializerUInt64`1" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.ConcurrentDictionarySerializer`3" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.DictionarySerializer`2" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.DictionarySerializer`3" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.DictionaryOfIReadOnlyDictionarySerializer`2" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.ImmutableDictionarySerializer`2" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.ImmutableSortedDictionarySerializer`2" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.ImmutableIDictionarySerializer`2" Activate="Required Public" />
-    <Type Name="ProtoBuf.Serializers.ConcurrentBagSerializer`2" Activate="Required Public" />
-    ...-->
 
-    <!--<Namespace Name="ProtoBuf.Internal" Dynamic="Required All" />-->
-    <Type Name="ProtoBuf.Internal.Level300DefaultSerializer" Dynamic="Required All" />
-    <Type Name="ProtoBuf.Internal.Level300FixedSerializer" Dynamic="Required All" />
-    
-    <Type Name="CommunityToolkit.Mvvm.Messaging.IMessengerExtensions" Dynamic="Required All" />
 
-    <!-- Required for Lively Wallpaper. -->
-    <Namespace Name="System.Text.Json" Serialize="All" />
   </Application>
 </Directives>


### PR DESCRIPTION
Followed [this blog post](https://devblogs.microsoft.com/ifdef-windows/leveraging-trimming-to-make-the-microsoft-store-faster-and-reduce-its-binary-size/), and used [this troubleshooter](https://dotnet.github.io/native/troubleshooter/type.html) to enable .NET Native trimming.

Reduces the overall bundle size by approximately 10 MB.
<img width="1296" height="760" alt="Comparison between a bundle with trimming and one without it" src="https://github.com/user-attachments/assets/dd8b8e90-2b78-478a-8e03-7cfc53c97403" />

And after unzipping, each package saves approximately 10 MB, with the `Screenbox.dll` file being the primary beneficiary of this reduction.

| Without trimming | With trimming |
|-|-|
|<img width="1042" height="1022" alt="imagem" src="https://github.com/user-attachments/assets/155cb59f-6a8b-41b3-8de5-0aeb9ef3c385" />|<img width="1042" height="1022" alt="imagem" src="https://github.com/user-attachments/assets/c3a1707e-8c17-4c53-8fcf-bbc549428f82" />|