### PR TITLE
fix: F11 keyboard shortcut

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="Screenbox.Controls.PlayerControls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -350,7 +350,10 @@
                             Key="F"
                             x:Name="FullscreenMenuItemKeyboardAccelerator"
                             IsEnabled="False" />
-                        <KeyboardAccelerator Key="F11" />
+                        <KeyboardAccelerator
+                            Key="F11"
+                            x:Name="FullscreenMenuItemFnKeyboardAccelerator"
+                            IsEnabled="False" />
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
             </MenuFlyout>
@@ -573,6 +576,7 @@
                     MirroredWhenRightToLeft="True" />
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="F" />
+                    <KeyboardAccelerator Key="F11" />
                 </Button.KeyboardAccelerators>
             </Button>
             <!--  More  -->
@@ -608,6 +612,7 @@
                         <Setter Target="ExtraOptionsSeparator.Visibility" Value="Visible" />
                         <Setter Target="FullscreenMenuItem.Visibility" Value="Visible" />
                         <Setter Target="FullscreenMenuItemKeyboardAccelerator.IsEnabled" Value="True" />
+                        <Setter Target="FullscreenMenuItemFnKeyboardAccelerator.IsEnabled" Value="True" />
                         <Setter Target="CompactOverlayMenuItem.Visibility" Value="Visible" />
                         <Setter Target="CompactOverlayMenuItemKeyboardAccelerator.IsEnabled" Value="True" />
                     </VisualState.Setters>


### PR DESCRIPTION
Closes #933. The accelerator was only present in the `MenuFlyoutItem`, so it was only functional when resizing the app until the button was hidden and the menu item became active, after that it would work for the remaining of the app lifetime.

I wonder if we should remove both accelerators and implement them the same way we do in the `PlayerPage`, fewer moving parts.