### PR TITLE
fix: use escape key to exit compact overlay mode

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -62,6 +62,7 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
 
     [ObservableProperty]
     [NotifyPropertyChangedRecipients]
+    [NotifyPropertyChangedFor(nameof(IsPlayerVisibilityVisible))]
     private PlayerVisibilityState _playerVisibility;
 
     [ObservableProperty]
@@ -71,6 +72,8 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     public bool SeekBarPointerInteracting { get; set; }
 
     public Func<double, string>? GetVolumeChangeStatusMessage { get; set; }
+
+    public bool IsPlayerVisibilityVisible => PlayerVisibility is PlayerVisibilityState.Visible;
 
     private IMediaPlayer? MediaPlayer => _playerContext.MediaPlayer;
 

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -555,6 +555,7 @@
                     MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="M" Modifiers="Control" />
+                    <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsCompact, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
             </Button>
             <!--  Fullscreen  -->
@@ -573,6 +574,7 @@
                     MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="F" />
+                    <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsFullscreen, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
             </Button>
             <!--  More  -->

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -555,7 +555,6 @@
                     MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="M" Modifiers="Control" />
-                    <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsCompact, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
             </Button>
             <!--  Fullscreen  -->
@@ -574,7 +573,6 @@
                     MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="F" />
-                    <KeyboardAccelerator Key="Escape" IsEnabled="{x:Bind ViewModel.IsFullscreen, Mode=OneWay}" />
                 </Button.KeyboardAccelerators>
             </Button>
             <!--  More  -->

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -173,6 +173,11 @@
             <KeyboardAccelerator Key="NumberPad9" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="Home" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="End" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
+            <!--  Escape key handling  -->
+            <KeyboardAccelerator
+                Key="Escape"
+                Invoked="EscapeKeyboardAccelerator_OnInvoked"
+                IsEnabled="{x:Bind ViewModel.IsPlayerVisibilityVisible, Mode=OneWay}" />
         </Grid.KeyboardAccelerators>
 
         <Button

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -173,8 +173,6 @@
             <KeyboardAccelerator Key="NumberPad9" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="Home" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
             <KeyboardAccelerator Key="End" Invoked="SeekToPercentageKeyboardAccelerator_OnInvoked" />
-            <!--  Escape key handling  -->
-            <KeyboardAccelerator Key="Escape" Invoked="EscapeKeyboardAccelerator_OnInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Button

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -100,7 +100,6 @@ public sealed partial class PlayerPage : Page
                 VideoView.ContextFlyout.ShowAt(PlayerControls,
                     new FlyoutShowOptions { Placement = GlobalizationHelper.IsRightToLeftLanguage ? FlyoutPlacementMode.TopEdgeAlignedLeft : FlyoutPlacementMode.TopEdgeAlignedRight });
                 break;
-            case VirtualKey.Escape when shouldHideControls:
             case VirtualKey.GamepadB when shouldHideControls:
                 ViewModel.TryHideControls(true);
                 break;
@@ -514,5 +513,21 @@ public sealed partial class PlayerPage : Page
     private void SeekToPercentageKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
+    }
+
+    private void EscapeKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        switch (ViewModel.ViewMode)
+        {
+            case WindowViewMode.Compact:
+            case WindowViewMode.FullScreen:
+                ViewModel.GoBack();
+                args.Handled = true;
+                break;
+            case WindowViewMode.Default:
+                ViewModel.TryHideControls();
+                args.Handled = true;
+                break;
+        }
     }
 }

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -522,6 +522,7 @@ public sealed partial class PlayerPage : Page
     {
         switch (ViewModel.ViewMode)
         {
+            case WindowViewMode.Compact:
             case WindowViewMode.FullScreen:
                 ViewModel.GoBack();
                 args.Handled = true;

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -87,7 +87,6 @@ public sealed partial class PlayerPage : Page
             return;
         }
 
-        bool handled = true;
         bool shouldHideControls = ViewModel is { ControlsHidden: false, ViewMode: WindowViewMode.Default };
 
         switch (e.Key)
@@ -101,15 +100,14 @@ public sealed partial class PlayerPage : Page
                 VideoView.ContextFlyout.ShowAt(PlayerControls,
                     new FlyoutShowOptions { Placement = GlobalizationHelper.IsRightToLeftLanguage ? FlyoutPlacementMode.TopEdgeAlignedLeft : FlyoutPlacementMode.TopEdgeAlignedRight });
                 break;
+            case VirtualKey.Escape when shouldHideControls:
             case VirtualKey.GamepadB when shouldHideControls:
-                handled = ViewModel.TryHideControls();
+                ViewModel.TryHideControls(true);
                 break;
             default:
                 base.OnKeyDown(e);
                 return;
         }
-
-        e.Handled = handled;
     }
 
     private void AlbumArtImageOnSourceChanged(DependencyObject sender, DependencyProperty dp)
@@ -516,21 +514,5 @@ public sealed partial class PlayerPage : Page
     private void SeekToPercentageKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         args.Handled = ViewModel.ProcessPercentJumpKeyDown(args.KeyboardAccelerator.Key);
-    }
-
-    private void EscapeKeyboardAccelerator_OnInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-    {
-        switch (ViewModel.ViewMode)
-        {
-            case WindowViewMode.Compact:
-            case WindowViewMode.FullScreen:
-                ViewModel.GoBack();
-                args.Handled = true;
-                break;
-            case WindowViewMode.Default:
-                ViewModel.TryHideControls();
-                args.Handled = true;
-                break;
-        }
     }
 }


### PR DESCRIPTION
Fixes a regression introduced in #733 when handling the escape key that was partially fixed in #852. Fixes escape key handling in the `PlayQueueControl` `CommadBar`.