### PR TITLE
chore: replace strings:Resources markups with x:Bind where possible

### DIFF
--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -67,11 +67,11 @@
                         TrueValue="True" />
                     <ctConverters:BoolToObjectConverter
                         x:Key="BoolToPlayPauseTextConverter"
-                        FalseValue="{strings:Resources Key=Play}"
-                        TrueValue="{strings:Resources Key=Pause}" />
-                    <converters:DefaultStringConverter x:Key="GenreTextConverter" Default="{strings:Resources Key=UnknownGenre}" />
-                    <converters:DefaultStringConverter x:Key="ArtistTextConverter" Default="{strings:Resources Key=UnknownArtist}" />
-                    <converters:DefaultStringConverter x:Key="AlbumTextConverter" Default="{strings:Resources Key=UnknownAlbum}" />
+                        FalseValue="{x:Bind strings:Resources.Play}"
+                        TrueValue="{x:Bind strings:Resources.Pause}" />
+                    <converters:DefaultStringConverter x:Key="GenreTextConverter" Default="{x:Bind strings:Resources.UnknownGenre}" />
+                    <converters:DefaultStringConverter x:Key="ArtistTextConverter" Default="{x:Bind strings:Resources.UnknownArtist}" />
+                    <converters:DefaultStringConverter x:Key="AlbumTextConverter" Default="{x:Bind strings:Resources.UnknownAlbum}" />
 
                     <!--  Font sizes  -->
                     <x:Double x:Key="TopNavigationViewItemFontSize">18</x:Double>

--- a/Screenbox/Controls/CompositeTrackPicker.xaml
+++ b/Screenbox/Controls/CompositeTrackPicker.xaml
@@ -67,7 +67,7 @@
                         VerticalAlignment="Center"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{strings:Resources Key=Audio}"
+                        Text="{x:Bind strings:Resources.Audio}"
                         TextWrapping="NoWrap" />
                     <HyperlinkButton
                         Grid.Column="1"
@@ -76,7 +76,7 @@
                         Command="{x:Bind ShowAudioOptionsCommand}">
                         <TextBlock
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{strings:Resources Key=Options}"
+                            Text="{x:Bind strings:Resources.Options}"
                             TextWrapping="NoWrap" />
                     </HyperlinkButton>
                 </Grid>
@@ -123,7 +123,7 @@
                         VerticalAlignment="Center"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{strings:Resources Key=Subtitles}"
+                        Text="{x:Bind strings:Resources.Subtitles}"
                         TextWrapping="NoWrap" />
                     <HyperlinkButton
                         Grid.Column="1"
@@ -132,7 +132,7 @@
                         Command="{x:Bind ShowSubtitleOptionsCommand}">
                         <TextBlock
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{strings:Resources Key=Options}"
+                            Text="{x:Bind strings:Resources.Options}"
                             TextWrapping="NoWrap" />
                     </HyperlinkButton>
                 </Grid>
@@ -146,7 +146,7 @@
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Left"
                     Command="{x:Bind ViewModel.AddSubtitleCommand}"
-                    Content="{strings:Resources Key=AddSubtitle}"
+                    Content="{x:Bind strings:Resources.AddSubtitle}"
                     Style="{StaticResource SubtleButtonStyle}">
                     <Button.Resources>
                         <ResourceDictionary>
@@ -166,7 +166,7 @@
                 </Button>
             </ListView.Footer>
             <d:ListView.Items>
-                <ListViewItem Content="{strings:Resources Key=Disable}" />
+                <ListViewItem Content="{x:Bind strings:Resources.Disable}" />
                 <ListViewItem Content="English" IsSelected="True" />
                 <ListViewItem Content="French (Français)" />
                 <ListViewItem Content="Spanish (Latin America) (Castellano)" />

--- a/Screenbox/Controls/LivelyWallpaperSelector.xaml
+++ b/Screenbox/Controls/LivelyWallpaperSelector.xaml
@@ -40,14 +40,14 @@
                 Padding="16,0,4,0"
                 VerticalAlignment="Center"
                 Style="{StaticResource BodyTextBlockStyle}"
-                Text="{strings:Resources Key=Visuals}" />
+                Text="{x:Bind strings:Resources.Visuals}" />
             <!--  Let user select new wallpaper to install  -->
             <Button
                 Grid.Column="1"
                 Margin="0,0,16,0"
                 Padding="8,2,8,3"
                 Command="{x:Bind ViewModel.BrowseVisualizerCommand}"
-                Content="{strings:Resources Key=BrowseFiles}"
+                Content="{x:Bind strings:Resources.BrowseFiles}"
                 FontSize="{StaticResource CaptionTextBlockFontSize}" />
         </Grid>
 
@@ -85,7 +85,7 @@
                             BorderBrush="{ThemeResource ControlStrokeColorForStrongFillWhenOnImageBrush}"
                             BorderThickness="1"
                             CornerRadius="4"
-                            ToolTipService.ToolTip="{strings:Resources Key=PoweredByLivelyWallpaper}"
+                            ToolTipService.ToolTip="{x:Bind strings:Resources.PoweredByLivelyWallpaper}"
                             Visibility="{x:Bind Path, Converter={StaticResource StringVisibilityConverter}}">
                             <Image
                                 Width="16"

--- a/Screenbox/Controls/MediaListViewItem.xaml
+++ b/Screenbox/Controls/MediaListViewItem.xaml
@@ -44,7 +44,7 @@
             AutoPlay="False"
             IsHitTestVisible="False"
             Source="{StaticResource AnimatedPlayingVisualSource}"
-            ToolTipService.ToolTip="{strings:Resources Key=IsPlaying}"
+            ToolTipService.ToolTip="{x:Bind strings:Resources.IsPlaying}"
             Visibility="Collapsed" />
 
         <TextBlock
@@ -108,7 +108,7 @@
             <TextBlock
                 x:Name="ArtistText"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding MainArtist.Name, Converter={StaticResource ArtistTextConverter}, FallbackValue={strings:Resources Key=UnknownArtist}}"
+                Text="{Binding MainArtist.Name, Converter={StaticResource ArtistTextConverter}, FallbackValue={x:Bind strings:Resources.UnknownArtist}}"
                 TextWrapping="NoWrap">
                 <interactivity:Interaction.Behaviors>
                     <behaviors:OverflowTextToolTipBehavior />
@@ -129,7 +129,7 @@
             <TextBlock
                 x:Name="AlbumText"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{Binding Album.Name, Converter={StaticResource AlbumTextConverter}, FallbackValue={strings:Resources Key=UnknownAlbum}}"
+                Text="{Binding Album.Name, Converter={StaticResource AlbumTextConverter}, FallbackValue={x:Bind strings:Resources.UnknownAlbum}}"
                 TextWrapping="NoWrap">
                 <interactivity:Interaction.Behaviors>
                     <behaviors:OverflowTextToolTipBehavior />
@@ -144,7 +144,7 @@
             VerticalAlignment="Center"
             Opacity="{ThemeResource TextFillColorTertiaryOpacity}"
             Style="{StaticResource CaptionTextBlockStyle}"
-            Text="{Binding MediaInfo.MusicProperties.Genre, Converter={StaticResource GenreTextConverter}, FallbackValue={strings:Resources Key=UnknownGenre}}"
+            Text="{Binding MediaInfo.MusicProperties.Genre, Converter={StaticResource GenreTextConverter}, FallbackValue={x:Bind strings:Resources.UnknownGenre}}"
             TextWrapping="NoWrap"
             Visibility="Collapsed">
             <interactivity:Interaction.Behaviors>

--- a/Screenbox/Controls/PlayQueueControl.xaml
+++ b/Screenbox/Controls/PlayQueueControl.xaml
@@ -37,18 +37,18 @@
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                            Glyph={StaticResource PlayGlyph}}"
-                        Text="{strings:Resources Key=Play}" />
+                        Text="{x:Bind strings:Resources.Play}" />
                     <MenuFlyoutItem
                         Command="{x:Bind ViewModel.PlayNextCommand}"
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                            Glyph={StaticResource PlayAddGlyph}}"
-                        Text="{strings:Resources Key=PlayNext}" />
+                        Text="{x:Bind strings:Resources.PlayNext}" />
                     <MenuFlyoutSeparator />
                     <MenuFlyoutSubItem
                         x:Name="AddToPlaylistSubMenu"
                         Icon="{ui:SymbolIcon Symbol=Add}"
-                        Text="{strings:Resources Key=AddToPlaylist}" />
+                        Text="{x:Bind strings:Resources.AddToPlaylist}" />
                     <MenuFlyoutItem
                         Command="{StaticResource OpenWithCommand}"
                         CommandParameter="{Binding}"
@@ -58,39 +58,39 @@
                         Command="{x:Bind ViewModel.RemoveCommand}"
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon Glyph=&#xE894;}"
-                        Text="{strings:Resources Key=Remove}" />
+                        Text="{x:Bind strings:Resources.Remove}" />
                     <MenuFlyoutItem
                         Command="{x:Bind ViewModel.MoveItemUpCommand}"
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon Glyph=&#xE74A;}"
-                        Text="{strings:Resources Key=MoveUp}" />
+                        Text="{x:Bind strings:Resources.MoveUp}" />
                     <MenuFlyoutItem
                         Command="{x:Bind ViewModel.MoveItemDownCommand}"
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon Glyph=&#xE74B;}"
-                        Text="{strings:Resources Key=MoveDown}" />
+                        Text="{x:Bind strings:Resources.MoveDown}" />
                     <MenuFlyoutItem
                         Command="{StaticResource ShowPropertiesCommand}"
                         CommandParameter="{Binding}"
                         Icon="{ui:FontIcon Glyph=&#xE946;}"
-                        Text="{strings:Resources Key=Properties}" />
+                        Text="{x:Bind strings:Resources.Properties}" />
                     <MenuFlyoutItem
                         Command="{x:Bind Common.OpenAlbumCommand}"
                         CommandParameter="{Binding Album}"
                         Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                        Text="{strings:Resources Key=ShowAlbum}"
+                        Text="{x:Bind strings:Resources.ShowAlbum}"
                         Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                     <MenuFlyoutItem
                         Command="{x:Bind Common.OpenArtistCommand}"
                         CommandParameter="{Binding MainArtist}"
                         Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                        Text="{strings:Resources Key=ShowArtist}"
+                        Text="{x:Bind strings:Resources.ShowArtist}"
                         Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                     <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                     <MenuFlyoutItem
                         CommandParameter="{Binding}"
                         Icon="{ui:SymbolIcon Symbol=Setting}"
-                        Text="{strings:Resources Key=SetPlaybackOptions}"
+                        Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                         Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                         <MenuFlyoutItem.Command>
                             <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.Playlist.PlaySingleCommand}" />
@@ -127,7 +127,7 @@
                 x:Name="AddFilesButton"
                 Margin="0,0,8,0"
                 AccessKey="{strings:KeyboardResources Key=CommandAddOpenFilesKey}"
-                AutomationProperties.Name="{strings:Resources Key=AddFiles}"
+                AutomationProperties.Name="{x:Bind strings:Resources.AddFiles}"
                 Command="{x:Bind ViewModel.AddFilesCommand}"
                 Visibility="Collapsed">
                 <StackPanel Orientation="Horizontal">
@@ -135,7 +135,7 @@
                         Margin="{StaticResource IconButtonStandardIconMargin}"
                         FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                         Glyph="{StaticResource FolderOpenGlyph}" />
-                    <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFiles}" />
+                    <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.AddFiles}" />
                 </StackPanel>
             </Button>
 
@@ -155,7 +155,7 @@
                     <TextBlock
                         x:Name="ClearButtonLabel"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=Clear}" />
+                        Text="{x:Bind strings:Resources.Clear}" />
                 </StackPanel>
             </Button>
 
@@ -177,7 +177,7 @@
                     <TextBlock
                         x:Name="AddToPlaylistButtonLabel"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=AddToPlaylist}" />
+                        Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 </StackPanel>
             </muxc:DropDownButton>
 
