### PR TITLE
chore: remove UTF-8 with BOM, use UTF-8 encoding instead

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+charset = utf-8
 
 # Solution files
 [*.sln]
@@ -34,7 +35,6 @@ indent_size = 2
 
 # XML user interface files
 [*.xaml]
-charset = utf-8-bom
 indent_size = 4
 
 # Data serialization files
@@ -53,9 +53,6 @@ indent_size = 2
 [*.cs]
 
 #### Core EditorConfig Options ####
-
-# Encoding
-charset = utf-8-bom
 
 # Indentation and spacing
 indent_size = 4

--- a/Screenbox/Strings/en-US/KeyboardResources.resw
+++ b/Screenbox/Strings/en-US/KeyboardResources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/Screenbox/Strings/en-US/ManifestResources.resw
+++ b/Screenbox/Strings/en-US/ManifestResources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 


### PR DESCRIPTION
UTF-8 with BOM encoding breaks Crowdin syncing. It's better to follow the cross-platform standard and use UTF-8 instead of going the Windows-only route.