### PR TITLE
ci: remove build concurrency requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,6 @@ on:
     - v**
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   xaml-lint:
     runs-on: windows-latest


### PR DESCRIPTION
This concurrency enforcement was put in to save compute cost, but it mainly fails the build prematurely without any tangible benefits.