@@ -197,7 +197,7 @@
                     <TextBlock
                         x:Name="MultiSelectToggleLabel"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=Multiselect}" />
+                        Text="{x:Bind strings:Resources.Multiselect}" />
                 </StackPanel>
             </ToggleButton>
         </StackPanel>
@@ -239,11 +239,11 @@
                     CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Label="{strings:Resources Key=PlayNext}" />
+                    Label="{x:Bind strings:Resources.PlayNext}" />
                 <AppBarButton
                     x:Name="AddToPlaylistSelectionButton"
                     Icon="Add"
-                    Label="{strings:Resources Key=AddToPlaylist}">
+                    Label="{x:Bind strings:Resources.AddToPlaylist}">
                     <AppBarButton.Resources>
                         <Visibility x:Key="AppBarButtonHasFlyoutChevronVisibility">Visible</Visibility>
                         <x:String x:Key="AppBarButtonFlyoutGlyph">&#xE972;</x:String>
@@ -264,7 +264,7 @@
                     Command="{x:Bind ViewModel.RemoveSelectedCommand}"
                     CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
                     Icon="{ui:FontIcon Glyph=&#xE894;}"
-                    Label="{strings:Resources Key=Remove}">
+                    Label="{x:Bind strings:Resources.Remove}">
                     <AppBarButton.KeyboardAccelerators>
                         <KeyboardAccelerator Key="Delete" />
                     </AppBarButton.KeyboardAccelerators>
@@ -274,13 +274,13 @@
                     Command="{x:Bind ViewModel.MoveSelectedItemUpCommand}"
                     CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
                     Icon="{ui:FontIcon Glyph=&#xE74A;}"
-                    Label="{strings:Resources Key=MoveUp}" />
+                    Label="{x:Bind strings:Resources.MoveUp}" />
                 <AppBarButton
                     x:Name="MoveDownButton"
                     Command="{x:Bind ViewModel.MoveSelectedItemDownCommand}"
                     CommandParameter="{x:Bind PlaylistListView.SelectedItems}"
                     Icon="{ui:FontIcon Glyph=&#xE74B;}"
-                    Label="{strings:Resources Key=MoveDown}" />
+                    Label="{x:Bind strings:Resources.MoveDown}" />
 
                 <CommandBar.Content>
                     <StackPanel Orientation="Horizontal">
@@ -302,10 +302,10 @@
                             Padding="4,5,4,5"
                             VerticalAlignment="Top"
                             extensions:AcceleratorService.ToolTip="{x:Bind strings:Resources.ClearSelection}"
-                            AutomationProperties.Name="{strings:Resources Key=ClearSelection}"
+                            AutomationProperties.Name="{x:Bind strings:Resources.ClearSelection}"
                             BorderThickness="0"
                             Command="{x:Bind ViewModel.Selection.ClearSelectionCommand}"
-                            Content="{strings:Resources Key=Clear}">
+                            Content="{x:Bind strings:Resources.Clear}">
                             <Button.Resources>
                                 <!--  Override default brushes to make the Button background transparent and the foreground to use the accent color  -->
                                 <ResourceDictionary>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -55,7 +55,7 @@
                     Spacing="8">
                     <Slider
                         x:Name="SpeedSlider"
-                        Header="{strings:Resources Key=CustomPlaybackSpeed}"
+                        Header="{x:Bind strings:Resources.CustomPlaybackSpeed}"
                         IsThumbToolTipEnabled="False"
                         Maximum="2"
                         Minimum="0"
@@ -72,7 +72,7 @@
                     <TextBox
                         x:Name="AspectRatioTextBox"
                         AutomationProperties.Name="Custom aspect ratio TextBox"
-                        Header="{strings:Resources Key=CustomAspectRatio}"
+                        Header="{x:Bind strings:Resources.CustomAspectRatio}"
                         PlaceholderText="16:9"
                         TextChanged="AspectRatioTextBox_OnTextChanged" />
                 </StackPanel>
@@ -86,7 +86,7 @@
                     Spacing="8">
                     <Slider
                         x:Name="SubtitleTimingOffsetSlider"
-                        Header="{strings:Resources Key=TimingOffset}"
+                        Header="{x:Bind strings:Resources.TimingOffset}"
                         IsThumbToolTipEnabled="False"
                         Maximum="3000"
                         Minimum="-3000"
@@ -105,7 +105,7 @@
                     Spacing="8">
                     <Slider
                         x:Name="AudioTimingOffsetSlider"
-                        Header="{strings:Resources Key=TimingOffset}"
+                        Header="{x:Bind strings:Resources.TimingOffset}"
                         IsThumbToolTipEnabled="False"
                         Maximum="3000"
                         Minimum="-3000"
@@ -123,7 +123,7 @@
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource FolderOpenGlyph}}"
                     KeyTipPlacementMode="Left"
-                    Text="{strings:Resources Key=OpenFiles}">
+                    Text="{x:Bind strings:Resources.OpenFiles}">
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="O" Modifiers="Control" />
                     </MenuFlyoutItem.KeyboardAccelerators>
@@ -223,7 +223,7 @@
                         x:Name="CustomPlaybackSpeedMenuItem"
                         Click="CustomSpeedMenuItem_OnClick"
                         GroupName="SpeedGroup"
-                        Text="{strings:Resources Key=Custom}" />
+                        Text="{x:Bind strings:Resources.Custom}" />
                 </MenuFlyoutSubItem>
                 <MenuFlyoutItem
                     AccessKey="{strings:KeyboardResources Key=MenuItemSaveSnapshotKey}"
@@ -253,19 +253,19 @@
                     AccessKey="{strings:KeyboardResources Key=MenuItemAspectRatioKey}"
                     Icon="{ui:FontIcon Glyph=&#xE799;}"
                     IsEnabled="{x:Bind ViewModel.HasVideo, Mode=OneWay}"
-                    Text="{strings:Resources Key=AspectRatio}">
+                    Text="{x:Bind strings:Resources.AspectRatio}">
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetAspectRatioCommand}"
                         CommandParameter="Fit"
                         GroupName="AspectRatioGroup"
                         IsChecked="True"
                         Tag="0:0"
-                        Text="{strings:Resources Key=Fit}" />
+                        Text="{x:Bind strings:Resources.Fit}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetAspectRatioCommand}"
                         CommandParameter="Fill"
                         GroupName="AspectRatioGroup"
-                        Text="{strings:Resources Key=Fill}" />
+                        Text="{x:Bind strings:Resources.Fill}" />
                     <MenuFlyoutSeparator />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetAspectRatioCommand}"
@@ -301,7 +301,7 @@
                         x:Name="CustomAspectRatioMenuItem"
                         Click="CustomAspectRatioMenuItem_OnClick"
                         GroupName="AspectRatioGroup"
-                        Text="{strings:Resources Key=Custom}" />
+                        Text="{x:Bind strings:Resources.Custom}" />
                 </MenuFlyoutSubItem>
                 <!--<MenuFlyoutSubItem
                     Icon="{ui:FontIcon Glyph=&#xE714;}"
@@ -314,7 +314,7 @@
                     CommandParameter="{x:Bind ViewModel.Playlist.CurrentItem, Mode=OneWay}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
                     IsEnabled="{x:Bind ViewModel.HasActiveItem, Mode=OneWay}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind ViewModel.IsAdvancedModeActive, Mode=OneWay}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.ResetMediaPlaybackCommand}" />
@@ -584,7 +584,7 @@
                 IsAccessKeyScope="True"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
-                ToolTipService.ToolTip="{strings:Resources Key=More}">
+                ToolTipService.ToolTip="{x:Bind strings:Resources.More}">
                 <FontIcon Glyph="&#xE712;" />
             </Button>
         </StackPanel>

--- a/Screenbox/Controls/PropertiesView.xaml
+++ b/Screenbox/Controls/PropertiesView.xaml
@@ -72,7 +72,7 @@
             <muxc:Expander
                 Margin="0,0,0,8"
                 HorizontalAlignment="Stretch"
-                Header="{strings:Resources Key=Media}"
+                Header="{x:Bind strings:Resources.Media}"
                 IsExpanded="True">
                 <muxc:ItemsRepeater
                     ItemTemplate="{StaticResource PropertyItemTemplate}"
@@ -83,7 +83,7 @@
             <muxc:Expander
                 Margin="0,8"
                 HorizontalAlignment="Stretch"
-                Header="{strings:Resources Key=Video}"
+                Header="{x:Bind strings:Resources.Video}"
                 IsExpanded="True"
                 Visibility="{x:Bind ViewModel.VideoProperties, Converter={StaticResource CollectionVisibilityConverter}}">
                 <muxc:ItemsRepeater
@@ -95,7 +95,7 @@
             <muxc:Expander
                 Margin="0,8"
                 HorizontalAlignment="Stretch"
-                Header="{strings:Resources Key=Music}"
+                Header="{x:Bind strings:Resources.Music}"
                 IsExpanded="True"
                 Visibility="{x:Bind ViewModel.AudioProperties, Converter={StaticResource CollectionVisibilityConverter}}">
                 <muxc:ItemsRepeater
@@ -107,7 +107,7 @@
             <muxc:Expander
                 Margin="0,8"
                 HorizontalAlignment="Stretch"
-                Header="{strings:Resources Key=File}"
+                Header="{x:Bind strings:Resources.File}"
                 IsExpanded="True">
                 <StackPanel Orientation="Vertical">
                     <muxc:ItemsRepeater

--- a/Screenbox/Controls/SeekBar.xaml
+++ b/Screenbox/Controls/SeekBar.xaml
@@ -42,7 +42,7 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             AccessKey="{strings:KeyboardResources Key=PlayerSeekBarKey}"
-            AutomationProperties.Name="{strings:Resources Key=Seek}"
+            AutomationProperties.Name="{x:Bind strings:Resources.Seek}"
             Background="{x:Bind Background, Mode=OneWay}"
             Foreground="{x:Bind Foreground, Mode=OneWay}"
             IsEnabled="{x:Bind ViewModel.IsSeekable, Mode=OneWay, FallbackValue=False}"

--- a/Screenbox/Controls/TimeDisplay.xaml
+++ b/Screenbox/Controls/TimeDisplay.xaml
@@ -19,14 +19,14 @@
                 d:Text="43:21"
                 Style="{x:Bind TextBlockStyle, Mode=OneWay}"
                 Text="{x:Bind Time, Mode=OneWay, Converter={StaticResource HumanizedDurationConverter}}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeElapsed}"
+                ToolTipService.ToolTip="{x:Bind strings:Resources.TimeElapsed}"
                 Typography.NumeralAlignment="Tabular" />
             <TextBlock
                 x:Name="RemainingText"
                 d:Text="-58:39"
                 Style="{x:Bind TextBlockStyle, Mode=OneWay}"
                 Text="{x:Bind GetRemainingTime(Time), Mode=OneWay}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeRemaining}"
+                ToolTipService.ToolTip="{x:Bind strings:Resources.TimeRemaining}"
                 Typography.NumeralAlignment="Tabular"
                 Visibility="Collapsed" />
             <TextBlock
@@ -37,7 +37,7 @@
                 d:Text="1:23:45"
                 Style="{x:Bind TextBlockStyle, Mode=OneWay}"
                 Text="{x:Bind Length, Mode=OneWay, Converter={StaticResource HumanizedDurationConverter}}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeLength}"
+                ToolTipService.ToolTip="{x:Bind strings:Resources.TimeLength}"
                 Typography.NumeralAlignment="Tabular" />
         </StackPanel>
 

--- a/Screenbox/Controls/VolumeControl.xaml
+++ b/Screenbox/Controls/VolumeControl.xaml
@@ -78,7 +78,7 @@
             VerticalAlignment="Center"
             d:Value="60"
             AccessKey="{strings:KeyboardResources Key=PlayerVolumeButtonSliderKey}"
-            AutomationProperties.Name="{strings:Resources Key=VolumeSliderTooltip}"
+            AutomationProperties.Name="{x:Bind strings:Resources.VolumeSliderTooltip}"
             IsThumbToolTipEnabled="{x:Bind ShowValueText, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             Maximum="{x:Bind ViewModel.MaxVolume, Mode=OneWay}"
             PointerWheelChanged="VolumeSlider_OnPointerWheelChanged"

