### PR TITLE
feat: adds ability to delete video file in player

### DIFF
--- a/Screenbox.Core/Messages/DeleteCurrentMediaFileRequestMessage.cs
+++ b/Screenbox.Core/Messages/DeleteCurrentMediaFileRequestMessage.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Screenbox.Core.Messages;
+
+public sealed class DeleteCurrentMediaFileRequestMessage : RequestMessage<Task<bool>>
+{
+}

--- a/Screenbox.Core/Messages/FailedToDeleteMediaFileNotificationMessage.cs
+++ b/Screenbox.Core/Messages/FailedToDeleteMediaFileNotificationMessage.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+
+namespace Screenbox.Core.Messages;
+
+/// <summary>
+/// Sent by a view model when deleting a media file from disk fails.
+/// <see cref="ViewModels.NotificationViewModel"/> handles this message
+/// </summary>
+public sealed class FailedToDeleteMediaFileNotificationMessage
+{
+    /// <summary>Gets the error detail from the underlying exception, or <c>null</c> if unavailable.</summary>
+    public string? Reason { get; }
+
+    public FailedToDeleteMediaFileNotificationMessage(string? reason = null)
+    {
+        Reason = reason;
+    }
+}

--- a/Screenbox.Core/Messages/MediaFileDeletedNotificationMessage.cs
+++ b/Screenbox.Core/Messages/MediaFileDeletedNotificationMessage.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+
+namespace Screenbox.Core.Messages;
+
+/// <summary>
+/// Sent by a view model when a media file is successfully deleted from disk.
+/// <see cref="ViewModels.NotificationViewModel"/> displays a localized success notification.
+/// </summary>
+public sealed class MediaFileDeletedNotificationMessage
+{
+    /// <summary>Gets the display name of the deleted media file.</summary>
+    public string FileName { get; }
+
+    public MediaFileDeletedNotificationMessage(string fileName)
+    {
+        FileName = fileName;
+    }
+}

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -168,6 +168,19 @@ public sealed class FilesService : IFilesService
         }
     }
 
