### PR TITLE
refactor: move service events to WindowContext and ViewModels

### DIFF
--- a/Screenbox.Core/Common/ServiceHelpers.cs
+++ b/Screenbox.Core/Common/ServiceHelpers.cs
@@ -57,6 +57,7 @@ public static class ServiceHelpers
         services.AddSingleton<CastContext>();
         services.AddSingleton<LibraryContext>();
         services.AddSingleton<PlayQueueContext>();
+        services.AddSingleton<WindowContext>();
 
         // Coordinators
         services.AddSingleton<ILibraryCoordinator, LibraryCoordinator>();

--- a/Screenbox.Core/Contexts/WindowContext.cs
+++ b/Screenbox.Core/Contexts/WindowContext.cs
@@ -1,0 +1,22 @@
+﻿#nullable enable
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Screenbox.Core.Enums;
+
+namespace Screenbox.Core.Contexts;
+
+/// <summary>
+/// Holds the observable state of the application window, such as the current view mode.
+/// Written by <see cref="Services.IWindowService"/> and observed by view models via the messenger.
+/// </summary>
+public sealed partial class WindowContext : ObservableRecipient
+{
+    /// <summary>
+    /// Gets or sets the current window view mode (e.g., Default, FullScreen, Compact).
+    /// Broadcasts a <see cref="CommunityToolkit.Mvvm.Messaging.Messages.PropertyChangedMessage{T}"/> via the
+    /// messenger when changed, so view models can react without subscribing to a service event.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedRecipients]
+    private WindowViewMode _viewMode;
+}

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Contexts\LibraryContext.cs" />
     <Compile Include="Contexts\PlaylistsContext.cs" />
     <Compile Include="Contexts\PlayQueueContext.cs" />
+    <Compile Include="Contexts\WindowContext.cs" />
     <Compile Include="Enums\MediaPlaybackType.cs" />
     <Compile Include="Enums\NotificationLevel.cs" />
     <Compile Include="Enums\PlaybackActionKind.cs" />

--- a/Screenbox.Core/Services/IWindowService.cs
+++ b/Screenbox.Core/Services/IWindowService.cs
@@ -1,8 +1,6 @@
 ﻿#nullable enable
 
 using Screenbox.Core.Enums;