--- a/Screenbox/Dialogs/CreatePlaylistDialog.xaml
+++ b/Screenbox/Dialogs/CreatePlaylistDialog.xaml
@@ -5,10 +5,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=CreateNewPlaylist}"
-    CloseButtonText="{strings:Resources Key=Cancel}"
+    Title="{x:Bind strings:Resources.CreateNewPlaylist}"
+    CloseButtonText="{x:Bind strings:Resources.Cancel}"
     DefaultButton="Primary"
-    PrimaryButtonText="{strings:Resources Key=Create}"
+    PrimaryButtonText="{x:Bind strings:Resources.Create}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 

--- a/Screenbox/Dialogs/DeletePlaylistDialog.xaml
+++ b/Screenbox/Dialogs/DeletePlaylistDialog.xaml
@@ -5,10 +5,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=DeletePlaylist}"
-    CloseButtonText="{strings:Resources Key=Cancel}"
+    Title="{x:Bind strings:Resources.DeletePlaylist}"
+    CloseButtonText="{x:Bind strings:Resources.Cancel}"
     PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
-    PrimaryButtonText="{strings:Resources Key=Delete}"
+    PrimaryButtonText="{x:Bind strings:Resources.Delete}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 

--- a/Screenbox/Dialogs/OpenUrlDialog.xaml
+++ b/Screenbox/Dialogs/OpenUrlDialog.xaml
@@ -5,15 +5,15 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=OpenUrl}"
-    CloseButtonText="{strings:Resources Key=Close}"
+    Title="{x:Bind strings:Resources.OpenUrl}"
+    CloseButtonText="{x:Bind strings:Resources.Close}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind CanOpen(UrlBox.Text), Mode=OneWay}"
-    PrimaryButtonText="{strings:Resources Key=Open}"
+    PrimaryButtonText="{x:Bind strings:Resources.Open}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
     <Grid>
-        <TextBox x:Name="UrlBox" PlaceholderText="{strings:Resources Key=OpenUrlPlaceholder}" />
+        <TextBox x:Name="UrlBox" PlaceholderText="{x:Bind strings:Resources.OpenUrlPlaceholder}" />
     </Grid>
 </ContentDialog>

--- a/Screenbox/Dialogs/PropertiesDialog.xaml
+++ b/Screenbox/Dialogs/PropertiesDialog.xaml
@@ -6,8 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=Properties}"
-    CloseButtonText="{strings:Resources Key=Close}"
+    Title="{x:Bind strings:Resources.Properties}"
+    CloseButtonText="{x:Bind strings:Resources.Close}"
     DefaultButton="Close"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">

--- a/Screenbox/Dialogs/RenamePlaylistDialog.xaml
+++ b/Screenbox/Dialogs/RenamePlaylistDialog.xaml
@@ -5,10 +5,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=RenamePlaylist}"
-    CloseButtonText="{strings:Resources Key=Cancel}"
+    Title="{x:Bind strings:Resources.RenamePlaylist}"
+    CloseButtonText="{x:Bind strings:Resources.Cancel}"
     DefaultButton="Primary"
-    PrimaryButtonText="{strings:Resources Key=Rename}"
+    PrimaryButtonText="{x:Bind strings:Resources.Rename}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 

--- a/Screenbox/Dialogs/SetOptionsDialog.xaml
+++ b/Screenbox/Dialogs/SetOptionsDialog.xaml
@@ -7,21 +7,21 @@
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
-    Title="{strings:Resources Key=SetPlaybackOptions}"
-    CloseButtonText="{strings:Resources Key=Close}"
+    Title="{x:Bind strings:Resources.SetPlaybackOptions}"
+    CloseButtonText="{x:Bind strings:Resources.Close}"
     DefaultButton="Primary"
-    PrimaryButtonText="{strings:Resources Key=Set}"
-    SecondaryButtonText="{strings:Resources Key=SetAndPlay}"
+    PrimaryButtonText="{x:Bind strings:Resources.Set}"
+    SecondaryButtonText="{x:Bind strings:Resources.SetAndPlay}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
 
     <StackPanel Orientation="Vertical" Spacing="12">
         <TextBlock x:Name="HelpText" TextWrapping="Wrap">
-            <Run Text="{strings:Resources Key=SetPlaybackOptionsHelpTextLine1}" /><LineBreak /><Run Text="{x:Bind VlcCommandLineHelpTextParts[0]}" />
+            <Run Text="{x:Bind strings:Resources.SetPlaybackOptionsHelpTextLine1}" /><LineBreak /><Run Text="{x:Bind VlcCommandLineHelpTextParts[0]}" />
             <Hyperlink NavigateUri="https://wiki.videolan.org/VLC_command-line_help/">
-                <Run Text="{strings:Resources Key=VlcCommandLineHelpLink}" />
+                <Run Text="{x:Bind strings:Resources.VlcCommandLineHelpLink}" />
             </Hyperlink>
-            <Run Text="{x:Bind VlcCommandLineHelpTextParts[1]}" /><LineBreak /><Run Text="{strings:Resources Key=SetPlaybackOptionsHelpTextLine2}" />
+            <Run Text="{x:Bind VlcCommandLineHelpTextParts[1]}" /><LineBreak /><Run Text="{x:Bind strings:Resources.SetPlaybackOptionsHelpTextLine2}" />
         </TextBlock>
         <TextBox
             x:Name="OptionsTextBox"

--- a/Screenbox/Pages/AlbumDetailsPage.xaml
+++ b/Screenbox/Pages/AlbumDetailsPage.xaml
@@ -32,24 +32,24 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
                     CommandParameter="{Binding}"
@@ -59,18 +59,18 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding MainArtist}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}"
+                    Text="{x:Bind strings:Resources.ShowArtist}"
                     Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -209,7 +209,7 @@
                                 CommandParameter="{x:Bind ViewModel.SortedItems, Mode=OneWay, Converter={StaticResource FirstOrDefaultConverter}}"
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource PlayGlyph}}"
-                                Label="{strings:Resources Key=Play}"
+                                Label="{x:Bind strings:Resources.Play}"
                                 Style="{StaticResource AccentButtonAppBarButtonStyle}">
                                 <interactivity:Interaction.Behaviors>
                                     <behaviors:AutoFocusBehavior />
@@ -222,7 +222,7 @@
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource ShuffleGlyph},
                                                    MirroredWhenRightToLeft=True}"
-                                Label="{strings:Resources Key=ShuffleAndPlay}"
+                                Label="{x:Bind strings:Resources.ShuffleAndPlay}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
                         </controls:CommandBarEx>
                     </Grid>

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -43,18 +43,18 @@
                     Command="{Binding PlayAlbumNextCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{Binding AddAlbumToQueueCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenAlbumCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                    Text="{strings:Resources Key=ShowAlbum}" />
+                    Text="{x:Bind strings:Resources.ShowAlbum}" />
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>
@@ -74,7 +74,7 @@
             Grid.Row="0"
             Margin="{StaticResource ContentPagePadding}"
             AccessKey="{strings:KeyboardResources Key=CommandShuffleAndPlayKey}"
-            AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}"
+            AutomationProperties.Name="{x:Bind strings:Resources.ShuffleAndPlay}"
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
@@ -83,7 +83,7 @@
                     FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                     Glyph="{StaticResource ShuffleGlyph}"
                     MirroredWhenRightToLeft="True" />
-                <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
+                <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.ShuffleAndPlay}" />
             </StackPanel>
         </Button>
 
@@ -104,30 +104,30 @@
                         GroupName="SortOrder"
                         IsChecked="True"
                         Tag="title"
-                        Text="{strings:Resources Key=PropertyTitle}" />
+                        Text="{x:Bind strings:Resources.PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="artist"
                         GroupName="SortOrder"
                         Tag="artist"
-                        Text="{strings:Resources Key=Artist}" />
+                        Text="{x:Bind strings:Resources.Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="year"
                         GroupName="SortOrder"
                         Tag="year"
-                        Text="{strings:Resources Key=ReleasedYear}" />
+                        Text="{x:Bind strings:Resources.ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="dateAdded"
                         GroupName="SortOrder"
                         Tag="dateAdded"
-                        Text="{strings:Resources Key=DateAdded}" />
+                        Text="{x:Bind strings:Resources.DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>
             <StackPanel Orientation="Horizontal">
                 <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
-                <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
+                <TextBlock x:Name="SortByText"><Run Text="{x:Bind strings:Resources.SortBy}" /><Run Text=":&#160;" /></TextBlock>
                 <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
             </StackPanel>
         </muxc:DropDownButton>

--- a/Screenbox/Pages/AllVideosPage.xaml
+++ b/Screenbox/Pages/AllVideosPage.xaml
@@ -29,24 +29,24 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
                     CommandParameter="{Binding}"
@@ -56,12 +56,12 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -70,7 +70,7 @@
                                 x:Name="AlbumTitle"
                                 MaxLines="2"
                                 Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Key.Name, Converter={StaticResource AlbumTextConverter}, FallbackValue={strings:Resources Key=UnknownAlbum}}">
+                                Text="{Binding Key.Name, Converter={StaticResource AlbumTextConverter}, FallbackValue={x:Bind strings:Resources.UnknownAlbum}}">
                                 <interactivity:Interaction.Behaviors>
                                     <behaviors:OverflowTextToolTipBehavior />
                                 </interactivity:Interaction.Behaviors>
@@ -120,24 +120,24 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
                     CommandParameter="{Binding}"
@@ -147,18 +147,18 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenAlbumCommand}"
                     CommandParameter="{Binding Album}"
                     Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                    Text="{strings:Resources Key=ShowAlbum}"
+                    Text="{x:Bind strings:Resources.ShowAlbum}"
                     Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -256,7 +256,7 @@
                         Margin="0,12,0,0"
                         Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                         Style="{StaticResource BodyTextBlockStyle}"
-                        Text="{strings:Resources Key=Artist}"
+                        Text="{x:Bind strings:Resources.Artist}"
                         TextWrapping="NoWrap">
                         <interactivity:Interaction.Behaviors>
                             <behaviors:OverflowTextToolTipBehavior />
@@ -289,7 +289,7 @@
                                 Command="{x:Bind ViewModel.PlayCommand}"
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource PlayGlyph}}"
-                                Label="{strings:Resources Key=Play}"
+                                Label="{x:Bind strings:Resources.Play}"
                                 Style="{StaticResource AccentButtonAppBarButtonStyle}">
                                 <interactivity:Interaction.Behaviors>
                                     <behaviors:AutoFocusBehavior />
@@ -302,7 +302,7 @@
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource ShuffleGlyph},
                                                    MirroredWhenRightToLeft=True}"
-                                Label="{strings:Resources Key=ShuffleAndPlay}"
+                                Label="{x:Bind strings:Resources.ShuffleAndPlay}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
                         </controls:CommandBarEx>
                     </Grid>

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -37,18 +37,18 @@
                     Command="{Binding PlayArtistNextCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{Binding AddArtistToQueueCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}" />
+                    Text="{x:Bind strings:Resources.ShowArtist}" />
             </MenuFlyout>
         </ResourceDictionary>
     </Page.Resources>
@@ -68,7 +68,7 @@
             Grid.Row="0"
             Margin="{StaticResource ContentPagePadding}"
             AccessKey="{strings:KeyboardResources Key=CommandShuffleAndPlayKey}"
-            AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}"
+            AutomationProperties.Name="{x:Bind strings:Resources.ShuffleAndPlay}"
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
@@ -77,7 +77,7 @@
                     FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                     Glyph="{StaticResource ShuffleGlyph}"
                     MirroredWhenRightToLeft="True" />
-                <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
+                <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.ShuffleAndPlay}" />
             </StackPanel>
         </Button>
 