+    public async Task<bool> TryDeleteFileAsync(StorageFile file, StorageDeleteOption deleteOption = StorageDeleteOption.Default)
+    {
+        try
+        {
+            await file.DeleteAsync(deleteOption);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
     public void AddToRecent(IStorageItem item)
     {
         string metadata = DateTimeOffset.Now.ToUnixTimeSeconds().ToString();

--- a/Screenbox.Core/Services/IFilesService.cs
+++ b/Screenbox.Core/Services/IFilesService.cs
@@ -23,6 +23,7 @@ namespace Screenbox.Core.Services
         public IAsyncOperation<StorageFolder> PickFolderAsync();
         public Task OpenFileLocationAsync(string path);
         public Task OpenFileLocationAsync(StorageFile file);
+        public Task<bool> TryDeleteFileAsync(StorageFile file, StorageDeleteOption deleteOption = StorageDeleteOption.Default);
         public void AddToRecent(IStorageItem item);
         public Task<StorageFile> SaveToDiskAsync<T>(StorageFolder folder, string fileName, T source);
         public Task SaveToDiskAsync<T>(StorageFile file, T source);

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -36,6 +36,7 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
     IRecipient<QueuePlaylistMessage>,
     IRecipient<ClearPlaylistMessage>,
     IRecipient<PlaylistRequestMessage>,
+    IRecipient<DeleteCurrentMediaFileRequestMessage>,
     IRecipient<PropertyChangedMessage<IMediaPlayer?>>
 {
     // UI-bindable properties
@@ -181,6 +182,11 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
     public void Receive(PlaylistRequestMessage message)
     {
         message.Reply(new Playlist(_playlist));
+    }
+
+    public void Receive(DeleteCurrentMediaFileRequestMessage message)
+    {
+        message.Reply(DeleteCurrentMediaFileAsync());
     }
 
     public async void Receive(PlayMediaMessage message)
@@ -618,6 +624,54 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
         var playlist = new Playlist(nextItem, new List<MediaViewModel> { nextItem });
         LoadFromPlaylist(playlist);
         PlaySingle(nextItem);
+    }
+
+    private async Task<bool> DeleteCurrentMediaFileAsync()
+    {
+        // checks here for the video to delete
+        if (CurrentItem is not { } mediaToDelete) return false;
+
+        StorageFile? file = mediaToDelete.Source as StorageFile;
+        if (file == null && mediaToDelete.Source is Uri { IsFile: true, IsLoopback: true, IsAbsoluteUri: true } uri)
+        {
+            try
+            {
+                file = await StorageFile.GetFileFromPathAsync(uri.LocalPath);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        if (file == null) return false;
+
+        int deleteIndex = Items.IndexOf(mediaToDelete);
+        if (deleteIndex < 0) return false;
+
+        bool wasPlaying = MediaPlayer?.PlaybackState is MediaPlaybackState.Playing or MediaPlaybackState.Opening;
+        MediaViewModel? replacement = Items.Count <= 1
+            ? null
+            : deleteIndex < Items.Count - 1
+                ? Items[deleteIndex + 1]
+                : Items[deleteIndex - 1];
+
+        CurrentItem = replacement;
+        if (replacement == null)
+        {
+            MediaPlayer?.Pause();
+        }
+        else if (wasPlaying)
+        {
+            MediaPlayer?.Play();
+        }
+
+        // finally we can delete the video!
+        if (!await _filesService.TryDeleteFileAsync(file)) return false;
+
+        Items.Remove(mediaToDelete);
+        mediaToDelete.Clean();
+        return true;
     }
 
     #endregion

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -628,8 +628,14 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
 
     private async Task<bool> DeleteCurrentMediaFileAsync()
     {
-        // checks here for the video to delete
-        if (CurrentItem is not { } mediaToDelete) return false;
+        bool Fail(string? reason = null)
+        {
+            Messenger.Send(new FailedToDeleteMediaFileNotificationMessage(reason));
+            return false;
+        }
+
+        if (CurrentItem is not { } mediaToDelete) return Fail();
+        string deletedName = mediaToDelete.Name;
 
         StorageFile? file = mediaToDelete.Source as StorageFile;
         if (file == null && mediaToDelete.Source is Uri { IsFile: true, IsLoopback: true, IsAbsoluteUri: true } uri)
@@ -640,14 +646,14 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
             }
             catch (Exception)
             {
-                return false;
+                return Fail();
             }
         }
 
-        if (file == null) return false;
+        if (file == null) return Fail();
 
         int deleteIndex = Items.IndexOf(mediaToDelete);
-        if (deleteIndex < 0) return false;
+        if (deleteIndex < 0) return Fail();
 
         bool wasPlaying = MediaPlayer?.PlaybackState is MediaPlaybackState.Playing or MediaPlaybackState.Opening;
         MediaViewModel? replacement = Items.Count <= 1
@@ -666,11 +672,11 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
             MediaPlayer?.Play();
         }
 
-        // finally we can delete the video!
-        if (!await _filesService.TryDeleteFileAsync(file)) return false;
+        if (!await _filesService.TryDeleteFileAsync(file)) return Fail();
 
         Items.Remove(mediaToDelete);
         mediaToDelete.Clean();
+        Messenger.Send(new MediaFileDeletedNotificationMessage(deletedName));
         return true;
     }
 

--- a/Screenbox.Core/ViewModels/MediaListViewModel.cs
+++ b/Screenbox.Core/ViewModels/MediaListViewModel.cs
@@ -652,27 +652,29 @@ public sealed partial class MediaListViewModel : ObservableRecipient,
 
         if (file == null) return Fail();
 
-        int deleteIndex = Items.IndexOf(mediaToDelete);
-        if (deleteIndex < 0) return Fail();
-
-        bool wasPlaying = MediaPlayer?.PlaybackState is MediaPlaybackState.Playing or MediaPlaybackState.Opening;
-        MediaViewModel? replacement = Items.Count <= 1
-            ? null
-            : deleteIndex < Items.Count - 1
-                ? Items[deleteIndex + 1]
-                : Items[deleteIndex - 1];
-
-        CurrentItem = replacement;
-        if (replacement == null)
+        // Stop playback first to release the file handle before deleting.
+        try
         {
-            MediaPlayer?.Pause();
+            if (MediaPlayer is VlcMediaPlayer vlcMediaPlayer)
+            {
+                vlcMediaPlayer.VlcPlayer.Stop();
+            }
+            else
+            {
+                MediaPlayer?.Pause();
+            }
         }
-        else if (wasPlaying)
+        catch (Exception)
         {
-            MediaPlayer?.Play();
+            return Fail();
         }
 
         if (!await _filesService.TryDeleteFileAsync(file)) return Fail();
+
+        if (ReferenceEquals(CurrentItem, mediaToDelete))
+        {
+            CurrentItem = null;
+        }
 
         Items.Remove(mediaToDelete);
         mediaToDelete.Clean();

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -546,6 +546,16 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
         {
             return false;
         }
+
+        try
+        {
+            _ = Messenger.Send(new DeleteCurrentMediaFileRequestMessage());
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -530,6 +530,25 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     }
 
     /// <summary>
+    /// Handles the Delete shortcut in player context.
+    /// </summary>
+    /// <param name="key">The key that was pressed.</param>
+    /// <param name="modifiers">The modifier keys held during the key press.</param>
+    /// <returns><see langword="true"/> if handled; otherwise, <see langword="false"/>.</returns>
+    public bool ProcessDeleteKeyDown(VirtualKey key, VirtualKeyModifiers modifiers)
+    {
+        if (PlayerVisibility != PlayerVisibilityState.Visible)
+        {
+            return false;
+        }
+
+        if (key != VirtualKey.Delete || modifiers != VirtualKeyModifiers.None)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Handles a window resize operation based on keyboard input.
     /// </summary>
     /// <remarks>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -353,6 +353,19 @@
                         <KeyboardAccelerator Key="F11" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem
+                    Click="DeleteMediaFileMenuFlyoutItem_OnClick"
+                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                    IsEnabled="{x:Bind ViewModel.HasActiveItem, Mode=OneWay}"
+                    Text="{x:Bind strings:Resources.Delete}">
+                    <MenuFlyoutItem.Icon>
+                        <ui:SymbolIcon Foreground="{ThemeResource SystemFillColorCriticalBrush}" Symbol="Delete" />
+                    </MenuFlyoutItem.Icon>
+                    <MenuFlyoutItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="Delete" />
+                    </MenuFlyoutItem.KeyboardAccelerators>
+                </MenuFlyoutItem>
             </MenuFlyout>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -36,6 +36,8 @@ public sealed partial class PlayerControls : UserControl
 
     internal CommonViewModel Common { get; }
 
+    public event RoutedEventHandler? DeleteMediaFileRequested;
+
     private Flyout? _castFlyout;
 
     public PlayerControls()
@@ -70,6 +72,11 @@ public sealed partial class PlayerControls : UserControl
     {
         _castFlyout ??= CastControl.GetFlyout();
         _castFlyout.ShowAt(MoreButton, new FlyoutShowOptions { Placement = FlyoutPlacementMode.TopEdgeAlignedRight });
+    }
+
+    private void DeleteMediaFileMenuFlyoutItem_OnClick(object sender, RoutedEventArgs e)
+    {
+        DeleteMediaFileRequested?.Invoke(this, e);
     }
 
     private void CustomSpeedMenuItem_OnClick(object sender, RoutedEventArgs e)

--- a/Screenbox/Dialogs/DeleteMediaFileDialog.xaml
+++ b/Screenbox/Dialogs/DeleteMediaFileDialog.xaml
@@ -1,0 +1,58 @@
+<ContentDialog
+    x:Class="Screenbox.Dialogs.DeleteMediaFileDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:strings="using:Screenbox.Strings"
+    Title="{strings:Resources Key=DeleteMediaFile}"
+    CloseButtonText="{strings:Resources Key=Cancel}"
+    PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+    PrimaryButtonText="{strings:Resources Key=Delete}"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    mc:Ignorable="d">
+
+    <ContentDialog.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Default">
+                    <SolidColorBrush x:Key="DangerFillColorPrimaryBrush" Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorSecondaryBrush"
+                        Opacity="0.9"
+                        Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorTertiaryBrush"
+                        Opacity="0.8"
+                        Color="{StaticResource SystemFillColorCritical}" />
+
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="DangerFillColorPrimaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="DangerFillColorSecondaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="DangerFillColorTertiaryBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="DangerFillColorPrimaryBrush" Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorSecondaryBrush"
+                        Opacity="0.9"
+                        Color="{StaticResource SystemFillColorCritical}" />
+                    <SolidColorBrush
+                        x:Key="DangerFillColorTertiaryBrush"
+                        Opacity="0.8"
+                        Color="{StaticResource SystemFillColorCritical}" />
+
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="DangerFillColorPrimaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="DangerFillColorSecondaryBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="DangerFillColorTertiaryBrush" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <StaticResource x:Key="AccentButtonBackground" ResourceKey="SystemColorHighlightColorBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+                    <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemColorButtonFaceColorBrush" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </ContentDialog.Resources>
+
+    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Bind strings:Resources.DeleteMediaFileConfirmation(MediaName)}" />
+</ContentDialog>

--- a/Screenbox/Dialogs/DeleteMediaFileDialog.xaml
+++ b/Screenbox/Dialogs/DeleteMediaFileDialog.xaml
@@ -1,4 +1,4 @@
-<ContentDialog
+﻿<ContentDialog
     x:Class="Screenbox.Dialogs.DeleteMediaFileDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -54,5 +54,10 @@
         </ResourceDictionary>
     </ContentDialog.Resources>
 
-    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Bind strings:Resources.DeleteMediaFileConfirmation(MediaName)}" />
+    <StackPanel Spacing="12">
+        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Bind strings:Resources.DeleteMediaFileConfirmation(MediaName)}" />
+        <CheckBox
+            x:Name="SkipWarningCheckBox"
+            Content="{strings:Resources Key=DeleteMediaFileSkipWarning}" />
+    </StackPanel>
 </ContentDialog>

