### PR TITLE
fix: flyout positioning for RTL languages

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using Screenbox.Core.ViewModels;
+using Screenbox.Helpers;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -69,7 +70,7 @@ public sealed partial class PlayerControls : UserControl
     private void CastMenuFlyoutItem_OnClick(object sender, RoutedEventArgs e)
     {
         _castFlyout ??= CastControl.GetFlyout();
-        _castFlyout.ShowAt(MoreButton, new FlyoutShowOptions { Placement = FlyoutPlacementMode.TopEdgeAlignedRight });
+        _castFlyout.ShowAt(MoreButton, new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
     }
 
     private void CustomSpeedMenuItem_OnClick(object sender, RoutedEventArgs e)

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -70,7 +70,7 @@ public sealed partial class PlayerControls : UserControl
     private void CastMenuFlyoutItem_OnClick(object sender, RoutedEventArgs e)
     {
         _castFlyout ??= CastControl.GetFlyout();
-        _castFlyout.ShowAt(MoreButton, new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
+        _castFlyout.ShowAt(MoreButton, new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
     }
 
     private void CustomSpeedMenuItem_OnClick(object sender, RoutedEventArgs e)

--- a/Screenbox/Helpers/GlobalizationHelper.cs
+++ b/Screenbox/Helpers/GlobalizationHelper.cs
@@ -37,7 +37,7 @@ public static class GlobalizationHelper
     /// if <see cref="IsRightToLeftLanguage"/> is <see langword="true"/>; otherwise, returns the
     /// original value.
     /// </returns>
-    public static FlyoutPlacementMode MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode placement)
+    public static FlyoutPlacementMode MirrorWhenRightToLeft(this FlyoutPlacementMode placement)
     {
         if (!IsRightToLeftLanguage)
         {

--- a/Screenbox/Helpers/GlobalizationHelper.cs
+++ b/Screenbox/Helpers/GlobalizationHelper.cs
@@ -2,6 +2,7 @@
 
 using System.Globalization;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls.Primitives;
 
 namespace Screenbox.Helpers;
 
@@ -24,5 +25,38 @@ public static class GlobalizationHelper
     public static FlowDirection GetFlowDirection()
     {
         return IsRightToLeftLanguage ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+    }
+
+    /// <summary>
+    /// Mirrors the horizontal placement of the specified <see cref="FlyoutPlacementMode"/>
+    /// for right-to-left (RTL) layouts.
+    /// </summary>
+    /// <param name="placement">A value of the enumeration that specifies the placement of the flyout.</param>
+    /// <returns>
+    /// A mirrored horizontal placement value for the <see cref="FlyoutBase.Placement"/> property
+    /// if <see cref="IsRightToLeftLanguage"/> is <see langword="true"/>; otherwise, returns the
+    /// original value.
+    /// </returns>
+    public static FlyoutPlacementMode MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode placement)
+    {
+        if (!IsRightToLeftLanguage)
+        {
+            return placement;
+        }
+
+        return placement switch
+        {
+            FlyoutPlacementMode.Left => FlyoutPlacementMode.Right,
+            FlyoutPlacementMode.Right => FlyoutPlacementMode.Left,
+            FlyoutPlacementMode.TopEdgeAlignedLeft => FlyoutPlacementMode.TopEdgeAlignedRight,
+            FlyoutPlacementMode.TopEdgeAlignedRight => FlyoutPlacementMode.TopEdgeAlignedLeft,
+            FlyoutPlacementMode.BottomEdgeAlignedLeft => FlyoutPlacementMode.BottomEdgeAlignedRight,
+            FlyoutPlacementMode.BottomEdgeAlignedRight => FlyoutPlacementMode.BottomEdgeAlignedLeft,
+            FlyoutPlacementMode.LeftEdgeAlignedTop => FlyoutPlacementMode.RightEdgeAlignedTop,
+            FlyoutPlacementMode.LeftEdgeAlignedBottom => FlyoutPlacementMode.RightEdgeAlignedBottom,
+            FlyoutPlacementMode.RightEdgeAlignedTop => FlyoutPlacementMode.LeftEdgeAlignedTop,
+            FlyoutPlacementMode.RightEdgeAlignedBottom => FlyoutPlacementMode.LeftEdgeAlignedBottom,
+            _ => placement,
+        };
     }
 }

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:controls="using:Screenbox.Controls"
     xmlns:ctAnimations="using:CommunityToolkit.WinUI.Animations"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -220,6 +221,17 @@
                     <VisualState.Setters>
                         <Setter Target="GroupOverview.HorizontalAlignment" Value="Stretch" />
                         <Setter Target="GroupOverview.VerticalAlignment" Value="Stretch" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+
+            <VisualStateGroup x:Name="FlowDirectionStates">
+                <VisualState x:Name="RightToLeft">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{x:Bind helpers:GlobalizationHelper.IsRightToLeftLanguage}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="SortByFlyout.Placement" Value="BottomEdgeAlignedLeft" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -94,7 +94,7 @@
                 </MenuFlyoutItem>
             </MenuFlyout>
 
-            <MenuFlyout x:Key="OpenFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
+            <MenuFlyout x:Key="OpenFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
                 <MenuFlyoutItem
                     AccessKey="{strings:KeyboardResources Key=MenuItemFileKey}"
                     Command="{x:Bind Common.OpenFilesCommand}"

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -13,6 +13,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Screenbox.Core.Models"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:primitives="using:Windows.UI.Xaml.Controls.Primitives"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
@@ -93,7 +94,7 @@
                 </MenuFlyoutItem>
             </MenuFlyout>
 
-            <MenuFlyout x:Key="OpenFlyout" Placement="BottomEdgeAlignedRight">
+            <MenuFlyout x:Key="OpenFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
                 <MenuFlyoutItem
                     AccessKey="{strings:KeyboardResources Key=MenuItemFileKey}"
                     Command="{x:Bind Common.OpenFilesCommand}"

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -11,6 +11,7 @@
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:primitives="using:Windows.UI.Xaml.Controls.Primitives"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
@@ -18,7 +19,7 @@
     mc:Ignorable="d">
 
     <Page.Resources>
-        <MenuFlyout x:Key="AddToPlayQueueFlyout" Placement="BottomEdgeAlignedRight">
+        <MenuFlyout x:Key="AddToPlayQueueFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
             <MenuFlyoutItem
                 AccessKey="{strings:KeyboardResources Key=MenuItemFileKey}"
                 Command="{x:Bind PlayQueue.ViewModel.AddFilesCommand}"

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -19,7 +19,7 @@
     mc:Ignorable="d">
 
     <Page.Resources>
-        <MenuFlyout x:Key="AddToPlayQueueFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
+        <MenuFlyout x:Key="AddToPlayQueueFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
             <MenuFlyoutItem
                 AccessKey="{strings:KeyboardResources Key=MenuItemFileKey}"
                 Command="{x:Bind PlayQueue.ViewModel.AddFilesCommand}"

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -94,11 +94,11 @@ public sealed partial class PlayerPage : Page
             case VirtualKey.GamepadY when ViewModel.ViewMode != WindowViewMode.Compact:
                 ViewModel.ControlsHidden = false;
                 PlayQueueFlyout.ShowAt(PlayQueueButton,
-                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.BottomEdgeAlignedLeft) });
+                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorWhenRightToLeft(FlyoutPlacementMode.BottomEdgeAlignedLeft) });
                 break;
             case VirtualKey.GamepadMenu:
                 VideoView.ContextFlyout.ShowAt(PlayerControls,
-                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
+                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
                 break;
             case VirtualKey.GamepadB when shouldHideControls:
                 ViewModel.TryHideControls(true);

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -94,11 +94,11 @@ public sealed partial class PlayerPage : Page
             case VirtualKey.GamepadY when ViewModel.ViewMode != WindowViewMode.Compact:
                 ViewModel.ControlsHidden = false;
                 PlayQueueFlyout.ShowAt(PlayQueueButton,
-                    new FlyoutShowOptions { Placement = GlobalizationHelper.IsRightToLeftLanguage ? FlyoutPlacementMode.BottomEdgeAlignedRight : FlyoutPlacementMode.BottomEdgeAlignedLeft });
+                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.BottomEdgeAlignedLeft) });
                 break;
             case VirtualKey.GamepadMenu:
                 VideoView.ContextFlyout.ShowAt(PlayerControls,
-                    new FlyoutShowOptions { Placement = GlobalizationHelper.IsRightToLeftLanguage ? FlyoutPlacementMode.TopEdgeAlignedLeft : FlyoutPlacementMode.TopEdgeAlignedRight });
+                    new FlyoutShowOptions { Placement = GlobalizationHelper.MirrorFlyoutPlacementWhenRightToLeft(FlyoutPlacementMode.TopEdgeAlignedRight) });
                 break;
             case VirtualKey.GamepadB when shouldHideControls:
                 ViewModel.TryHideControls(true);