--- a/Screenbox/Pages/FolderListViewPage.xaml
+++ b/Screenbox/Pages/FolderListViewPage.xaml
@@ -25,24 +25,24 @@
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlayGlyph}}"
-                Text="{strings:Resources Key=Play}" />
+                Text="{x:Bind strings:Resources.Play}" />
             <MenuFlyoutItem
                 Command="{x:Bind ViewModel.PlayNextCommand}"
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlayAddGlyph}}"
-                Text="{strings:Resources Key=PlayNext}" />
+                Text="{x:Bind strings:Resources.PlayNext}" />
             <MenuFlyoutItem
                 Command="{x:Bind ViewModel.AddToQueueCommand}"
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlaylistMusicGlyph}}"
-                Text="{strings:Resources Key=AddToQueue}" />
+                Text="{x:Bind strings:Resources.AddToQueue}" />
             <MenuFlyoutSeparator />
             <MenuFlyoutSubItem
                 x:Name="AddToPlaylistSubMenu"
                 Icon="{ui:SymbolIcon Symbol=Add}"
-                Text="{strings:Resources Key=AddToPlaylist}" />
+                Text="{x:Bind strings:Resources.AddToPlaylist}" />
             <MenuFlyoutItem
                 Command="{StaticResource OpenWithCommand}"
                 CommandParameter="{Binding Media}"
@@ -52,12 +52,12 @@
                 Command="{StaticResource ShowPropertiesCommand}"
                 CommandParameter="{Binding Media}"
                 Icon="{ui:FontIcon Glyph=&#xE946;}"
-                Text="{strings:Resources Key=Properties}" />
+                Text="{x:Bind strings:Resources.Properties}" />
             <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
             <MenuFlyoutItem
                 CommandParameter="{Binding}"
                 Icon="{ui:SymbolIcon Symbol=Setting}"
-                Text="{strings:Resources Key=SetPlaybackOptions}"
+                Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                 Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                 <MenuFlyoutItem.Command>
                     <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -136,7 +136,7 @@
             Padding="{StaticResource ContentPagePadding}"
             HorizontalAlignment="Center"
             VerticalAlignment="Top"
-            Text="{strings:Resources Key=EmptyFolder}"
+            Text="{x:Bind strings:Resources.EmptyFolder}"
             Visibility="{x:Bind ViewModel.IsEmpty, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" />
 
         <VisualStateManager.VisualStateGroups>

--- a/Screenbox/Pages/FolderViewPage.xaml
+++ b/Screenbox/Pages/FolderViewPage.xaml
@@ -28,24 +28,24 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
                     CommandParameter="{Binding Media}"
@@ -55,12 +55,12 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding Media}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -38,24 +38,24 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
                     CommandParameter="{Binding}"
@@ -65,29 +65,29 @@
                     Command="{x:Bind ViewModel.RemoveCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Clear}"
-                    Text="{strings:Resources Key=Remove}" />
+                    Text="{x:Bind strings:Resources.Remove}" />
                 <MenuFlyoutItem
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenAlbumCommand}"
                     CommandParameter="{Binding Album}"
                     Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                    Text="{strings:Resources Key=ShowAlbum}"
+                    Text="{x:Bind strings:Resources.ShowAlbum}"
                     Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding MainArtist}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}"
+                    Text="{x:Bind strings:Resources.ShowArtist}"
                     Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -113,19 +113,19 @@
                     Command="{x:Bind Common.OpenFilesCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource FolderOpenGlyph}}"
-                    Text="{strings:Resources Key=OpenFiles}" />
+                    Text="{x:Bind strings:Resources.OpenFiles}" />
                 <MenuFlyoutItem
                     x:Name="OpenMenuFlyoutFolderItem"
                     AccessKey="{strings:KeyboardResources Key=MenuItemFolderKey}"
                     Command="{x:Bind ViewModel.OpenFolderCommand}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource FolderListGlyph}}"
-                    Text="{strings:Resources Key=OpenFolder}" />
+                    Text="{x:Bind strings:Resources.OpenFolder}" />
                 <MenuFlyoutItem
                     AccessKey="{strings:KeyboardResources Key=MenuItemUrlKey}"
                     Icon="{ui:SymbolIcon Symbol=Globe}"
                     KeyTipPlacementMode="Left"
-                    Text="{strings:Resources Key=OpenUrl}">
+                    Text="{x:Bind strings:Resources.OpenUrl}">
                     <MenuFlyoutItem.Command>
                         <commands:OpenUrlCommand NextCommand="{x:Bind ViewModel.OpenUrlCommand}" />
                     </MenuFlyoutItem.Command>
@@ -150,16 +150,16 @@
             <TextBlock
                 x:Name="HeaderText"
                 Style="{StaticResource TitleMediumTextBlockStyle}"
-                Text="{strings:Resources Key=Home}" />
+                Text="{x:Bind strings:Resources.Home}" />
             <muxc:SplitButton
                 x:Name="HeaderOpenButton"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
-                extensions:SplitButtonExtensions.PrimaryButtonToolTip="{strings:Resources Key=OpenFilesToolTip}"
+                extensions:SplitButtonExtensions.PrimaryButtonToolTip="{x:Bind strings:Resources.OpenFilesToolTip}"
                 extensions:SplitButtonExtensions.SecondaryButtonAccessKey="{strings:KeyboardResources Key=CommandMoreOptionsKey}"
-                extensions:SplitButtonExtensions.SecondaryButtonToolTip="{strings:Resources Key=OpenFilesSecondaryToolTip}"
+                extensions:SplitButtonExtensions.SecondaryButtonToolTip="{x:Bind strings:Resources.OpenFilesSecondaryToolTip}"
                 AccessKey="{strings:KeyboardResources Key=CommandAddOpenFilesKey}"
-                AutomationProperties.HelpText="{strings:Resources Key=OpenFilesToolTip}"
+                AutomationProperties.HelpText="{x:Bind strings:Resources.OpenFilesToolTip}"
                 AutomationProperties.Name="{x:Bind HeaderOpenButtonText.Text}"
                 Command="{x:Bind Common.OpenFilesCommand}"
                 Flyout="{StaticResource OpenFlyout}">
@@ -171,7 +171,7 @@
                     <TextBlock
                         x:Name="HeaderOpenButtonText"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=OpenFiles}" />
+                        Text="{x:Bind strings:Resources.OpenFiles}" />
                 </StackPanel>
                 <interactivity:Interaction.Behaviors>
                     <behaviors:SplitButtonXYNavigationBehavior />
@@ -190,7 +190,7 @@
                 VerticalAlignment="Center"
                 AutomationProperties.HeadingLevel="Level2"
                 Style="{StaticResource SubtitleTextBlockStyle}"
-                Text="{strings:Resources Key=Recent}" />
+                Text="{x:Bind strings:Resources.Recent}" />
             <Grid
                 x:Name="SelectionGrid"
                 Grid.Row="0"

--- a/Screenbox/Pages/MainPage.xaml
+++ b/Screenbox/Pages/MainPage.xaml
@@ -100,7 +100,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="H" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="HomeNavItemText" Text="{strings:Resources Key=Home}" />
+                    <TextBlock x:Name="HomeNavItemText" Text="{x:Bind strings:Resources.Home}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     extensions:AcceleratorService.ToolTip="{x:Bind MusicNavItemText.Text}"
@@ -111,7 +111,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="U" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="MusicNavItemText" Text="{strings:Resources Key=MusicLibrary}" />
+                    <TextBlock x:Name="MusicNavItemText" Text="{x:Bind strings:Resources.MusicLibrary}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     extensions:AcceleratorService.ToolTip="{x:Bind VideosNavItemText.Text}"
@@ -124,7 +124,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="D" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="VideosNavItemText" Text="{strings:Resources Key=VideoLibrary}" />
+                    <TextBlock x:Name="VideosNavItemText" Text="{x:Bind strings:Resources.VideoLibrary}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     extensions:AcceleratorService.ToolTip="{x:Bind NetworkNavItemText.Text}"
@@ -135,7 +135,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="N" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="NetworkNavItemText" Text="{strings:Resources Key=Network}" />
+                    <TextBlock x:Name="NetworkNavItemText" Text="{x:Bind strings:Resources.Network}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItemSeparator />
                 <muxc:NavigationViewItem
@@ -152,7 +152,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="Q" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="PlayQueueNavItemText" Text="{strings:Resources Key=PlayQueue}" />
+                    <TextBlock x:Name="PlayQueueNavItemText" Text="{x:Bind strings:Resources.PlayQueue}" />
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     extensions:AcceleratorService.ToolTip="{x:Bind PlaylistsNavItemText.Text}"
@@ -165,7 +165,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="P" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="PlaylistsNavItemText" Text="{strings:Resources Key=Playlists}" />
+                    <TextBlock x:Name="PlaylistsNavItemText" Text="{x:Bind strings:Resources.Playlists}" />
                 </muxc:NavigationViewItem>
             </muxc:NavigationView.MenuItems>
             <muxc:NavigationView.FooterMenuItems>
@@ -186,7 +186,7 @@
                     <muxc:NavigationViewItem.KeyboardAccelerators>
                         <KeyboardAccelerator Key="G" Modifiers="Control" />
                     </muxc:NavigationViewItem.KeyboardAccelerators>
-                    <TextBlock x:Name="SettingsNavItemText" Text="{strings:Resources Key=Settings}" />
+                    <TextBlock x:Name="SettingsNavItemText" Text="{x:Bind strings:Resources.Settings}" />
                 </muxc:NavigationViewItem>
             </muxc:NavigationView.FooterMenuItems>
 
@@ -196,11 +196,11 @@
                     extensions:AcceleratorService.ToolTip="{x:Bind NavViewSearchBox.(AutomationProperties.Name)}"
                     AccessKey="{strings:KeyboardResources Key=NavigationPaneAutoSuggestButtonKey}"
                     AccessKeyInvoked="NavViewSearchBox_OnAccessKeyInvoked"
-                    AutomationProperties.Name="{strings:Resources Key=SearchBoxToolTip}"
+                    AutomationProperties.Name="{x:Bind strings:Resources.SearchBoxToolTip}"
                     ItemTemplate="{StaticResource SearchAutoSuggestBoxItemTemplate}"
                     ItemsSource="{x:Bind ViewModel.SearchSuggestions, Mode=OneWay}"
                     KeyTipPlacementMode="Right"
-                    PlaceholderText="{strings:Resources Key=SearchBoxPlaceholderText}"
+                    PlaceholderText="{x:Bind strings:Resources.SearchBoxPlaceholderText}"
                     QueryIcon="Find"
                     QuerySubmitted="NavViewSearchBox_OnQuerySubmitted"
                     SuggestionChosen="NavViewSearchBox_OnSuggestionChosen"

--- a/Screenbox/Pages/MusicPage.xaml
+++ b/Screenbox/Pages/MusicPage.xaml
@@ -40,28 +40,28 @@
                     x:Name="HeaderNavView"
                     Margin="56,0,16,0"
                     Style="{StaticResource TitleMediumTextBlockStyle}"
-                    Text="{strings:Resources Key=Music}" />
+                    Text="{x:Bind strings:Resources.Music}" />
             </muxc:NavigationView.PaneHeader>
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem
                     x:Name="SongsMenuItem"
                     AccessKey="{strings:KeyboardResources Key=TopNavigationItemSongsKey}"
                     AutomationProperties.HeadingLevel="Level2"
-                    Content="{strings:Resources Key=Songs}"
+                    Content="{x:Bind strings:Resources.Songs}"
                     FontSize="{StaticResource TopNavigationViewItemFontSize}"
                     Tag="songs" />
                 <muxc:NavigationViewItem
                     x:Name="AlbumsMenuItem"
                     AccessKey="{strings:KeyboardResources Key=TopNavigationItemAlbumsKey}"
                     AutomationProperties.HeadingLevel="Level2"
-                    Content="{strings:Resources Key=Albums}"
+                    Content="{x:Bind strings:Resources.Albums}"
                     FontSize="{StaticResource TopNavigationViewItemFontSize}"
                     Tag="albums" />
                 <muxc:NavigationViewItem
                     x:Name="ArtistsMenuItem"
                     AccessKey="{strings:KeyboardResources Key=TopNavigationItemArtistsKey}"
                     AutomationProperties.HeadingLevel="Level2"