--- a/Screenbox/Dialogs/DeleteMediaFileDialog.xaml.cs
+++ b/Screenbox/Dialogs/DeleteMediaFileDialog.xaml.cs
@@ -10,6 +10,8 @@ public sealed partial class DeleteMediaFileDialog : ContentDialog
 {
     private string MediaName { get; }
 
+    public bool SkipWarning => SkipWarningCheckBox.IsChecked == true;
+
     public DeleteMediaFileDialog(string mediaName)
     {
         this.DefaultStyleKey = typeof(ContentDialog);

--- a/Screenbox/Dialogs/DeleteMediaFileDialog.xaml.cs
+++ b/Screenbox/Dialogs/DeleteMediaFileDialog.xaml.cs
@@ -1,0 +1,21 @@
+﻿using Screenbox.Helpers;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Screenbox.Dialogs;
+
+// copied the other dialogs
+
+public sealed partial class DeleteMediaFileDialog : ContentDialog
+{
+    private string MediaName { get; }
+
+    public DeleteMediaFileDialog(string mediaName)
+    {
+        this.DefaultStyleKey = typeof(ContentDialog);
+        this.InitializeComponent();
+        FlowDirection = GlobalizationHelper.GetFlowDirection();
+        RequestedTheme = ((FrameworkElement)Window.Current.Content).RequestedTheme;
+        MediaName = mediaName;
+    }
+}

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -173,6 +173,7 @@
             <KeyboardAccelerator Key="NumberPad9" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="Home" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="End" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
+            <KeyboardAccelerator Key="Delete" Invoked="DeleteKeyboardAccelerator_OnInvoked" />
             <!--  Hide controls  -->
             <KeyboardAccelerator Key="Escape" Invoked="HideControlsKeyboardAccelerator_OnInvoked" />
         </Grid.KeyboardAccelerators>

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -468,6 +468,7 @@
 
         <controls:PlayerControls
             x:Name="PlayerControls"
+            DeleteMediaFileRequested="PlayerControls_OnDeleteMediaFileRequested"
             Grid.Row="2"
             Grid.Column="0"
             Padding="6,20,6,12" />

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using Screenbox.Controls;
+using Screenbox.Dialogs;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
@@ -518,7 +519,7 @@ public sealed partial class PlayerPage : Page
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
     }
 
-    private void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    private async void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         if (FocusManager.GetFocusedElement() is TextBox)
         {
@@ -526,7 +527,22 @@ public sealed partial class PlayerPage : Page
             return;
         }
 
-        args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
+        if (ViewModel.Media == null)
+        {
+            args.Handled = false;
+            return;
+        }
+
+        var deleteConfirmation = new DeleteMediaFileDialog(ViewModel.Media.Name);
+        var result = await deleteConfirmation.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
+        }
+        else
+        {
+            args.Handled = true;
+        }
     }
 
     private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading;
