### PR TITLE
feat: use escape key to exit fullscreen mode

### DIFF
--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -173,8 +173,8 @@
             <KeyboardAccelerator Key="NumberPad9" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="Home" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="End" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
-            <!--  Hide controls  -->
-            <KeyboardAccelerator Key="Escape" Invoked="HideControlsKeyboardAccelerator_OnInvoked" />
+            <!--  Escape key handling  -->
+            <KeyboardAccelerator Key="Escape" Invoked="EscapeKeyboardAccelerator_OnInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Button

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -518,12 +518,18 @@ public sealed partial class PlayerPage : Page
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
     }
 
-    private void HideControlsKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    private void EscapeKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
-        if (ViewModel.ViewMode == WindowViewMode.Default)
+        switch (ViewModel.ViewMode)
         {
-            ViewModel.TryHideControls();
-            args.Handled = true;
+            case WindowViewMode.FullScreen:
+                ViewModel.GoBack();
+                args.Handled = true;
+                break;
+            case WindowViewMode.Default:
+                ViewModel.TryHideControls();
+                args.Handled = true;
+                break;
         }
     }
 }


### PR DESCRIPTION
Implement feedback from Discord

> I utilized the Screenbox media player and found it to be excellent; all the video and audio codecs function properly and are user-friendly.
> However, there is one problem that concerns me, and I'm not sure if you share the same sentiment.
> The 'Esc' key does not function to exit fullscreen mode; while the 'F' key works, I prefer using 'Esc' as it has become almost second nature for us.
> I hope you can address this in future updates. 