-                    Content="{strings:Resources Key=Artists}"
+                    Content="{x:Bind strings:Resources.Artists}"
                     FontSize="{StaticResource TopNavigationViewItemFontSize}"
                     Tag="artists" />
             </muxc:NavigationView.MenuItems>
@@ -71,9 +71,9 @@
                     Margin="{StaticResource ContentPagePadding}"
                     VerticalAlignment="Top"
                     AccessKey="{strings:KeyboardResources Key=CommandAddFolderKey}"
-                    AutomationProperties.Name="{strings:Resources Key=AddFolder}"
+                    AutomationProperties.Name="{x:Bind strings:Resources.AddFolder}"
                     Command="{x:Bind ViewModel.AddFolderCommand}"
-                    ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}"
+                    ToolTipService.ToolTip="{x:Bind strings:Resources.AddMusicFolderToolTip}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
                         <FontIcon
@@ -84,7 +84,7 @@
                         <TextBlock
                             x:Name="HeaderAddFolderButtonText"
                             Margin="8,0,0,0"
-                            Text="{strings:Resources Key=AddFolder}" />
+                            Text="{x:Bind strings:Resources.AddFolder}" />
                     </StackPanel>
                 </Button>
             </muxc:NavigationView.PaneFooter>

--- a/Screenbox/Pages/NetworkPage.xaml
+++ b/Screenbox/Pages/NetworkPage.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Page.Resources>
-        <converters:DefaultStringConverter x:Key="DefaultTitleTextConverter" Default="{strings:Resources Key=Network}" />
+        <converters:DefaultStringConverter x:Key="DefaultTitleTextConverter" Default="{x:Bind strings:Resources.Network}" />
     </Page.Resources>
 
     <Grid>

--- a/Screenbox/Pages/PlayQueuePage.xaml
+++ b/Screenbox/Pages/PlayQueuePage.xaml
@@ -25,19 +25,19 @@
                 Command="{x:Bind PlayQueue.ViewModel.AddFilesCommand}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource FolderOpenGlyph}}"
-                Text="{strings:Resources Key=AddFiles}" />
+                Text="{x:Bind strings:Resources.AddFiles}" />
             <MenuFlyoutItem
                 x:Name="AddToPlayQueueMenuFlyoutFolderItem"
                 AccessKey="{strings:KeyboardResources Key=MenuItemFolderKey}"
                 Command="{x:Bind ViewModel.AddFolderCommand}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource FolderListGlyph}}"
-                Text="{strings:Resources Key=AddFolder}" />
+                Text="{x:Bind strings:Resources.AddFolder}" />
             <MenuFlyoutItem
                 AccessKey="{strings:KeyboardResources Key=MenuItemUrlKey}"
                 Icon="{ui:SymbolIcon Symbol=Globe}"
                 KeyTipPlacementMode="Left"
-                Text="{strings:Resources Key=AddUrl}">
+                Text="{x:Bind strings:Resources.AddUrl}">
                 <MenuFlyoutItem.Command>
                     <commands:OpenUrlCommand NextCommand="{x:Bind ViewModel.AddUrlCommand}" />
                 </MenuFlyoutItem.Command>
@@ -70,7 +70,7 @@
             <TextBlock
                 Grid.Column="0"
                 Style="{StaticResource TitleMediumTextBlockStyle}"
-                Text="{strings:Resources Key=PlayQueue}"
+                Text="{x:Bind strings:Resources.PlayQueue}"
                 TextWrapping="NoWrap">
                 <interactivity:Interaction.Behaviors>
                     <behaviors:OverflowTextToolTipBehavior />
@@ -81,11 +81,11 @@
                 x:Name="HeaderAddButton"
                 Grid.Column="1"
                 VerticalAlignment="Top"
-                extensions:SplitButtonExtensions.PrimaryButtonToolTip="{strings:Resources Key=AddFilesToPlayQueueToolTip}"
+                extensions:SplitButtonExtensions.PrimaryButtonToolTip="{x:Bind strings:Resources.AddFilesToPlayQueueToolTip}"
                 extensions:SplitButtonExtensions.SecondaryButtonAccessKey="{strings:KeyboardResources Key=CommandMoreOptionsKey}"
-                extensions:SplitButtonExtensions.SecondaryButtonToolTip="{strings:Resources Key=AddFilesToPlayQueueSecondaryToolTip}"
+                extensions:SplitButtonExtensions.SecondaryButtonToolTip="{x:Bind strings:Resources.AddFilesToPlayQueueSecondaryToolTip}"
                 AccessKey="{strings:KeyboardResources Key=CommandAddOpenFilesKey}"
-                AutomationProperties.HelpText="{strings:Resources Key=AddFilesToPlayQueueToolTip}"
+                AutomationProperties.HelpText="{x:Bind strings:Resources.AddFilesToPlayQueueToolTip}"
                 AutomationProperties.Name="{x:Bind HeaderAddButtonText.Text}"
                 Command="{x:Bind PlayQueue.ViewModel.AddFilesCommand}"
                 Flyout="{StaticResource AddToPlayQueueFlyout}">
@@ -97,7 +97,7 @@
                     <TextBlock
                         x:Name="HeaderAddButtonText"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=AddFiles}" />
+                        Text="{x:Bind strings:Resources.AddFiles}" />
                 </StackPanel>
                 <interactivity:Interaction.Behaviors>
                     <behaviors:SplitButtonXYNavigationBehavior />

--- a/Screenbox/Pages/PlayerPage.xaml
+++ b/Screenbox/Pages/PlayerPage.xaml
@@ -350,7 +350,7 @@
             HorizontalContentAlignment="Left"
             VerticalContentAlignment="Top"
             AccessKey="{strings:KeyboardResources Key=PlayerRestoreKey}"
-            AutomationProperties.Name="{strings:Resources Key=RestoreView}"
+            AutomationProperties.Name="{x:Bind strings:Resources.RestoreView}"
             Command="{x:Bind ViewModel.RestorePlayerCommand}"
             KeyTipPlacementMode="Center"
             Visibility="Collapsed">
@@ -385,7 +385,7 @@
                 </muxc:AnimatedIcon.FallbackIconSource>
             </muxc:AnimatedIcon>
             <ToolTipService.ToolTip>
-                <ToolTip Content="{strings:Resources Key=RestoreView}" PlacementRect="0,6,162,90" />
+                <ToolTip Content="{x:Bind strings:Resources.RestoreView}" PlacementRect="0,6,162,90" />
             </ToolTipService.ToolTip>
         </Button>
 

--- a/Screenbox/Pages/PlaylistDetailsPage.xaml
+++ b/Screenbox/Pages/PlaylistDetailsPage.xaml
@@ -29,42 +29,42 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.RemoveCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Delete}"
-                    Text="{strings:Resources Key=Remove}" />
+                    Text="{x:Bind strings:Resources.Remove}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding MainArtist}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}"
+                    Text="{x:Bind strings:Resources.ShowArtist}"
                     Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -182,7 +182,7 @@
                                 CommandParameter="{x:Bind ViewModel.Source.Items, Mode=OneWay, Converter={StaticResource FirstOrDefaultConverter}}"
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource PlayGlyph}}"
-                                Label="{strings:Resources Key=Play}"
+                                Label="{x:Bind strings:Resources.Play}"
                                 Style="{StaticResource AccentButtonAppBarButtonStyle}">
                                 <interactivity:Interaction.Behaviors>
                                     <behaviors:AutoFocusBehavior />
@@ -195,24 +195,24 @@
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource ShuffleGlyph},
                                                    MirroredWhenRightToLeft=True}"
-                                Label="{strings:Resources Key=ShuffleAndPlay}"
+                                Label="{x:Bind strings:Resources.ShuffleAndPlay}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
 
                             <AppBarButton
                                 Command="{x:Bind ViewModel.AddFilesCommand}"
                                 Icon="{ui:SymbolIcon Symbol=Add}"
-                                Label="{strings:Resources Key=AddFiles}"
+                                Label="{x:Bind strings:Resources.AddFiles}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
 
                             <AppBarButton
                                 Command="{x:Bind RenamePlaylistCommand}"
                                 Icon="{ui:SymbolIcon Symbol=Rename}"
-                                Label="{strings:Resources Key=Rename}"
+                                Label="{x:Bind strings:Resources.Rename}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
 
                             <AppBarButton
                                 Command="{x:Bind ExportPlaylistCommand}"
-                                Label="{strings:Resources Key=Export}"
+                                Label="{x:Bind strings:Resources.Export}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}">
                                 <AppBarButton.Icon>
                                     <FontIcon Glyph="&#xEDE1;" MirroredWhenRightToLeft="True" />
@@ -222,7 +222,7 @@
                             <AppBarButton
                                 Command="{x:Bind DeletePlaylistCommand}"
                                 Icon="{ui:SymbolIcon Symbol=Delete}"
-                                Label="{strings:Resources Key=Delete}"
+                                Label="{x:Bind strings:Resources.Delete}"
                                 Style="{StaticResource DefaultButtonAppBarButtonStyle}" />
                         </controls:CommandBarEx>
                     </Grid>

--- a/Screenbox/Pages/PlaylistsPage.xaml
+++ b/Screenbox/Pages/PlaylistsPage.xaml
@@ -26,29 +26,29 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind ViewModel.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{x:Bind RenamePlaylistCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Rename}"
-                    Text="{strings:Resources Key=Rename}" />
+                    Text="{x:Bind strings:Resources.Rename}" />
                 <MenuFlyoutItem
                     Command="{x:Bind ExportPlaylistCommand}"
                     CommandParameter="{Binding}"
-                    Text="{strings:Resources Key=Export}">
+                    Text="{x:Bind strings:Resources.Export}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xEDE1;" MirroredWhenRightToLeft="True" />
                     </MenuFlyoutItem.Icon>
@@ -57,7 +57,7 @@
                     Command="{x:Bind DeletePlaylistCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Delete}"
-                    Text="{strings:Resources Key=Delete}" />
+                    Text="{x:Bind strings:Resources.Delete}" />
             </MenuFlyout>
 
             <MenuFlyout x:Key="CreatePlaylistFlyout" Placement="{x:Bind helpers:GlobalizationHelper.MirrorWhenRightToLeft(primitives:FlyoutPlacementMode.BottomEdgeAlignedRight)}">
@@ -110,7 +110,7 @@
                 x:Name="HeaderText"
                 Grid.Column="0"
                 Style="{StaticResource TitleMediumTextBlockStyle}"
-                Text="{strings:Resources Key=Playlists}"
+                Text="{x:Bind strings:Resources.Playlists}"
                 TextWrapping="NoWrap" />
 
             <muxc:SplitButton
@@ -126,7 +126,7 @@
                     <TextBlock
                         x:Name="HeaderCreateButtonText"
                         Margin="8,0,0,0"
-                        Text="{strings:Resources Key=NewPlaylist}" />
+                        Text="{x:Bind strings:Resources.NewPlaylist}" />
                 </StackPanel>
                 <interactivity:Interaction.Behaviors>
                     <behaviors:SplitButtonXYNavigationBehavior />
@@ -188,7 +188,7 @@
                         Style="{StaticResource AccentSplitButtonStyle}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Margin="{StaticResource IconButtonStandardIconMargin}" Glyph="&#xE710;" />
-                            <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=NewPlaylist}" />
+                            <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.NewPlaylist}" />
                         </StackPanel>
                         <interactivity:Interaction.Behaviors>
                             <behaviors:SplitButtonXYNavigationBehavior />

--- a/Screenbox/Pages/Search/SearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SearchResultPage.xaml
@@ -27,19 +27,19 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
@@ -50,24 +50,24 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenAlbumCommand}"
                     CommandParameter="{Binding Album}"
                     Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                    Text="{strings:Resources Key=ShowAlbum}"
+                    Text="{x:Bind strings:Resources.ShowAlbum}"
                     Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding MainArtist}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}"