+using System.Threading.Tasks;
 using CommunityToolkit.Diagnostics;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
@@ -530,18 +531,16 @@ public sealed partial class PlayerPage : Page
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
     }
 
-    private async void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    private async void PlayerControls_OnDeleteMediaFileRequested(object sender, RoutedEventArgs e)
     {
-        if (FocusManager.GetFocusedElement() is TextBox)
-        {
-            args.Handled = false;
-            return;
-        }
+        await TryDeleteCurrentMediaFileAsync(VirtualKey.Delete, VirtualKeyModifiers.None);
+    }
 
+    private async Task<bool> TryDeleteCurrentMediaFileAsync(VirtualKey key, VirtualKeyModifiers modifiers)
+    {
         if (ViewModel.Media == null)
         {
-            args.Handled = false;
-            return;
+            return false;
         }
 
         if (!SkipDeleteMediaFileWarning)
@@ -550,14 +549,24 @@ public sealed partial class PlayerPage : Page
             var result = await deleteConfirmation.ShowAsync();
             if (result != ContentDialogResult.Primary)
             {
-                args.Handled = true;
-                return;
+                return true;
             }
 
             SkipDeleteMediaFileWarning = deleteConfirmation.SkipWarning;
         }
 
-        args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
+        return ViewModel.ProcessDeleteKeyDown(key, modifiers);
+    }
+
+    private async void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (FocusManager.GetFocusedElement() is TextBox)
+        {
+            args.Handled = false;
+            return;
+        }
+
+        args.Handled = await TryDeleteCurrentMediaFileAsync(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
     }
 
     private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -520,7 +520,13 @@ public sealed partial class PlayerPage : Page
 
     private void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
