### PR TITLE
ci: add Crowdin action for translation syncing

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,0 +1,39 @@
+name: Crowdin Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Crowdin Sync
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin
+          crowdin_branch_name: main
+          create_pull_request: true
+          pull_request_title: 'l10n: New Crowdin updates'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_labels: 'crowdin, l10n'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: "608787"
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,13 @@
-pull_request_title: 'l10n: Crowdin updates'
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
+pull_request_title: 'l10n: New Crowdin updates'
 pull_request_labels:
   - crowdin
   - l10n
+commit_message: "l10n: New translations %original_file_name% (%language%)"
+append_commit_message: false
+preserve_hierarchy: true
 files:
   - source: /Screenbox/Strings/en-US/*.resw
     ignore:


### PR DESCRIPTION
Move away from the native Crowdin GitHub integration to GitHub Actions.