+                    Text="{x:Bind strings:Resources.ShowArtist}"
                     Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -119,11 +119,11 @@
                         <TextBlock
                             HorizontalAlignment="Left"
                             Style="{StaticResource SubtitleTextBlockStyle}"
-                            Text="{strings:Resources Key=Artists}" />
+                            Text="{x:Bind strings:Resources.Artists}" />
                         <HyperlinkButton
                             HorizontalAlignment="Right"
                             Command="{x:Bind ViewModel.SeeAllArtistsCommand}"
-                            Content="{strings:Resources Key=SeeAll}"
+                            Content="{x:Bind strings:Resources.SeeAll}"
                             Visibility="{x:Bind ViewModel.HasMoreArtists, Mode=OneWay}" />
                     </Grid>
                     <GridView
@@ -149,11 +149,11 @@
                         <TextBlock
                             HorizontalAlignment="Left"
                             Style="{StaticResource SubtitleTextBlockStyle}"
-                            Text="{strings:Resources Key=Albums}" />
+                            Text="{x:Bind strings:Resources.Albums}" />
                         <HyperlinkButton
                             HorizontalAlignment="Right"
                             Command="{x:Bind ViewModel.SeeAllAlbumsCommand}"
-                            Content="{strings:Resources Key=SeeAll}"
+                            Content="{x:Bind strings:Resources.SeeAll}"
                             Visibility="{x:Bind ViewModel.HasMoreAlbums, Mode=OneWay}" />
                     </Grid>
                     <GridView
@@ -183,11 +183,11 @@
                         <TextBlock
                             HorizontalAlignment="Left"
                             Style="{StaticResource SubtitleTextBlockStyle}"
-                            Text="{strings:Resources Key=Songs}" />
+                            Text="{x:Bind strings:Resources.Songs}" />
                         <HyperlinkButton
                             HorizontalAlignment="Right"
                             Command="{x:Bind ViewModel.SeeAllSongsCommand}"
-                            Content="{strings:Resources Key=SeeAll}"
+                            Content="{x:Bind strings:Resources.SeeAll}"
                             Visibility="{x:Bind ViewModel.HasMoreSongs, Mode=OneWay}" />
                     </Grid>
                     <ListView
@@ -222,11 +222,11 @@
                         <TextBlock
                             HorizontalAlignment="Left"
                             Style="{StaticResource SubtitleTextBlockStyle}"
-                            Text="{strings:Resources Key=Videos}" />
+                            Text="{x:Bind strings:Resources.Videos}" />
                         <HyperlinkButton
                             HorizontalAlignment="Right"
                             Command="{x:Bind ViewModel.SeeAllVideosCommand}"
-                            Content="{strings:Resources Key=SeeAll}"
+                            Content="{x:Bind strings:Resources.SeeAll}"
                             Visibility="{x:Bind ViewModel.HasMoreVideos, Mode=OneWay}" />
                     </Grid>
                     <GridView

--- a/Screenbox/Pages/Search/SongSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/SongSearchResultPage.xaml
@@ -20,19 +20,19 @@
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlayGlyph}}"
-                Text="{strings:Resources Key=Play}" />
+                Text="{x:Bind strings:Resources.Play}" />
             <MenuFlyoutItem
                 Command="{x:Bind Common.PlayNextCommand}"
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlayAddGlyph}}"
-                Text="{strings:Resources Key=PlayNext}" />
+                Text="{x:Bind strings:Resources.PlayNext}" />
             <MenuFlyoutItem
                 Command="{x:Bind Common.AddToQueueCommand}"
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                    Glyph={StaticResource PlaylistMusicGlyph}}"
-                Text="{strings:Resources Key=AddToQueue}" />
+                Text="{x:Bind strings:Resources.AddToQueue}" />
             <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 Command="{StaticResource OpenWithCommand}"
@@ -43,24 +43,24 @@
                 Command="{StaticResource ShowPropertiesCommand}"
                 CommandParameter="{Binding}"
                 Icon="{ui:FontIcon Glyph=&#xE946;}"
-                Text="{strings:Resources Key=Properties}" />
+                Text="{x:Bind strings:Resources.Properties}" />
             <MenuFlyoutItem
                 Command="{x:Bind Common.OpenAlbumCommand}"
                 CommandParameter="{Binding Album}"
                 Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                Text="{strings:Resources Key=ShowAlbum}"
+                Text="{x:Bind strings:Resources.ShowAlbum}"
                 Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
             <MenuFlyoutItem
                 Command="{x:Bind Common.OpenArtistCommand}"
                 CommandParameter="{Binding MainArtist}"
                 Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                Text="{strings:Resources Key=ShowArtist}"
+                Text="{x:Bind strings:Resources.ShowArtist}"
                 Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
             <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
             <MenuFlyoutItem
                 CommandParameter="{Binding}"
                 Icon="{ui:SymbolIcon Symbol=Setting}"
-                Text="{strings:Resources Key=SetPlaybackOptions}"
+                Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                 Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                 <MenuFlyoutItem.Command>
                     <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />

--- a/Screenbox/Pages/Search/VideoSearchResultPage.xaml
+++ b/Screenbox/Pages/Search/VideoSearchResultPage.xaml
@@ -50,7 +50,7 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -54,12 +54,12 @@
         <XamlUICommand
             x:Key="RemoveVideosFolderCommand"
             Command="{x:Bind ViewModel.RemoveVideosFolderCommand}"
-            Description="{strings:Resources Key=RemoveFolder}" />
+            Description="{x:Bind strings:Resources.RemoveFolder}" />
 
         <XamlUICommand
             x:Key="RemoveMusicFolderCommand"
             Command="{x:Bind ViewModel.RemoveMusicFolderCommand}"
-            Description="{strings:Resources Key=RemoveFolder}" />
+            Description="{x:Bind strings:Resources.RemoveFolder}" />
 
         <DataTemplate x:Key="VideosLibraryLocationTemplate" x:DataType="storage:StorageFolder">
             <ctc:SettingsCard Description="{x:Bind Path}" Header="{x:Bind DisplayName}">
@@ -121,7 +121,7 @@
             <TextBlock
                 x:Name="HeaderText"
                 Style="{StaticResource TitleMediumTextBlockStyle}"
-                Text="{strings:Resources Key=Settings}" />
+                Text="{x:Bind strings:Resources.Settings}" />
         </Grid>
 
         <ScrollViewer
@@ -146,12 +146,12 @@
                 <TextBlock
                     Margin="1,8,0,8"
                     Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"
-                    Text="{strings:Resources Key=SettingsCategoryLibraries}" />
+                    Text="{x:Bind strings:Resources.SettingsCategoryLibraries}" />
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsSearchRemovableStorageDescription}"
-                    Header="{strings:Resources Key=SettingsSearchRemovableStorageHeader}"
+                    Description="{x:Bind strings:Resources.SettingsSearchRemovableStorageDescription}"
+                    Header="{x:Bind strings:Resources.SettingsSearchRemovableStorageHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE88E;}"
                     ItemTemplate="{StaticResource RemovableStorageFolderTemplate}"
                     ItemsSource="{x:Bind ViewModel.RemovableStorageFolders}"
@@ -161,14 +161,14 @@
                     </interactivity:Interaction.Behaviors>
                     <ToggleSwitch
                         x:Name="SearchRemovableStorageToggle"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsSearchRemovableStorageDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsSearchRemovableStorageDescription}"
                         IsOn="{x:Bind ViewModel.SearchRemovableStorage, Mode=TwoWay}" />
                 </ctc:SettingsExpander>
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="{x:Bind strings:Resources.LocationSpecified(ViewModel.MusicLocations.Count), Mode=OneWay, FallbackValue={x:Null}}"
-                    Header="{strings:Resources Key=SettingsMusicLibraryLocationsHeader}"
+                    Header="{x:Bind strings:Resources.SettingsMusicLibraryLocationsHeader}"
                     ItemTemplate="{StaticResource MusicLibraryLocationTemplate}"
                     ItemsSource="{x:Bind ViewModel.MusicLocations}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
@@ -183,17 +183,17 @@
                     </interactivity:Interaction.Behaviors>
                     <Button
                         x:Name="AddMusicFolderButton"
-                        AutomationProperties.HelpText="{strings:Resources Key=AddMusicFolderToolTip}"
-                        AutomationProperties.Name="{strings:Resources Key=AddFolder}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.AddMusicFolderToolTip}"
+                        AutomationProperties.Name="{x:Bind strings:Resources.AddFolder}"
                         Command="{x:Bind ViewModel.AddMusicFolderCommand}"
-                        ToolTipService.ToolTip="{strings:Resources Key=AddMusicFolderToolTip}">
+                        ToolTipService.ToolTip="{x:Bind strings:Resources.AddMusicFolderToolTip}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon
                                 x:Name="SettingsExpanderAddMusicFolderButtonIcon"
                                 Margin="{StaticResource IconButtonStandardIconMargin}"
                                 FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                                 Glyph="{StaticResource NewFolderGlyph}" />
-                            <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
+                            <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.AddFolder}" />
                         </StackPanel>
                     </Button>
                 </ctc:SettingsExpander>
@@ -201,7 +201,7 @@
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="{x:Bind strings:Resources.LocationSpecified(ViewModel.VideoLocations.Count), Mode=OneWay, FallbackValue={x:Null}}"
-                    Header="{strings:Resources Key=SettingsVideoLibraryLocationsHeader}"
+                    Header="{x:Bind strings:Resources.SettingsVideoLibraryLocationsHeader}"
                     ItemTemplate="{StaticResource VideosLibraryLocationTemplate}"
                     ItemsSource="{x:Bind ViewModel.VideoLocations}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
@@ -216,24 +216,24 @@
                     </interactivity:Interaction.Behaviors>
                     <Button
                         x:Name="AddVideoFolderButton"
-                        AutomationProperties.HelpText="{strings:Resources Key=AddVideoFolderToolTip}"
-                        AutomationProperties.Name="{strings:Resources Key=AddFolder}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.AddVideoFolderToolTip}"
+                        AutomationProperties.Name="{x:Bind strings:Resources.AddFolder}"
                         Command="{x:Bind ViewModel.AddVideosFolderCommand}"
-                        ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}">
+                        ToolTipService.ToolTip="{x:Bind strings:Resources.AddVideoFolderToolTip}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon
                                 x:Name="SettingsExpanderAddVideoFolderButtonIcon"
                                 Margin="{StaticResource IconButtonStandardIconMargin}"
                                 FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                                 Glyph="{StaticResource NewFolderGlyph}" />
-                            <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=AddFolder}" />
+                            <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.AddFolder}" />
                         </StackPanel>
                     </Button>
                 </ctc:SettingsExpander>
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
-                    Header="{strings:Resources Key=RefreshLibraries}"
+                    Header="{x:Bind strings:Resources.RefreshLibraries}"
                     HeaderIcon="{ui:SymbolIcon Symbol=Repair}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <interactivity:Interaction.Behaviors>
@@ -242,26 +242,26 @@
                     <Button
                         x:Name="RefreshLibrariesButton"
                         Command="{x:Bind ViewModel.RefreshLibrariesCommand}"
-                        Content="{strings:Resources Key=Refresh}" />
+                        Content="{x:Bind strings:Resources.Refresh}" />
                     <ctc:SettingsExpander.Items>
                         <ctc:SettingsCard ContentAlignment="Left">
                             <StackPanel Orientation="Vertical">
                                 <CheckBox
                                     AutomationProperties.FullDescription="{x:Bind SettingsUseIndexerDescriptionText.Text}"
-                                    Content="{strings:Resources Key=SettingsUseIndexerHeader}"
+                                    Content="{x:Bind strings:Resources.SettingsUseIndexerHeader}"
                                     IsChecked="{x:Bind ViewModel.UseIndexer, Mode=TwoWay}" />
                                 <TextBlock
                                     x:Name="SettingsUseIndexerDescriptionText"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                     Style="{StaticResource CaptionTextBlockStyle}"