-        args.Handled = false;
+        if (FocusManager.GetFocusedElement() is TextBox)
+        {
+            args.Handled = false;
+            return;
+        }
+
+        args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
     }
 
     private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -13,6 +13,7 @@ using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
 using Screenbox.Helpers;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -32,11 +33,21 @@ namespace Screenbox.Pages;
 /// </summary>
 public sealed partial class PlayerPage : Page
 {
+    private const string SkipDeleteMediaFileWarningSettingKey = "SkipDeleteMediaFileWarning";
+
     internal PlayerPageViewModel ViewModel => (PlayerPageViewModel)DataContext;
 
     private readonly DispatcherQueueTimer _delayFlyoutOpenTimer;
     private CancellationTokenSource? _animationCancellationTokenSource;
     private bool _startup;
+
+    private static bool SkipDeleteMediaFileWarning
+    {
+        get => ApplicationData.Current.LocalSettings.Values.TryGetValue(SkipDeleteMediaFileWarningSettingKey, out object value)
+            && value is bool enabled
+            && enabled;
+        set => ApplicationData.Current.LocalSettings.Values[SkipDeleteMediaFileWarningSettingKey] = value;
+    }
 
     public PlayerPage()
     {
@@ -533,16 +544,20 @@ public sealed partial class PlayerPage : Page
             return;
         }
 
-        var deleteConfirmation = new DeleteMediaFileDialog(ViewModel.Media.Name);
-        var result = await deleteConfirmation.ShowAsync();
-        if (result == ContentDialogResult.Primary)
+        if (!SkipDeleteMediaFileWarning)
         {
-            args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
+            var deleteConfirmation = new DeleteMediaFileDialog(ViewModel.Media.Name);
+            var result = await deleteConfirmation.ShowAsync();
+            if (result != ContentDialogResult.Primary)
+            {
+                args.Handled = true;
+                return;
+            }
+
+            SkipDeleteMediaFileWarning = deleteConfirmation.SkipWarning;
         }
-        else
-        {
-            args.Handled = true;
-        }
+
+        args.Handled = ViewModel.ProcessDeleteKeyDown(args.KeyboardAccelerator.Key, args.KeyboardAccelerator.Modifiers);
     }
 
     private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -518,6 +518,11 @@ public sealed partial class PlayerPage : Page
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
     }
 
+    private void DeleteKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        args.Handled = false;
+    }
+
     private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         if (ViewModel.ViewMode == WindowViewMode.Default)

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1062,6 +1062,9 @@
     <value>Are you sure you want to delete '{0}'? You cannot undo this action.</value>
     <comment>#Format[String fileName]</comment>
   </data>
+  <data name="DeleteMediaFileSkipWarning" xml:space="preserve">
+    <value>Don't show this warning again</value>
+  </data>
   <data name="SettingsSavePlaybackPositionHeader" xml:space="preserve">
     <value>Playback position history</value>
   </data>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -712,6 +712,13 @@
     <value>Playlist renamed to "{0}"</value>
     <comment>#Format[String name]</comment>
   </data>
