### PR TITLE
fix: play queue move up/down command CanExecute status

### DIFF
--- a/Screenbox.Core/ViewModels/PlayQueuePanelViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayQueuePanelViewModel.cs
@@ -1,9 +1,8 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -60,7 +59,7 @@ public sealed partial class PlayQueuePanelViewModel : ObservableRecipient
         Queue.Items.CollectionChanged += ItemsOnCollectionChanged;
 
         Selection.SetItemsSource(Queue.Items);
-        Selection.PropertyChanged += Selection_OnPropertyChanged;
+        Selection.SelectedItemsChanged += Selection_SelectedItemsChanged;
     }
 
     private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -72,15 +71,12 @@ public sealed partial class PlayQueuePanelViewModel : ObservableRecipient
         }
     }
 
-    private void Selection_OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void Selection_SelectedItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(Selection.IsAllSelected))
-        {
-            PlaySelectedNextCommand.NotifyCanExecuteChanged();
-            RemoveSelectedCommand.NotifyCanExecuteChanged();
-            MoveSelectedItemUpCommand.NotifyCanExecuteChanged();
-            MoveSelectedItemDownCommand.NotifyCanExecuteChanged();
-        }
+        PlaySelectedNextCommand.NotifyCanExecuteChanged();
+        RemoveSelectedCommand.NotifyCanExecuteChanged();
+        MoveSelectedItemUpCommand.NotifyCanExecuteChanged();
+        MoveSelectedItemDownCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]
@@ -204,13 +200,13 @@ public sealed partial class PlayQueuePanelViewModel : ObservableRecipient
 
     private bool HasSelection() => Selection.SelectedItems.Count > 0;
 
-    private bool IsSelectedItemNotFirst(IList<object>? selectedItems) =>
-        selectedItems?.Count == 1 &&
-        Queue.Items.Count > 0 && Queue.Items[0] != selectedItems[0];
+    private bool IsSelectedItemNotFirst() =>
+        Selection.SelectedItems.Count == 1 &&
+        Queue.Items.Count > 0 && Queue.Items[0] != Selection.SelectedItems[0];
 
-    private bool IsSelectedItemNotLast(IList<object>? selectedItems) =>
-        selectedItems?.Count == 1 &&
-        Queue.Items.Count > 0 && Queue.Items[Queue.Items.Count - 1] != selectedItems[0];
+    private bool IsSelectedItemNotLast() =>
+        Selection.SelectedItems.Count == 1 &&
+        Queue.Items.Count > 0 && Queue.Items[Queue.Items.Count - 1] != Selection.SelectedItems[0];
 
     private bool IsItemNotFirst(MediaViewModel item) => Queue.Items.Count > 0 && Queue.Items[0] != item;
 

--- a/Screenbox.Core/ViewModels/PlayQueuePanelViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayQueuePanelViewModel.cs
@@ -59,7 +59,7 @@ public sealed partial class PlayQueuePanelViewModel : ObservableRecipient
         Queue.Items.CollectionChanged += ItemsOnCollectionChanged;
 
         Selection.SetItemsSource(Queue.Items);
-        Selection.SelectedItemsChanged += Selection_SelectedItemsChanged;
+        Selection.SelectedItems.CollectionChanged += Selection_SelectedItemsChanged;
     }
 
     private void ItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Screenbox.Core/ViewModels/SelectionViewModel.cs
+++ b/Screenbox.Core/ViewModels/SelectionViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -49,6 +49,9 @@ public sealed partial class SelectionViewModel : ObservableObject
     private bool _isSelectionModeActive;
 
     private IReadOnlyCollection<object>? _sourceCollection;
+
+    /// <inheritdoc cref="ObservableCollection{T}.CollectionChanged"/>
+    public event NotifyCollectionChangedEventHandler? SelectedItemsChanged;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectionViewModel"/> class.
@@ -106,6 +109,7 @@ public sealed partial class SelectionViewModel : ObservableObject
 
     private void SelectedItems_OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
+        SelectedItemsChanged?.Invoke(sender, e);
         RefreshSelectionState();
     }
 

--- a/Screenbox.Core/ViewModels/SelectionViewModel.cs
+++ b/Screenbox.Core/ViewModels/SelectionViewModel.cs
@@ -50,9 +50,6 @@ public sealed partial class SelectionViewModel : ObservableObject
 
     private IReadOnlyCollection<object>? _sourceCollection;
 
-    /// <inheritdoc cref="ObservableCollection{T}.CollectionChanged"/>
-    public event NotifyCollectionChangedEventHandler? SelectedItemsChanged;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectionViewModel"/> class.
     /// </summary>
@@ -109,7 +106,6 @@ public sealed partial class SelectionViewModel : ObservableObject
 
     private void SelectedItems_OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        SelectedItemsChanged?.Invoke(sender, e);
         RefreshSelectionState();
     }
 


### PR DESCRIPTION
Fixes a regression introduced in #870. Evaluating only on `IsAllSelected` changes isn't sufficient.

**Before**

https://github.com/user-attachments/assets/5ee4843f-601b-4143-942a-d476d88ff731

**After**

https://github.com/user-attachments/assets/02e1fe26-2381-422d-9657-06f93f67ed5e