-                                    Text="{strings:Resources Key=SettingsUseIndexerDescription}" />
+                                    Text="{x:Bind strings:Resources.SettingsUseIndexerDescription}" />
                             </StackPanel>
                         </ctc:SettingsCard>
                         <ctc:SettingsCard
                             ActionIcon="{ui:FontIcon Glyph=&#xE8A7;,
                                                      MirroredWhenRightToLeft=True}"
                             CornerRadius="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}"
-                            Header="{strings:Resources Key=ManageSystemIndexingLink}"
+                            Header="{x:Bind strings:Resources.ManageSystemIndexingLink}"
                             IsClickEnabled="True">
                             <interactivity:Interaction.Behaviors>
                                 <interactivity:EventTriggerBehavior EventName="Click">
@@ -273,12 +273,12 @@
                 </ctc:SettingsExpander>
 
                 <!--  Personalization section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPersonalization}" />
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{x:Bind strings:Resources.SettingsCategoryPersonalization}" />
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsThemeSelectionDescription}"
-                    Header="{strings:Resources Key=SettingsThemeSelectionHeader}"
+                    Description="{x:Bind strings:Resources.SettingsThemeSelectionDescription}"
+                    Header="{x:Bind strings:Resources.SettingsThemeSelectionHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource FiltersGlyph}}">
                     <ComboBox
@@ -297,8 +297,8 @@
                 </ctc:SettingsCard>
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsLanguageSelectionDescription}"
-                    Header="{strings:Resources Key=SettingsLanguageSelectionHeader}"
+                    Description="{x:Bind strings:Resources.SettingsLanguageSelectionDescription}"
+                    Header="{x:Bind strings:Resources.SettingsLanguageSelectionHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xF2B7;}">
                     <ComboBox
                         x:Name="LanguageComboBox"
@@ -318,30 +318,30 @@
                 </ctc:SettingsCard>
 
                 <!--  General section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{x:Bind strings:Resources.SettingsCategoryGeneral}" />
 
                 <ctc:SettingsCard
                     x:Name="SettingsEnqueueAllFilesInFolderCard"
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}"
-                    Header="{strings:Resources Key=SettingsEnqueueAllFilesInFolderHeader}"
+                    Description="{x:Bind strings:Resources.SettingsEnqueueAllFilesInFolderDescription}"
+                    Header="{x:Bind strings:Resources.SettingsEnqueueAllFilesInFolderHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource FolderListGlyph}}">
-                    <ToggleSwitch AutomationProperties.HelpText="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
+                    <ToggleSwitch AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsEnqueueAllFilesInFolderDescription}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 
                 <!--  Player section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{x:Bind strings:Resources.SettingsCategoryPlayer}" />
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsAutoResizeDescription}"
-                    Header="{strings:Resources Key=SettingsAutoResizeHeader}"
+                    Description="{x:Bind strings:Resources.SettingsAutoResizeDescription}"
+                    Header="{x:Bind strings:Resources.SettingsAutoResizeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE799;}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <ComboBox
                         MinWidth="150"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsAutoResizeDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsAutoResizeDescription}"
                         ItemTemplate="{StaticResource ResourceNameToResourceStringTemplate}"
                         SelectedIndex="{x:Bind ViewModel.PlayerAutoResize, Mode=TwoWay}">
                         <interactivity:Interaction.Behaviors>
@@ -355,13 +355,13 @@
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsVolumeBoostDescription}"
-                    Header="{strings:Resources Key=SettingsVolumeBoostHeader}"
+                    Description="{x:Bind strings:Resources.SettingsVolumeBoostDescription}"
+                    Header="{x:Bind strings:Resources.SettingsVolumeBoostHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE767;,
                                              MirroredWhenRightToLeft=True}">
                     <ComboBox
                         MinWidth="150"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsVolumeBoostDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsVolumeBoostDescription}"
                         ItemTemplate="{StaticResource ResourceNameToResourceStringTemplate}"
                         SelectedIndex="{x:Bind ViewModel.VolumeBoost, Mode=TwoWay}">
                         <interactivity:Interaction.Behaviors>
@@ -407,7 +407,7 @@
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
-                    Header="{strings:Resources Key=SettingsGesturesHeader}"
+                    Header="{x:Bind strings:Resources.SettingsGesturesHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xEDA4;}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <ctc:SettingsExpander.Items>
@@ -485,8 +485,8 @@
                 <ctc:SettingsExpander
                     x:Name="SettingsAudioVisualExpander"
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsAudioVisualDescription}"
-                    Header="{strings:Resources Key=SettingsAudioVisualHeader}"
+                    Description="{x:Bind strings:Resources.SettingsAudioVisualDescription}"
+                    Header="{x:Bind strings:Resources.SettingsAudioVisualHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource MusicVisualizerGlyph}}">
                     <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind converters:DefaultStringConverter.GetValueOrDefault(AudioVisualSelector.ViewModel.SelectedVisualizer.Model.Title), Mode=OneWay}" />
@@ -497,9 +497,9 @@
                         <ctc:SettingsCard
                             x:Name="SettingsImportVisualsCard"
                             AutomationProperties.Name="{x:Bind SettingsImportVisualsCard.Header}"
-                            Description="{strings:Resources Key=SettingsImportVisualsDescription}"
-                            Header="{strings:Resources Key=SettingsImportVisualsHeader}">
-                            <Button Command="{x:Bind AudioVisualSelector.ViewModel.BrowseVisualizerCommand}" Content="{strings:Resources Key=BrowseFiles}" />
+                            Description="{x:Bind strings:Resources.SettingsImportVisualsDescription}"
+                            Header="{x:Bind strings:Resources.SettingsImportVisualsHeader}">
+                            <Button Command="{x:Bind AudioVisualSelector.ViewModel.BrowseVisualizerCommand}" Content="{x:Bind strings:Resources.BrowseFiles}" />
                         </ctc:SettingsCard>
                     </ctc:SettingsExpander.Items>
                     <ctc:SettingsExpander.ItemsFooter>
@@ -518,14 +518,14 @@
                                     Margin="0,6,0,0"
                                     AutomationProperties.HeadingLevel="Level4"
                                     Style="{StaticResource BodyStrongTextBlockStyle}"
-                                    Text="{strings:Resources Key=RelatedLinks}" />
+                                    Text="{x:Bind strings:Resources.RelatedLinks}" />
 
                                 <ctc:WrapPanel Grid.Column="1" Orientation="Horizontal">
                                     <HyperlinkButton
-                                        Content="{strings:Resources Key=GetLivelyApp}"
+                                        Content="{x:Bind strings:Resources.GetLivelyApp}"
                                         NavigateUri="https://www.rocksdanister.com/lively"
                                         Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}" />
-                                    <HyperlinkButton Content="{strings:Resources Key=GetLivelyVisuals}" NavigateUri="https://github.com/rocksdanister/audio-visualizer-wallpaper" />
+                                    <HyperlinkButton Content="{x:Bind strings:Resources.GetLivelyVisuals}" NavigateUri="https://github.com/rocksdanister/audio-visualizer-wallpaper" />
                                 </ctc:WrapPanel>
                             </Grid>
                         </ctc:SettingsCard>
@@ -533,18 +533,18 @@
                 </ctc:SettingsExpander>
 
                 <!--  Advanced section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryAdvanced}" />
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{x:Bind strings:Resources.SettingsCategoryAdvanced}" />
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsVideoUpscalingDescription}"
-                    Header="{strings:Resources Key=SettingsVideoUpscalingHeader}"
+                    Description="{x:Bind strings:Resources.SettingsVideoUpscalingDescription}"
+                    Header="{x:Bind strings:Resources.SettingsVideoUpscalingHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource ImagePixelGlyph}}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <ComboBox
                         MinWidth="150"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsVideoUpscalingHeader}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsVideoUpscalingHeader}"
                         ItemTemplate="{StaticResource ResourceNameToResourceStringTemplate}"
                         SelectedIndex="{x:Bind ViewModel.VideoUpscaling, Mode=TwoWay}">
                         <interactivity:Interaction.Behaviors>
@@ -558,21 +558,21 @@
 
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsUseMultipleInstancesDescription}"
-                    Header="{strings:Resources Key=SettingsUseMultipleInstancesHeader}"
+                    Description="{x:Bind strings:Resources.SettingsUseMultipleInstancesDescription}"
+                    Header="{x:Bind strings:Resources.SettingsUseMultipleInstancesHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xF5ED;,
                                              MirroredWhenRightToLeft=True}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <ToggleSwitch
                         x:Name="UseMultipleInstancesToggleSwitch"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsUseMultipleInstancesDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsUseMultipleInstancesDescription}"
                         IsOn="{x:Bind ViewModel.UseMultipleInstances, Mode=TwoWay}" />
                 </ctc:SettingsCard>
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsAdvancedModeDescription}"
-                    Header="{strings:Resources Key=SettingsAdvancedModeHeader}"
+                    Description="{x:Bind strings:Resources.SettingsAdvancedModeDescription}"
+                    Header="{x:Bind strings:Resources.SettingsAdvancedModeHeader}"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE756;}"
                     IsExpanded="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
                     <interactivity:Interaction.Behaviors>
@@ -580,23 +580,23 @@
                     </interactivity:Interaction.Behaviors>
                     <ToggleSwitch
                         x:Name="AdvancedModeToggleSwitch"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsAdvancedModeDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsAdvancedModeDescription}"
                         IsOn="{x:Bind ViewModel.AdvancedMode, Mode=TwoWay}" />
                     <ctc:SettingsExpander.Items>
                         <ctc:SettingsCard
                             x:Name="SettingsGlobalArgumentsCard"
                             AutomationProperties.Name="{x:Bind SettingsGlobalArgumentsCard.Header}"
-                            Description="{strings:Resources Key=SettingsGlobalArgumentsDescription}"
-                            Header="{strings:Resources Key=SettingsGlobalArgumentsHeader}"
+                            Description="{x:Bind strings:Resources.SettingsGlobalArgumentsDescription}"
+                            Header="{x:Bind strings:Resources.SettingsGlobalArgumentsHeader}"
                             IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}">
-                            <Button CommandParameter="{x:Bind ViewModel}" Content="{strings:Resources Key=SetArguments}">
+                            <Button CommandParameter="{x:Bind ViewModel}" Content="{x:Bind strings:Resources.SetArguments}">
                                 <Button.Command>
                                     <commands:SetPlaybackOptionsCommand />
                                 </Button.Command>
                             </Button>
                         </ctc:SettingsCard>
                         <ctc:SettingsCard
-                            Header="{strings:Resources Key=ActiveArguments}"
+                            Header="{x:Bind strings:Resources.ActiveArguments}"
                             IsEnabled="{x:Bind AdvancedModeToggleSwitch.IsOn, Mode=OneWay}"
                             Visibility="{x:Bind ViewModel.GlobalArguments, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}">
                             <ctc:SettingsCard.Description>
@@ -611,8 +611,8 @@
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
-                    Description="{strings:Resources Key=SettingsShowRecentDescription}"
-                    Header="{strings:Resources Key=SettingsShowRecentHeader}">
+                    Description="{x:Bind strings:Resources.SettingsShowRecentDescription}"
+                    Header="{x:Bind strings:Resources.SettingsShowRecentHeader}">
                     <ctc:SettingsExpander.HeaderIcon>
                         <FontIcon
                             FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
@@ -624,17 +624,17 @@
                     </interactivity:Interaction.Behaviors>
                     <ToggleSwitch
                         x:Name="ShowRecentToggleSwitch"
-                        AutomationProperties.HelpText="{strings:Resources Key=SettingsShowRecentDescription}"
+                        AutomationProperties.HelpText="{x:Bind strings:Resources.SettingsShowRecentDescription}"
                         IsOn="{x:Bind ViewModel.ShowRecent, Mode=TwoWay}" />
                     <ctc:SettingsExpander.Items>
                         <ctc:SettingsCard
                             x:Name="SettingsClearRecentCard"
                             AutomationProperties.Name="{x:Bind SettingsClearRecentCard.Header}"