+  <data name="MediaFileDeletedNotificationTitle" xml:space="preserve">
+    <value>Deleted "{0}"</value>
+    <comment>#Format[String name]</comment>
+  </data>
+  <data name="FailedToDeleteMediaFileNotificationTitle" xml:space="preserve">
+    <value>Failed to delete file</value>
+  </data>
   <data name="CriticalError" xml:space="preserve">
     <value>Critical error</value>
   </data>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1055,6 +1055,13 @@
     <value>Are you sure you want to delete '{0}' playlist? You cannot undo this action.</value>
     <comment>#Format[String playlistName]</comment>
   </data>
+  <data name="DeleteMediaFile" xml:space="preserve">
+    <value>Delete file</value>
+  </data>
+  <data name="DeleteMediaFileConfirmation" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}'? You cannot undo this action.</value>
+    <comment>#Format[String fileName]</comment>
+  </data>
   <data name="SettingsSavePlaybackPositionHeader" xml:space="preserve">
     <value>Playback position history</value>
   </data>

--- a/Screenbox/ViewModels/NotificationViewModel.cs
+++ b/Screenbox/ViewModels/NotificationViewModel.cs
@@ -26,6 +26,7 @@ public sealed partial class NotificationViewModel : ObservableRecipient,
     IRecipient<SubtitleAddedNotificationMessage>,
     IRecipient<ErrorMessage>,
     IRecipient<FailedToSaveFrameNotificationMessage>,
+    IRecipient<FailedToDeleteMediaFileNotificationMessage>,
     IRecipient<FailedToLoadSubtitleNotificationMessage>,
     IRecipient<FailedToOpenFilesNotificationMessage>,
     IRecipient<FailedToAddFolderNotificationMessage>,
@@ -33,7 +34,8 @@ public sealed partial class NotificationViewModel : ObservableRecipient,
     IRecipient<PlaylistCreatedNotificationMessage>,
     IRecipient<PlaylistDeletedNotificationMessage>,
     IRecipient<PlaylistRenamedNotificationMessage>,
-    IRecipient<PlaylistItemsAddedNotificationMessage>
+    IRecipient<PlaylistItemsAddedNotificationMessage>,
+    IRecipient<MediaFileDeletedNotificationMessage>
 {
     [ObservableProperty] private NotificationLevel _severity;
 
@@ -224,6 +226,14 @@ public sealed partial class NotificationViewModel : ObservableRecipient,
     }
 
     /// <summary>
+    /// Handles a notification that deleting a media file failed.
+    /// </summary>
+    public void Receive(FailedToDeleteMediaFileNotificationMessage message)
+    {
+        ShowErrorNotification(Resources.FailedToDeleteMediaFileNotificationTitle, message.Reason);
+    }
+
+    /// <summary>
     /// Handles a notification that loading a subtitle file failed.
     /// </summary>
     public void Receive(FailedToLoadSubtitleNotificationMessage message)
@@ -282,6 +292,14 @@ public sealed partial class NotificationViewModel : ObservableRecipient,
     public void Receive(PlaylistItemsAddedNotificationMessage message)
     {
         ShowSuccessNotification(Resources.PlaylistItemsAddedNotificationTitle(message.ItemCount, message.PlaylistName), null);
+    }
+
+    /// <summary>
+    /// Handles a notification that a media file was deleted.
+    /// </summary>
+    public void Receive(MediaFileDeletedNotificationMessage message)
+    {
+        ShowSuccessNotification(Resources.MediaFileDeletedNotificationTitle(message.FileName), null);
     }
 
     private void ShowSuccessNotification(string? title, string? message)


### PR DESCRIPTION
Closes #847 

Figured I'd make my first PR for a tool I like! Tried to keep style consistent and coding principles similar to how y'all implemented other key functions

Added the appropriate success and fail messages like other dialogues, and uses `DeleteAsync` UWP function like is used for some other existing folder operations in this codebase. 

Before deleting, the current video is moved to the next or prev video and THEN deletion is called.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/07e8afdc-44fa-4b2b-a736-6abdf2bf98da" />

---

Original Issue was:

<img width="563" height="177" alt="Image" src="https://github.com/user-attachments/assets/4596e518-c6c6-4be8-8ba7-afd6e1d641f4" />

Was wondering if there could be the ability to delete the active video, through the typical trash can icon, or by pressing the delete key. A lot of photo / gallery viewer softwares have this and it would be cool for this to have it as well!
