### PR TITLE
最後まで再生し終わったら次のファイルを自動再生する

### DIFF
--- a/Screenbox.Core/Coordinators/PlayQueueCoordinator.cs
+++ b/Screenbox.Core/Coordinators/PlayQueueCoordinator.cs
@@ -795,7 +795,7 @@ public sealed partial class PlayQueueCoordinator : ObservableRecipient, IPlayQue
 
     private void OnEndReached(IMediaPlayer sender, object? args)
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
             var playlist = _playlist;
             var result = _playbackControlService.HandleMediaEnded(playlist, _context.RepeatMode);
@@ -813,6 +813,10 @@ public sealed partial class PlayQueueCoordinator : ObservableRecipient, IPlayQue
             {
                 // Track repeat — restart from the beginning.
                 sender.Position = TimeSpan.Zero;
+            }
+            else if (CanNext())
+            {
+                await NextAsync();
             }
         });
     }

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -366,6 +366,20 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     }
 
     [RelayCommand]
+    private void SeekBackward10()
+    {
+        if (!HasActiveItem || MediaPlayer == null) return;
+        Messenger.Send(new ChangeTimeRequestMessage(TimeSpan.FromSeconds(-10), true, false));
+    }
+
+    [RelayCommand]
+    private void SeekForward30()
+    {
+        if (!HasActiveItem || MediaPlayer == null) return;
+        Messenger.Send(new ChangeTimeRequestMessage(TimeSpan.FromSeconds(30), true, false));
+    }
+
+    [RelayCommand]
     private void SetAspectRatio(string aspect)
     {
         switch (aspect)

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -403,6 +403,27 @@
                     <KeyboardAccelerator Key="Space" Invoked="PlayPauseKeyboardAccelerator_OnInvoked" />
                 </Button.KeyboardAccelerators>
             </Button>
+            <!--  Seek backward 10s / forward 30s  -->
+            <StackPanel FlowDirection="LeftToRight" Orientation="Horizontal">
+                <Button
+                    x:Name="SeekBackward10Button"
+                    Margin="0,0,4,0"
+                    extensions:AcceleratorService.ToolTip="10秒戻る"
+                    AutomationProperties.Name="{x:Bind SeekBackward10Button.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
+                    Command="{x:Bind ViewModel.SeekBackward10Command}"
+                    Style="{StaticResource PlayerButtonStyle}">
+                    <FontIcon Glyph="&#xEB9E;" />
+                </Button>
+                <Button
+                    x:Name="SeekForward30Button"
+                    Margin="0,0,4,0"
+                    extensions:AcceleratorService.ToolTip="30秒進む"
+                    AutomationProperties.Name="{x:Bind SeekForward30Button.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
+                    Command="{x:Bind ViewModel.SeekForward30Command}"
+                    Style="{StaticResource PlayerButtonStyle}">
+                    <FontIcon Glyph="&#xEB9D;" />
+                </Button>
+            </StackPanel>
             <!--  Previous/Next  -->
             <StackPanel FlowDirection="LeftToRight" Orientation="Horizontal">
                 <Button

--- a/Screenbox/Package.appxmanifest
+++ b/Screenbox/Package.appxmanifest
@@ -17,7 +17,7 @@
   <mp:PhoneIdentity PhoneProductId="13f69037-4fca-4b86-a6f5-a77c0969d41a" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
-    <DisplayName>[Debug] Screenbox</DisplayName>
+    <DisplayName>Screenbox</DisplayName>
     <PublisherDisplayName>Tung H.</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -36,7 +36,7 @@
       EntryPoint="Screenbox.App"
       desktop4:SupportsMultipleInstances="true">
       <uap:VisualElements
-        DisplayName="[Debug] Screenbox"
+        DisplayName="Screenbox"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"
         Description="ms-resource:ManifestResources/AppDescription"


### PR DESCRIPTION
## 変更内容

- 現在のファイルの再生が終了した際、次のファイルが存在する場合は自動的に再生を続行するようにしました
- 隣接ファイル（同じフォルダ内の次のファイル）も含めて自動再生の対象となります

## 修正詳細

`PlayQueueCoordinator.OnEndReached` において、再生終了時に `HandleMediaEnded` が null を返し、かつトラックリピートモードでない場合、`CanNext()` が true であれば `NextAsync()` を呼び出すようにしました。

これにより:
- プレイリスト内の次の動画が自動再生される
- 単一ファイル再生時は同じフォルダの次のファイルが自動再生される（隣接ファイル設定が有効な場合）