-                            Header="{strings:Resources Key=SettingsClearRecentHeader}">
+                            Header="{x:Bind strings:Resources.SettingsClearRecentHeader}">
                             <Button
                                 MinWidth="{StaticResource SettingsCardButtonMinWidth}"
                                 Command="{x:Bind ViewModel.ClearRecentHistoryCommand}"
-                                Content="{strings:Resources Key=Clear}" />
+                                Content="{x:Bind strings:Resources.Clear}" />
                         </ctc:SettingsCard>
                     </ctc:SettingsExpander.Items>
                 </ctc:SettingsExpander>
@@ -665,12 +665,12 @@
                 </ctc:SettingsExpander>
 
                 <!--  About section  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryAbout}" />
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{x:Bind strings:Resources.SettingsCategoryAbout}" />
 
                 <ctc:SettingsExpander
                     Margin="{StaticResource SettingsCardMargin}"
                     Description="Made with ❤️ by Tung Huynh"
-                    Header="{strings:Resources Key=AppFriendlyName}"
+                    Header="{x:Bind strings:Resources.AppFriendlyName}"
                     HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/StoreLogo.png}">
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -679,10 +679,10 @@
                     <ctc:SettingsExpander.Items>
                         <ctc:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Vertical">
                             <StackPanel Margin="{StaticResource HyperlinkButtonInlineMargin}" Orientation="Vertical">
-                                <HyperlinkButton Content="{strings:Resources Key=PrivacyPolicy}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
-                                <HyperlinkButton Content="{strings:Resources Key=License}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
-                                <HyperlinkButton Content="{strings:Resources Key=ThirdPartyNotices}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/NOTICE.md" />
-                                <HyperlinkButton Content="{strings:Resources Key=HyperlinkSourceCode}" NavigateUri="https://github.com/huynhsontung/Screenbox" />
+                                <HyperlinkButton Content="{x:Bind strings:Resources.PrivacyPolicy}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/PRIVACY.md" />
+                                <HyperlinkButton Content="{x:Bind strings:Resources.License}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/LICENSE" />
+                                <HyperlinkButton Content="{x:Bind strings:Resources.ThirdPartyNotices}" NavigateUri="https://github.com/huynhsontung/Screenbox/blob/main/NOTICE.md" />
+                                <HyperlinkButton Content="{x:Bind strings:Resources.HyperlinkSourceCode}" NavigateUri="https://github.com/huynhsontung/Screenbox" />
                             </StackPanel>
                         </ctc:SettingsCard>
                     </ctc:SettingsExpander.Items>
@@ -693,9 +693,9 @@
                     Padding="{StaticResource HyperlinkButtonInlineMargin}"
                     Orientation="Vertical"
                     XYFocusKeyboardNavigation="Enabled">
-                    <HyperlinkButton Content="{strings:Resources Key=HyperlinkDiscord}" NavigateUri="https://discord.gg/HZPZXjANxz" />
-                    <HyperlinkButton Content="{strings:Resources Key=HyperlinkSponsor}" NavigateUri="https://github.com/sponsors/huynhsontung" />
-                    <HyperlinkButton Content="{strings:Resources Key=HyperlinkTranslate}" NavigateUri="https://crowdin.com/project/screenbox" />
+                    <HyperlinkButton Content="{x:Bind strings:Resources.HyperlinkDiscord}" NavigateUri="https://discord.gg/HZPZXjANxz" />
+                    <HyperlinkButton Content="{x:Bind strings:Resources.HyperlinkSponsor}" NavigateUri="https://github.com/sponsors/huynhsontung" />
+                    <HyperlinkButton Content="{x:Bind strings:Resources.HyperlinkTranslate}" NavigateUri="https://crowdin.com/project/screenbox" />
                 </StackPanel>
 
             </StackPanel>
@@ -703,7 +703,7 @@
 
         <muxc:InfoBar
             x:Name="PendingChangesInfoBar"
-            Title="{strings:Resources Key=PendingChanges}"
+            Title="{x:Bind strings:Resources.PendingChanges}"
             Grid.Row="0"
             Grid.RowSpan="2"
             Margin="{StaticResource ContentPagePadding}"
@@ -711,7 +711,7 @@
             VerticalAlignment="Top"
             IsClosable="False"
             IsOpen="{x:Bind ViewModel.IsRelaunchRequired, Mode=OneWay}"
-            Message="{strings:Resources Key=RelaunchForChangesMessage}"
+            Message="{x:Bind strings:Resources.RelaunchForChangesMessage}"
             Severity="Warning">
             <muxc:InfoBar.Transitions>
                 <TransitionCollection>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -39,26 +39,26 @@
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayGlyph}}"
-                    Text="{strings:Resources Key=Play}" />
+                    Text="{x:Bind strings:Resources.Play}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.PlayNextCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlayAddGlyph}}"
-                    Text="{strings:Resources Key=PlayNext}" />
+                    Text="{x:Bind strings:Resources.PlayNext}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.AddToQueueCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                        Glyph={StaticResource PlaylistMusicGlyph}}"
-                    Text="{strings:Resources Key=AddToQueue}" />
+                    Text="{x:Bind strings:Resources.AddToQueue}" />
 
                 <MenuFlyoutSeparator />
 
                 <MenuFlyoutSubItem
                     x:Name="AddToPlaylistSubMenu"
                     Icon="{ui:SymbolIcon Symbol=Add}"
-                    Text="{strings:Resources Key=AddToPlaylist}" />
+                    Text="{x:Bind strings:Resources.AddToPlaylist}" />
 
                 <MenuFlyoutItem
                     Command="{StaticResource OpenWithCommand}"
@@ -70,24 +70,24 @@
                     Command="{StaticResource ShowPropertiesCommand}"
                     CommandParameter="{Binding}"
                     Icon="{ui:FontIcon Glyph=&#xE946;}"
-                    Text="{strings:Resources Key=Properties}" />
+                    Text="{x:Bind strings:Resources.Properties}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenAlbumCommand}"
                     CommandParameter="{Binding Album}"
                     Icon="{ui:FontIcon Glyph=&#xE93C;}"
-                    Text="{strings:Resources Key=ShowAlbum}"
+                    Text="{x:Bind strings:Resources.ShowAlbum}"
                     Visibility="{Binding Album, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutItem
                     Command="{x:Bind Common.OpenArtistCommand}"
                     CommandParameter="{Binding MainArtist}"
                     Icon="{ui:FontIcon Glyph=&#xE77B;}"
-                    Text="{strings:Resources Key=ShowArtist}"
+                    Text="{x:Bind strings:Resources.ShowArtist}"
                     Visibility="{Binding MainArtist, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
                 <MenuFlyoutSeparator Visibility="{x:Bind Common.IsAdvancedModeEnabled}" />
                 <MenuFlyoutItem
                     CommandParameter="{Binding}"
                     Icon="{ui:SymbolIcon Symbol=Setting}"
-                    Text="{strings:Resources Key=SetPlaybackOptions}"
+                    Text="{x:Bind strings:Resources.SetPlaybackOptions}"
                     Visibility="{x:Bind Common.IsAdvancedModeEnabled}">
                     <MenuFlyoutItem.Command>
                         <commands:SetPlaybackOptionsCommand PlayCommand="{x:Bind ViewModel.PlayCommand}" />
@@ -112,7 +112,7 @@
             Grid.Row="0"
             Margin="{StaticResource ContentPagePadding}"
             AccessKey="{strings:KeyboardResources Key=CommandShuffleAndPlayKey}"
-            AutomationProperties.Name="{strings:Resources Key=ShuffleAndPlay}"
+            AutomationProperties.Name="{x:Bind strings:Resources.ShuffleAndPlay}"
             Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
             Style="{StaticResource AccentButtonStyle}">
             <StackPanel Orientation="Horizontal">
@@ -121,7 +121,7 @@
                     FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
                     Glyph="{StaticResource ShuffleGlyph}"
                     MirroredWhenRightToLeft="True" />
-                <TextBlock Margin="8,0,0,0" Text="{strings:Resources Key=ShuffleAndPlay}" />
+                <TextBlock Margin="8,0,0,0" Text="{x:Bind strings:Resources.ShuffleAndPlay}" />
             </StackPanel>
         </Button>
 
@@ -142,36 +142,36 @@
                         GroupName="SortOrder"
                         IsChecked="True"
                         Tag="title"
-                        Text="{strings:Resources Key=PropertyTitle}" />
+                        Text="{x:Bind strings:Resources.PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="album"
                         GroupName="SortOrder"
                         Tag="album"
-                        Text="{strings:Resources Key=PropertyAlbum}" />
+                        Text="{x:Bind strings:Resources.PropertyAlbum}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="artist"
                         GroupName="SortOrder"
                         Tag="artist"
-                        Text="{strings:Resources Key=Artist}" />
+                        Text="{x:Bind strings:Resources.Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="year"
                         GroupName="SortOrder"
                         Tag="year"
-                        Text="{strings:Resources Key=ReleasedYear}" />
+                        Text="{x:Bind strings:Resources.ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="dateAdded"
                         GroupName="SortOrder"
                         Tag="dateAdded"
-                        Text="{strings:Resources Key=DateAdded}" />
+                        Text="{x:Bind strings:Resources.DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>
             <StackPanel Orientation="Horizontal">
                 <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
-                <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
+                <TextBlock x:Name="SortByText"><Run Text="{x:Bind strings:Resources.SortBy}" /><Run Text=":&#160;" /></TextBlock>
                 <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
             </StackPanel>
         </muxc:DropDownButton>

--- a/Screenbox/Pages/VideosPage.xaml
+++ b/Screenbox/Pages/VideosPage.xaml
@@ -49,21 +49,21 @@
                     x:Name="HeaderNavView"
                     Margin="56,0,16,0"
                     Style="{StaticResource TitleMediumTextBlockStyle}"
-                    Text="{strings:Resources Key=Videos}" />
+                    Text="{x:Bind strings:Resources.Videos}" />
             </muxc:NavigationView.PaneHeader>
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem
                     x:Name="FoldersMenuItem"
                     AccessKey="{strings:KeyboardResources Key=TopNavigationItemFoldersKey}"
                     AutomationProperties.HeadingLevel="Level2"
-                    Content="{strings:Resources Key=VideoFolders}"
+                    Content="{x:Bind strings:Resources.VideoFolders}"
                     FontSize="{StaticResource TopNavigationViewItemFontSize}"
                     Tag="folders" />
                 <muxc:NavigationViewItem
                     x:Name="AllVideosMenuItem"
                     AccessKey="{strings:KeyboardResources Key=TopNavigationItemVideosKey}"
                     AutomationProperties.HeadingLevel="Level2"
-                    Content="{strings:Resources Key=AllVideos}"
+                    Content="{x:Bind strings:Resources.AllVideos}"
                     FontSize="{StaticResource TopNavigationViewItemFontSize}"
                     Tag="all" />
             </muxc:NavigationView.MenuItems>
@@ -73,9 +73,9 @@
                     Margin="{StaticResource ContentPagePadding}"
                     VerticalAlignment="Top"
                     AccessKey="{strings:KeyboardResources Key=CommandAddFolderKey}"
-                    AutomationProperties.Name="{strings:Resources Key=AddFolder}"
+                    AutomationProperties.Name="{x:Bind strings:Resources.AddFolder}"
                     Command="{x:Bind ViewModel.AddFolderCommand}"
-                    ToolTipService.ToolTip="{strings:Resources Key=AddVideoFolderToolTip}"
+                    ToolTipService.ToolTip="{x:Bind strings:Resources.AddVideoFolderToolTip}"
                     Visibility="{x:Bind helpers:DeviceInfoHelper.IsDesktop}">
                     <StackPanel Orientation="Horizontal">
                         <FontIcon
@@ -86,7 +86,7 @@
                         <TextBlock
                             x:Name="HeaderAddFolderButtonText"
                             Margin="8,0,0,0"
-                            Text="{strings:Resources Key=AddFolder}" />
+                            Text="{x:Bind strings:Resources.AddFolder}" />
                     </StackPanel>
                 </Button>
             </muxc:NavigationView.PaneFooter>


### PR DESCRIPTION
UWP Native AOT will not support the `strings:Resources` markup anymore.