-using Screenbox.Core.Events;
-using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
@@ -10,7 +8,6 @@ namespace Screenbox.Core.Services
 {
     public interface IWindowService
     {
-        public event EventHandler<ViewModeChangedEventArgs>? ViewModeChanged;
         public WindowViewMode ViewMode { get; }
         public bool TryEnterFullScreen();
         public void ExitFullScreen();

--- a/Screenbox.Core/Services/WindowService.cs
+++ b/Screenbox.Core/Services/WindowService.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
+using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
-using Screenbox.Core.Events;
 using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -15,35 +15,22 @@ namespace Screenbox.Core.Services
 {
     public sealed class WindowService : IWindowService
     {
-        public event EventHandler<ViewModeChangedEventArgs>? ViewModeChanged;
+        public WindowViewMode ViewMode => _windowContext.ViewMode;
 
-        public WindowViewMode ViewMode
-        {
-            get => _viewMode;
-            private set
-            {
-                WindowViewMode oldValue = _viewMode;
-                if (oldValue != value)
-                {
-                    _viewMode = value;
-                    ViewModeChanged?.Invoke(this, new ViewModeChangedEventArgs(value, oldValue));
-                }
-            }
-        }
-
+        private readonly WindowContext _windowContext;
         private CoreCursor? _cursor;
-        private WindowViewMode _viewMode;
 
-        public WindowService()
+        public WindowService(WindowContext windowContext)
         {
+            _windowContext = windowContext;
             Window.Current.SizeChanged += OnWindowSizeChanged;
         }
 
         private void OnWindowSizeChanged(object sender, WindowSizeChangedEventArgs e)
         {
             ApplicationView view = ApplicationView.GetForCurrentView();
-            if (ViewMode == WindowViewMode.FullScreen && !view.IsFullScreenMode)
-                ViewMode = WindowViewMode.Default;
+            if (_windowContext.ViewMode == WindowViewMode.FullScreen && !view.IsFullScreenMode)
+                _windowContext.ViewMode = WindowViewMode.Default;
         }
 
         public bool TryEnterFullScreen()
@@ -51,7 +38,7 @@ namespace Screenbox.Core.Services
             ApplicationView? view = ApplicationView.GetForCurrentView();
             if (view.TryEnterFullScreenMode())
             {
-                ViewMode = WindowViewMode.FullScreen;
+                _windowContext.ViewMode = WindowViewMode.FullScreen;
                 return true;
             }
 
@@ -62,8 +49,8 @@ namespace Screenbox.Core.Services
         {
             ApplicationView? view = ApplicationView.GetForCurrentView();
             view?.ExitFullScreenMode();
-            if (ViewMode == WindowViewMode.FullScreen)
-                ViewMode = WindowViewMode.Default;
+            if (_windowContext.ViewMode == WindowViewMode.FullScreen)
+                _windowContext.ViewMode = WindowViewMode.Default;
         }
 
         public async Task<bool> TryExitCompactLayoutAsync()
@@ -71,8 +58,8 @@ namespace Screenbox.Core.Services
             ApplicationView? view = ApplicationView.GetForCurrentView();
             if (await view.TryEnterViewModeAsync(ApplicationViewMode.Default))
             {
-                if (ViewMode == WindowViewMode.Compact)
-                    ViewMode = WindowViewMode.Default;
+                if (_windowContext.ViewMode == WindowViewMode.Compact)
+                    _windowContext.ViewMode = WindowViewMode.Default;
                 return true;
             }
 
@@ -91,7 +78,7 @@ namespace Screenbox.Core.Services
 
             if (await view.TryEnterViewModeAsync(ApplicationViewMode.CompactOverlay, preferences))
             {
-                ViewMode = WindowViewMode.Compact;
+                _windowContext.ViewMode = WindowViewMode.Compact;
                 return true;
             }
 
@@ -168,3 +155,4 @@ namespace Screenbox.Core.Services
         }
     }
 }
+

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -11,7 +11,6 @@ using CommunityToolkit.Mvvm.Messaging.Messages;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Coordinators;
 using Screenbox.Core.Enums;
-using Screenbox.Core.Events;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Playback;
@@ -28,7 +27,8 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     IRecipient<SettingsChangedMessage>,
     IRecipient<TogglePlayPauseMessage>,
     IRecipient<ChangePlaybackRateRequestMessage>,
-    IRecipient<PropertyChangedMessage<PlayerVisibilityState>>
+    IRecipient<PropertyChangedMessage<PlayerVisibilityState>>,
+    IRecipient<PropertyChangedMessage<WindowViewMode>>
 {
     /// <summary>
     /// The observable play queue state. Bind to this for <c>Items</c>,
@@ -82,7 +82,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         _settingsService = settingsService;
         _playerContext = playerContext;
         _coordinator = coordinator;
-        _windowService.ViewModeChanged += WindowServiceOnViewModeChanged;
         _playbackRate = 1.0;
         _audioTimingOffset = 0.0;
         _subtitleTimingOffset = 0.0;
@@ -309,9 +308,10 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         _dispatcherQueue.TryEnqueue(() => ChapterName = sender.Chapter?.Title);
     }
 
-    private void WindowServiceOnViewModeChanged(object sender, ViewModeChangedEventArgs e)
+    public void Receive(PropertyChangedMessage<WindowViewMode> message)
     {
-        switch (e.NewValue)
+        if (message.Sender is not WindowContext) return;
+        switch (message.NewValue)
         {
             case WindowViewMode.Default:
                 IsFullscreen = false;

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -94,7 +94,6 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     private readonly PlayerContext _playerContext;
     private bool _visibilityOverride;
     private bool _resizeNext;
-    private DateTimeOffset _lastUpdated;
     private bool _isSpaceKeyHolding;
     private double? _playbackRateBeforeHold;
 
@@ -114,22 +113,10 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
         _spaceKeyHoldTimer = _dispatcherQueue.CreateTimer();
         _navigationViewDisplayMode = Messenger.Send<NavigationViewDisplayModeRequestMessage>();
         _playerVisibility = PlayerVisibilityState.Hidden;
-        _lastUpdated = DateTimeOffset.MinValue;
 
+        // Strong reference handlers. No need to unsubscribe since PlayerPageViewModel has the same lifetime as the app.
         FocusManager.GotFocus += FocusManagerOnFocusChanged;
-
-        // Subscribe here so navigation-triggered player dismissal is handled in the ViewModel
-        // rather than in page code-behind, keeping UI logic out of the view layer.
-        // Use a weak-reference forwarding handler so the navigation service does not retain
-        // this transient view model via a strong event subscription.
-        WeakReference<PlayerPageViewModel> weakThis = new(this);
-        navigationService.Navigated += (sender, args) =>
-        {
-            if (weakThis.TryGetTarget(out PlayerPageViewModel? viewModel))
-            {
-                viewModel.OnNavigationServiceNavigated(sender, args);
-            }
-        };
+        navigationService.Navigated += OnNavigationServiceNavigated;
 
         if (MediaPlayer != null)
         {

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -11,7 +11,6 @@ using CommunityToolkit.Mvvm.Messaging.Messages;
 using CommunityToolkit.WinUI;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
-using Screenbox.Core.Events;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Models;
@@ -40,7 +39,8 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     IRecipient<OverrideControlsHideDelayMessage>,
     IRecipient<DragDropMessage>,
     IRecipient<VisualizerChangedMessage>,
-    IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>
+    IRecipient<PropertyChangedMessage<NavigationViewDisplayMode>>,
+    IRecipient<PropertyChangedMessage<WindowViewMode>>
 {
     private const VirtualKey VK_OEM_PLUS = (VirtualKey)0xBB;
     private const VirtualKey VK_OEM_COMMA = (VirtualKey)0xBC;
@@ -58,6 +58,12 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     [ObservableProperty] private NavigationViewDisplayMode _navigationViewDisplayMode;
     [ObservableProperty] private MediaViewModel? _media;
     [ObservableProperty] private bool _showVisualizer;
+
+    /// <summary>
+    /// Set to <see langword="true"/> by the view model to signal the view to close the play queue flyout.
+    /// The view should reset this to <see langword="false"/> after closing the flyout.
+    /// </summary>
+    [ObservableProperty] private bool _shouldClosePlayQueueFlyout;
 
     [ObservableProperty]
     [NotifyPropertyChangedRecipients]
@@ -93,7 +99,8 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
     private double? _playbackRateBeforeHold;
 
     public PlayerPageViewModel(IWindowService windowService,
-        ISettingsService settingsService, IFilesService filesService, PlayerContext playerContext)
+        ISettingsService settingsService, IFilesService filesService, PlayerContext playerContext,
+        INavigationService navigationService)
     {
         _windowService = windowService;
         _settingsService = settingsService;
@@ -110,7 +117,10 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
         _lastUpdated = DateTimeOffset.MinValue;
 
         FocusManager.GotFocus += FocusManagerOnFocusChanged;
-        _windowService.ViewModeChanged += WindowServiceOnViewModeChanged;
+
+        // Subscribe here so navigation-triggered player dismissal is handled in the ViewModel
+        // rather than in page code-behind, keeping UI logic out of the view layer.
+        navigationService.Navigated += OnNavigationServiceNavigated;
 
         if (MediaPlayer != null)
         {
@@ -151,12 +161,17 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
         NavigationViewDisplayMode = message.NewValue;
     }
 
-    private void WindowServiceOnViewModeChanged(object sender, ViewModeChangedEventArgs e)
+    public void Receive(PropertyChangedMessage<WindowViewMode> message)
     {
-        _dispatcherQueue.TryEnqueue(() =>
-        {
-            ViewMode = e.NewValue;
-        });
+        if (message.Sender is not WindowContext) return;
+        _dispatcherQueue.TryEnqueue(() => ViewMode = message.NewValue);
+    }
+
+    private void OnNavigationServiceNavigated(object sender, EventArgs e)
+    {
+        if (PlayerVisibility != PlayerVisibilityState.Visible) return;
+        GoBack();
+        ShouldClosePlayQueueFlyout = true;
     }
 
     public void Receive(PropertyChangedMessage<IMediaPlayer?> message)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -120,7 +120,16 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
 
         // Subscribe here so navigation-triggered player dismissal is handled in the ViewModel
         // rather than in page code-behind, keeping UI logic out of the view layer.
-        navigationService.Navigated += OnNavigationServiceNavigated;
+        // Use a weak-reference forwarding handler so the navigation service does not retain
+        // this transient view model via a strong event subscription.
+        WeakReference<PlayerPageViewModel> weakThis = new(this);
+        navigationService.Navigated += (sender, args) =>
+        {
+            if (weakThis.TryGetTarget(out PlayerPageViewModel? viewModel))
+            {
+                viewModel.OnNavigationServiceNavigated(sender, args);
+            }
+        };
 
         if (MediaPlayer != null)
         {

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -267,7 +267,11 @@ public sealed partial class PlayerPage : Page
                 UpdateContentState();
                 break;
             case nameof(PlayerPageViewModel.ShouldClosePlayQueueFlyout) when ViewModel.ShouldClosePlayQueueFlyout:
-                PlayQueueFlyout.Hide();
+                if (PlayQueueFlyout.IsOpen)
+                {
+                    PlayQueueFlyout.Hide();
+                }
+
                 ViewModel.ShouldClosePlayQueueFlyout = false;
                 break;
         }

--- a/Screenbox/Pages/PlayerPage.xaml.cs
+++ b/Screenbox/Pages/PlayerPage.xaml.cs
@@ -8,7 +8,6 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using Screenbox.Controls;
 using Screenbox.Core.Enums;
-using Screenbox.Core.Services;
 using Screenbox.Core.ViewModels;
 using Screenbox.Helpers;
 using Windows.ApplicationModel.DataTransfer;
@@ -50,16 +49,6 @@ public sealed partial class PlayerPage : Page
         ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
         AlbumArtImage.RegisterPropertyChangedCallback(ImageBrush.ImageSourceProperty, AlbumArtImageOnSourceChanged);
         LayoutRoot.ActualThemeChanged += OnActualThemeChanged;
-
-        INavigationService navigationService = Ioc.Default.GetRequiredService<INavigationService>();   // For navigation events
-        navigationService.Navigated += NavigationServiceOnNavigated;
-    }
-    private void NavigationServiceOnNavigated(object sender, EventArgs e)
-    {
-        if (ViewModel.PlayerVisibility != PlayerVisibilityState.Visible) return;
-        ViewModel.GoBack();
-        if (PlayQueueFlyout.IsOpen)
-            PlayQueueFlyout.Hide();
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -276,6 +265,10 @@ public sealed partial class PlayerPage : Page
                 }
 
                 UpdateContentState();
+                break;
+            case nameof(PlayerPageViewModel.ShouldClosePlayQueueFlyout) when ViewModel.ShouldClosePlayQueueFlyout:
+                PlayQueueFlyout.Hide();
+                ViewModel.ShouldClosePlayQueueFlyout = false;
                 break;
         }
     }


### PR DESCRIPTION
## Summary

Singleton services should not own events — subscribers on transient ViewModels that register against a singleton service risk leaked subscriptions and complicated object lifetimes. This PR removes the two problematic service events and routes their communication through the established Contexts + MVVM Toolkit messenger pattern.

## Changes

### IWindowService.ViewModeChanged → WindowContext

- **New Screenbox.Core/Contexts/WindowContext.cs**: an ObservableRecipient holding ViewMode as an `[ObservableProperty][NotifyPropertyChangedRecipients]` property. When `WindowService` writes to it, the MVVM Toolkit messenger automatically broadcasts `PropertyChangedMessage<WindowViewMode>` — no explicit event wiring needed.
- **`WindowService`**: injects `WindowContext` as a dependency; all view-mode assignments write to the context. The `ViewModeChanged` event and private state field are removed.
- **`PlayerPageViewModel` and `PlayerControlsViewModel`**: implement `IRecipient<PropertyChangedMessage<WindowViewMode>>` and handle the message via the `Receive` method, guarded with `message.Sender is WindowContext`. The old `ViewModeChanged` event subscriptions are removed.
- **`ServiceHelpers`**: `WindowContext` registered as a singleton.
- **`Screenbox.Core.csproj`**: `WindowContext.cs` added to the explicit compile list (required for UWP-style projects).

### `INavigationService.Navigated` subscription moved out of code-behind

- **`PlayerPage.xaml.cs`**: removed the `INavigationService` IoC resolution and `Navigated` event subscription. Services are now consumed only through the ViewModel.
- **`PlayerPageViewModel`**: subscribes to `INavigationService.Navigated` (injected via constructor) and handles the event — calling `GoBack()` and setting `ShouldClosePlayQueueFlyout = true` when the user navigates while the player is visible.
- **New `ShouldClosePlayQueueFlyout` observable property**: acts as a one-shot trigger. The code-behind reacts in its existing `ViewModelOnPropertyChanged` switch, calls `PlayQueueFlyout.Hide()`, and immediately resets the flag to `alse`. This keeps the view's responsibility (hiding the flyout, which is not bindable in UWP) in the code-behind without coupling it to services or messaging.

## Motivation

- Removes subscription leak risk on transient ViewModels against singleton services.
- Keeps services stateless/event-free, consistent with all other services in the project.
- Follows the established Contexts pattern (alongside `CastContext`, `MediaPlayerContext`, etc.) for observable shared state.
- Keeps code-behind free of service dependencies — all service interaction flows through the ViewModel.