### PR TITLE
fix: network location opening issues

### DIFF
--- a/Screenbox.Core/Services/PlayerService.cs
+++ b/Screenbox.Core/Services/PlayerService.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using LibVLCSharp.Shared;
 using Screenbox.Core.Playback;
 using Windows.ApplicationModel.DataTransfer;
@@ -25,8 +26,16 @@ public sealed class PlayerService : IPlayerService
 
         try
         {
-            // Clear FA periodically because of 1000 items limit
-            StorageApplicationPermissions.FutureAccessList.Clear();
+            // Clear FA periodically because of 1000 items limit 
+            // Delete any entries with "media" metadata to avoid hitting the limit with stale entries
+            var tokensToRemove = StorageApplicationPermissions.FutureAccessList.Entries
+                .Where(entry => entry.Metadata == "media")
+                .Select(entry => entry.Token)
+                .ToList();
+            foreach (var token in tokensToRemove)
+            {
+                StorageApplicationPermissions.FutureAccessList.Remove(token);
+            }
         }
         catch (Exception)   // FileNotFoundException
         {
@@ -87,12 +96,16 @@ public sealed class PlayerService : IPlayerService
 
     private Media CreateMedia(VlcMediaPlayer player, IStorageFile file, params string[] options)
     {
-        if (file is StorageFile storageFile &&
-            storageFile.Provider.Id.Equals("network", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrEmpty(storageFile.Path))
+        // NOTE: There have been reports of network locations not working when using the URI approach.
+        // Optimization is disable until we can confirm that the issue is resolved in newer versions of LibVLC and/or Windows.
+        if (file is StorageFile storageFile
+            && storageFile.Provider.Id.Equals("network", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(storageFile.Path)
+            && !_useFal
+            && Uri.TryCreate(storageFile.Path, UriKind.Absolute, out var uri))
         {
             // Optimization for network files. Avoid having to deal with WinRT quirks.
-            return CreateMedia(player, new Uri(storageFile.Path, UriKind.Absolute), options);
+            return CreateMedia(player, uri, options);
         }
 
         string token = _useFal


### PR DESCRIPTION
Fixes #829 

This removes the optimization that converts a `StorageFile` to just a URL for network locations. This should resolve the file access issue for network files.