--- a/Screenbox/Pages/PlaylistsPage.xaml
+++ b/Screenbox/Pages/PlaylistsPage.xaml
@@ -13,6 +13,7 @@
     xmlns:local="using:Screenbox.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:primitives="using:Windows.UI.Xaml.Controls.Primitives"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
@@ -60,7 +61,7 @@
                     Text="{strings:Resources Key=Delete}" />
             </MenuFlyout>
 
-            <MenuFlyout x:Key="CreatePlaylistFlyout" Placement="BottomEdgeAlignedRight">
+            <MenuFlyout x:Key="CreatePlaylistFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
                 <MenuFlyoutItem Command="{x:Bind ViewModel.ImportPlaylistCommand}" Text="{x:Bind strings:Resources.ImportPlaylist}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE8B5;" MirroredWhenRightToLeft="True" />

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -277,6 +278,17 @@
                     <VisualState.Setters>
                         <Setter Target="GroupOverview.HorizontalAlignment" Value="Stretch" />
                         <Setter Target="GroupOverview.VerticalAlignment" Value="Stretch" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+
+            <VisualStateGroup x:Name="FlowDirectionStates">
+                <VisualState x:Name="RightToLeft">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{x:Bind helpers:GlobalizationHelper.IsRightToLeftLanguage}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="SortByFlyout.Placement" Value="BottomEdgeAlignedLeft" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>


### PR DESCRIPTION
Adds `MirrorWhenRightToLeft` helper to mirror flyout placements for right-to-left languages.

| Before | After |
| ------ | ----- |
|<img width="900" height="480" alt="Compact split button flyout opened on the wrong relative position" src="https://github.com/user-attachments/assets/ef2aaa93-f39a-42a4-ba87-3d32221cf268" />|<img width="900" height="480" alt="Compact split button flyout opened on the correct relative position" src="https://github.com/user-attachments/assets/212e85cc-646b-47fe-bfe3-772e208738ca" />|
|<img width="600" height="480" alt="Split button flyout opened on the wrong relative position" src="https://github.com/user-attachments/assets/af790684-c7b1-4005-ab97-c31252d97ef1" />|<img width="600" height="480" alt="Split button flyout opened on the correct relative position" src="https://github.com/user-attachments/assets/1bce1574-e044-4a67-a947-de7e73f8bf18" />|