### PR TITLE
refactor: grouped templates to enable x:Bind

### DIFF
--- a/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -12,20 +13,23 @@ using Screenbox.Core.Messages;
 
 namespace Screenbox.Core.ViewModels;
 
+/// <summary>
+/// Represents the view model for the artist details page.
+/// </summary>
 public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
 {
+    /// <summary>
+    /// Gets the albums grouped with their related media items.
+    /// </summary>
+    /// <value>The grouped collection of albums and associated songs.</value>
+    public ObservableGroupedCollection<AlbumViewModel, MediaViewModel> GroupedAlbums { get; }
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(TotalDuration))]
     [NotifyPropertyChangedFor(nameof(SongsCount))]
     private ArtistViewModel? _source;
 
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(AlbumsCount))]
-    private List<IGrouping<AlbumViewModel?, MediaViewModel>> _albums;
-
     public TimeSpan TotalDuration => Source != null ? GetTotalDuration(Source.RelatedSongs) : TimeSpan.Zero;
-
-    public int AlbumsCount => Albums.Count;
 
     public int SongsCount => Source?.RelatedSongs.Count ?? 0;
 
@@ -33,7 +37,7 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
 
     public ArtistDetailsPageViewModel()
     {
-        _albums = new List<IGrouping<AlbumViewModel?, MediaViewModel>>();
+        GroupedAlbums = new ObservableGroupedCollection<AlbumViewModel, MediaViewModel>();
     }
 
     public void OnNavigatedTo(object? parameter)
@@ -48,19 +52,23 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
 
     async partial void OnSourceChanged(ArtistViewModel? value)
     {
-        if (value == null)
+        if (value is null)
         {
-            Albums = new List<IGrouping<AlbumViewModel?, MediaViewModel>>();
+            GroupedAlbums.Clear();
             return;
         }
 
-        Albums = value.RelatedSongs
+        List<IGrouping<AlbumViewModel, MediaViewModel>> albumGroups = value.RelatedSongs
             .OrderBy(m => m.MediaInfo.MusicProperties.TrackNumber)
             .ThenBy(m => m.Name, StringComparer.CurrentCulture)
             .GroupBy(m => m.Album)
-            .OrderByDescending(g => g.Key?.Year ?? 0).ToList();
+            .OrderByDescending(g => g.Key?.Year ?? 0)
+            .ToList();
 
-        IEnumerable<Task> loadingTasks = Albums.Where(g => g.Key is { AlbumArt: null })
+        GroupedAlbums.SyncObservableGroups(albumGroups);
+
+        IEnumerable<Task> loadingTasks = albumGroups
+            .Where(g => g.Key is { AlbumArt: null })
             .Select(g => g.Key?.LoadAlbumArtAsync())
             .OfType<Task>();
         await Task.WhenAll(loadingTasks);
@@ -69,7 +77,7 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
     [RelayCommand]
     private void Play(MediaViewModel? media)
     {
-        _itemList ??= Albums.SelectMany(g => g).ToList();
+        _itemList ??= GroupedAlbums.SelectMany<IGrouping<AlbumViewModel, MediaViewModel>, MediaViewModel>(g => g).ToList();
         Messenger.SendQueueAndPlay(media ?? _itemList[0], _itemList);
     }
 

--- a/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistDetailsPageViewModel.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Mvvm.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using Screenbox.Core.Contexts;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 
@@ -33,10 +34,13 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
 
     public int SongsCount => Source?.RelatedSongs.Count ?? 0;
 
+    private readonly LibraryContext _libraryContext;
+
     private List<MediaViewModel>? _itemList;
 
-    public ArtistDetailsPageViewModel()
+    public ArtistDetailsPageViewModel(LibraryContext libraryContext)
     {
+        _libraryContext = libraryContext;
         GroupedAlbums = new ObservableGroupedCollection<AlbumViewModel, MediaViewModel>();
     }
 
@@ -61,7 +65,7 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
         List<IGrouping<AlbumViewModel, MediaViewModel>> albumGroups = value.RelatedSongs
             .OrderBy(m => m.MediaInfo.MusicProperties.TrackNumber)
             .ThenBy(m => m.Name, StringComparer.CurrentCulture)
-            .GroupBy(m => m.Album)
+            .GroupBy(m => m.Album ?? _libraryContext.Music.UnknownAlbum)
             .OrderByDescending(g => g.Key?.Year ?? 0)
             .ToList();
 
@@ -77,7 +81,7 @@ public sealed partial class ArtistDetailsPageViewModel : ObservableRecipient
     [RelayCommand]
     private void Play(MediaViewModel? media)
     {
-        _itemList ??= GroupedAlbums.SelectMany<IGrouping<AlbumViewModel, MediaViewModel>, MediaViewModel>(g => g).ToList();
+        _itemList ??= GroupedAlbums.SelectMany<IGrouping<AlbumViewModel, MediaViewModel>, MediaViewModel>(static g => g).ToList();
         Messenger.SendQueueAndPlay(media ?? _itemList[0], _itemList);
     }
 

--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -62,7 +62,6 @@
                         x:Key="BoolToPlayPauseTextConverter"
                         FalseValue="{strings:Resources Key=Play}"
                         TrueValue="{strings:Resources Key=Pause}" />
-                    <converters:DefaultStringConverter x:Key="AlbumTextConverter" Default="{strings:Resources Key=UnknownAlbum}" />
 
                     <!--  Font sizes  -->
                     <x:Double x:Key="TopNavigationViewItemFontSize">18</x:Double>

--- a/Screenbox/App.xaml
+++ b/Screenbox/App.xaml
@@ -58,12 +58,6 @@
                         EmptyValue="Collapsed"
                         NotEmptyValue="Visible" />
                     <ctConverters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" />
-                    <ctConverters:DoubleToObjectConverter
-                        x:Key="DoubleToBoolConverter"
-                        FalseValue="False"
-                        GreaterThan="0"
-                        NullValue="False"
-                        TrueValue="True" />
                     <ctConverters:BoolToObjectConverter
                         x:Key="BoolToPlayPauseTextConverter"
                         FalseValue="{strings:Resources Key=Play}"
@@ -128,23 +122,6 @@
                         <Setter Property="FontSize" Value="{StaticResource TitleMediumTextBlockFontSize}" />
                         <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
                     </Style>
-
-                    <!--  Semantic zoom group-level style  -->
-                    <DataTemplate x:Key="GroupOverviewLetterItemTemplate">
-                        <Button
-                            MinWidth="{StaticResource GridViewHeaderItemMinHeight}"
-                            MinHeight="{StaticResource GridViewHeaderItemMinHeight}"
-                            HorizontalAlignment="Stretch"
-                            Background="Transparent"
-                            BorderBrush="Transparent"
-                            ClickMode="Hover"
-                            IsEnabled="{Binding Group.Count, Converter={StaticResource DoubleToBoolConverter}, Mode=OneWay}">
-                            <TextBlock
-                                Style="{StaticResource SubtitleTextBlockStyle}"
-                                Text="{Binding Group.Key}"
-                                TextWrapping="NoWrap" />
-                        </Button>
-                    </DataTemplate>
                 </ResourceDictionary>
 
                 <ResourceDictionary Source="ms-appx:///Controls/ContentUnavailableView/ContentUnavailableView.xaml" />

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -20,19 +20,13 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <templates:GridViewItemTemplates />
+                <templates:GroupedViewTemplates />
             </ResourceDictionary.MergedDictionaries>
 
             <CollectionViewSource
                 x:Name="AlbumsSource"
                 IsSourceGrouped="True"
                 Source="{x:Bind ViewModel.GroupedAlbums}" />
-
-            <DataTemplate x:Key="GroupHeaderTemplate">
-                <TextBlock
-                    FontWeight="SemiBold"
-                    Text="{Binding Key}"
-                    TextTrimming="CharacterEllipsis" />
-            </DataTemplate>
 
             <MenuFlyout x:Key="AlbumFlyout">
                 <MenuFlyoutItem Command="{Binding PlayAlbumCommand}" Text="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}">

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -65,8 +65,8 @@
 
                     <StackPanel Grid.Column="1">
                         <TextBlock
-                            FontWeight="SemiBold"
                             FontSize="{StaticResource BodyTextBlockFontSize}"
+                            FontWeight="SemiBold"
                             Text="{x:Bind converters:DefaultStringConverter.GetValueOrFallback(Key.(viewModels:AlbumViewModel.Name), strings:Resources.UnknownAlbum)}"
                             TextTrimming="CharacterEllipsis">
                             <interactivity:Interaction.Behaviors>

--- a/Screenbox/Pages/ArtistDetailsPage.xaml
+++ b/Screenbox/Pages/ArtistDetailsPage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Screenbox.Behaviors"
+    xmlns:collections="using:CommunityToolkit.Mvvm.Collections"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
@@ -11,8 +12,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
+    xmlns:templates="using:Screenbox.Templates"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:viewModels="using:Screenbox.Core.ViewModels"
     Loaded="ArtistDetailsPage_OnLoaded"
     mc:Ignorable="d">
 
@@ -20,94 +23,62 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///Styles/CommandBar.xaml" />
+                <templates:GroupedViewTemplates />
             </ResourceDictionary.MergedDictionaries>
 
             <CollectionViewSource
                 x:Name="AlbumSource"
                 IsSourceGrouped="True"
-                Source="{x:Bind ViewModel.Albums}" />
+                Source="{x:Bind ViewModel.GroupedAlbums}" />
 
-            <DataTemplate x:Key="AlbumGroupHeaderTemplate">
-                <UserControl>
-                    <StackPanel
-                        x:Name="HeaderRootStackPanel"
-                        Width="160"
-                        Margin="0,0,12,24"
-                        Orientation="Vertical">
-                        <Grid
-                            x:Name="AlbumArtGrid"
-                            Width="160"
-                            Height="160"
-                            BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}"
-                            BorderThickness="1"
+            <DataTemplate x:Key="AlbumTopGroupHeaderTemplate" x:DataType="collections:IReadOnlyObservableGroup">
+                <Grid Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Grid
+                        Grid.Column="0"
+                        Width="72"
+                        Height="72"
+                        Margin="0,0,8,0"
+                        BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource ControlCornerRadius}"
+                        FlowDirection="LeftToRight"
+                        Shadow="{StaticResource ElevationThemeShadow}"
+                        Translation="0,0,8">
+                        <Grid.Background>
+                            <ImageBrush ImageSource="{x:Bind ((viewModels:AlbumViewModel)Key).AlbumArt, Mode=OneWay}" Stretch="UniformToFill" />
+                        </Grid.Background>
+                        <Border
+                            Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
                             CornerRadius="{StaticResource ControlCornerRadius}"
-                            FlowDirection="LeftToRight"
-                            Shadow="{StaticResource ElevationThemeShadow}"
-                            Translation="0,0,8">
-                            <Grid.Background>
-                                <ImageBrush ImageSource="{Binding Key.AlbumArt}" Stretch="UniformToFill" />
-                            </Grid.Background>
-                            <Border
-                                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
-                                CornerRadius="{StaticResource ControlCornerRadius}"
-                                Visibility="{Binding Key.AlbumArt, Converter={StaticResource EmptyObjectToVisibilityConverter}, ConverterParameter=true}">
-                                <FontIcon
-                                    x:Name="AlbumArtIcon"
-                                    FontSize="{StaticResource GridItemPlaceholderIconFontSize}"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    Glyph="&#xE93C;" />
-                            </Border>
-                        </Grid>
+                            Visibility="{x:Bind ((viewModels:AlbumViewModel)Key).AlbumArt, Converter={StaticResource EmptyObjectToVisibilityConverter}, ConverterParameter=true, Mode=OneWay}">
+                            <FontIcon
+                                FontSize="32"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Glyph="&#xE93C;" />
+                        </Border>
+                    </Grid>
 
-                        <StackPanel
-                            x:Name="TextPanel"
-                            Margin="0,4,0,0"
-                            Padding="8,0"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Top"
-                            Orientation="Vertical">
-                            <TextBlock
-                                x:Name="AlbumTitle"
-                                MaxLines="2"
-                                Style="{StaticResource BodyStrongTextBlockStyle}"
-                                Text="{Binding Key.Name, Converter={StaticResource AlbumTextConverter}, FallbackValue={strings:Resources Key=UnknownAlbum}}">
-                                <interactivity:Interaction.Behaviors>
-                                    <behaviors:OverflowTextToolTipBehavior />
-                                </interactivity:Interaction.Behaviors>
-                            </TextBlock>
-                            <TextBlock
-                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{Binding Key.Year}"
-                                Visibility="{Binding Text, RelativeSource={RelativeSource Self}, Converter={StaticResource StringVisibilityConverter}}" />
-                        </StackPanel>
-
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Top">
-                                    <VisualState.StateTriggers>
-                                        <triggers:IsEqualStateTrigger Value="{Binding GroupHeaderPlacement, ElementName=ItemsStackPanel}">
-                                            <triggers:IsEqualStateTrigger.To>
-                                                <GroupHeaderPlacement>Top</GroupHeaderPlacement>
-                                            </triggers:IsEqualStateTrigger.To>
-                                        </triggers:IsEqualStateTrigger>
-                                    </VisualState.StateTriggers>
-                                    <VisualState.Setters>
-                                        <Setter Target="HeaderRootStackPanel.Width" Value="Auto" />
-                                        <Setter Target="HeaderRootStackPanel.Margin" Value="0,8,0,8" />
-                                        <Setter Target="HeaderRootStackPanel.Orientation" Value="Horizontal" />
-                                        <Setter Target="AlbumArtGrid.Width" Value="72" />
-                                        <Setter Target="AlbumArtGrid.Height" Value="72" />
-                                        <Setter Target="AlbumArtIcon.FontSize" Value="32" />
-                                        <Setter Target="TextPanel.Margin" Value="8,0,0,0" />
-                                        <Setter Target="TextPanel.Padding" Value="0,0" />
-                                        <!--<Setter Target="AlbumTitle.FontSize" Value="{StaticResource SubtitleTextBlockFontSize}" />-->
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock
+                            FontWeight="SemiBold"
+                            FontSize="{StaticResource BodyTextBlockFontSize}"
+                            Text="{x:Bind converters:DefaultStringConverter.GetValueOrFallback(Key.(viewModels:AlbumViewModel.Name), strings:Resources.UnknownAlbum)}"
+                            TextTrimming="CharacterEllipsis">
+                            <interactivity:Interaction.Behaviors>
+                                <behaviors:OverflowTextToolTipBehavior />
+                            </interactivity:Interaction.Behaviors>
+                        </TextBlock>
+                        <TextBlock
+                            FontSize="{StaticResource CaptionTextBlockFontSize}"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Text="{x:Bind ((viewModels:AlbumViewModel)Key).Year}" />
                     </StackPanel>
-                </UserControl>
+                </Grid>
             </DataTemplate>
 
             <MenuFlyout x:Key="ItemFlyout">
@@ -244,7 +215,7 @@
                         Margin="0,8,0,0"
                         FontWeight="Normal"
                         Style="{StaticResource SubtitleTextBlockStyle}"
-                        Text="{x:Bind GetSubtext(ViewModel.AlbumsCount, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}"
+                        Text="{x:Bind GetSubtext(ViewModel.GroupedAlbums.Count, ViewModel.SongsCount, ViewModel.TotalDuration), Mode=OneWay}"
                         TextWrapping="NoWrap">
                         <interactivity:Interaction.Behaviors>
                             <behaviors:OverflowTextToolTipBehavior />
@@ -336,13 +307,14 @@
                     <ItemsStackPanel
                         x:Name="ItemsStackPanel"
                         AreStickyGroupHeadersEnabled="False"
-                        GroupHeaderPlacement="Top" />
+                        GroupHeaderPlacement="Top"
+                        GroupPadding="{StaticResource TopMediumMargin}" />
                 </ItemsPanelTemplate>
             </ListView.ItemsPanel>
             <ListView.GroupStyle>
-                <GroupStyle HeaderTemplate="{StaticResource AlbumGroupHeaderTemplate}" HidesIfEmpty="True">
+                <GroupStyle HeaderTemplate="{StaticResource AlbumTopGroupHeaderTemplate}" HidesIfEmpty="True">
                     <GroupStyle.HeaderContainerStyle>
-                        <!--  Remove margin, padding, bottom divider and from navigation  -->
+                        <!--  ListViewHeaderItem without margin, padding, and bottom divider, removed from tab navigation.  -->
                         <Style TargetType="ListViewHeaderItem">
                             <Setter Property="Margin" Value="0,0,0,0" />
                             <Setter Property="Padding" Value="0,0,0,0" />

--- a/Screenbox/Pages/ArtistsPage.xaml
+++ b/Screenbox/Pages/ArtistsPage.xaml
@@ -17,16 +17,13 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <templates:GridViewItemTemplates />
+                <templates:GroupedViewTemplates />
             </ResourceDictionary.MergedDictionaries>
 
             <CollectionViewSource
                 x:Name="ArtistsSource"
                 IsSourceGrouped="True"
                 Source="{x:Bind ViewModel.GroupedArtists}" />
-
-            <DataTemplate x:Key="GroupHeaderTemplate">
-                <TextBlock FontWeight="SemiBold" Text="{Binding Key}" />
-            </DataTemplate>
 
             <MenuFlyout x:Key="ArtistFlyout">
                 <MenuFlyoutItem Command="{Binding PlayArtistCommand}" Text="{Binding IsPlaying, Converter={StaticResource BoolToPlayPauseTextConverter}}">

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Screenbox.Pages.SongsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,23 +11,21 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
+    xmlns:templates="using:Screenbox.Templates"
     xmlns:triggers="using:CommunityToolkit.WinUI"
     xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
 
     <Page.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <templates:GroupedViewTemplates />
+            </ResourceDictionary.MergedDictionaries>
+
             <CollectionViewSource
                 x:Name="SongsSource"
                 IsSourceGrouped="True"
                 Source="{x:Bind ViewModel.GroupedSongs}" />
-
-            <DataTemplate x:Key="GroupHeaderTemplate">
-                <TextBlock
-                    FontWeight="SemiBold"
-                    Text="{Binding Key}"
-                    TextTrimming="CharacterEllipsis" />
-            </DataTemplate>
 
             <MenuFlyout x:Key="ItemFlyout">
                 <interactivity:Interaction.Behaviors>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -333,6 +333,9 @@
     <Compile Include="Templates\GridViewItemTemplates.xaml.cs">
       <DependentUpon>GridViewItemTemplates.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Templates\GroupedViewTemplates.xaml.cs">
+      <DependentUpon>GroupedViewTemplates.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Templates\SearchSuggestionTemplateSelector.cs" />
     <Compile Include="ViewModels\NotificationViewModel.cs" />
     <Compile Include="ViewModels\PropertyViewModel.cs" />
@@ -784,6 +787,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Templates\GridViewItemTemplates.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Templates\GroupedViewTemplates.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Screenbox/Templates/GroupedViewTemplates.xaml
+++ b/Screenbox/Templates/GroupedViewTemplates.xaml
@@ -1,0 +1,40 @@
+<ResourceDictionary
+    x:Class="Screenbox.Templates.GroupedViewTemplates"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Screenbox.Behaviors"
+    xmlns:collections="using:CommunityToolkit.Mvvm.Collections"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:local="using:Screenbox.Templates">
+
+    <!--  ListViewBase Header  -->
+    <DataTemplate x:Key="GroupHeaderTemplate" x:DataType="collections:IReadOnlyObservableGroup">
+        <TextBlock
+            FontWeight="SemiBold"
+            Text="{x:Bind (x:String)Key}"
+            TextTrimming="CharacterEllipsis">
+            <interactivity:Interaction.Behaviors>
+                <behaviors:OverflowTextToolTipBehavior />
+            </interactivity:Interaction.Behaviors>
+        </TextBlock>
+    </DataTemplate>
+
+    <!--  SemanticZoom ZoomedOutView  -->
+    <DataTemplate x:Key="GroupOverviewLetterItemTemplate" x:DataType="ICollectionViewGroup">
+        <Button
+            MinWidth="{StaticResource GridViewHeaderItemMinHeight}"
+            MinHeight="{StaticResource GridViewHeaderItemMinHeight}"
+            HorizontalAlignment="Stretch"
+            ClickMode="Hover"
+            FontSize="{StaticResource SubtitleTextBlockFontSize}"
+            FontWeight="SemiBold"
+            IsEnabled="{x:Bind local:GroupedViewTemplates.IsIntegerNormal(Group.(collections:IReadOnlyObservableGroup.Count)), Mode=OneWay}"
+            Style="{StaticResource SubtleButtonStyle}">
+            <TextBlock Text="{x:Bind (x:String)((collections:IReadOnlyObservableGroup)Group).Key}" TextTrimming="CharacterEllipsis">
+                <interactivity:Interaction.Behaviors>
+                    <behaviors:OverflowTextToolTipBehavior />
+                </interactivity:Interaction.Behaviors>
+            </TextBlock>
+        </Button>
+    </DataTemplate>
+</ResourceDictionary>

--- a/Screenbox/Templates/GroupedViewTemplates.xaml.cs
+++ b/Screenbox/Templates/GroupedViewTemplates.xaml.cs
@@ -1,0 +1,16 @@
+namespace Screenbox.Templates;
+
+public sealed partial class GroupedViewTemplates
+{
+    public GroupedViewTemplates()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Determines if a value is normal.</summary>
+    /// <param name="value">The value to be checked.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is normal; otherwise, <see langword="false"/>.</returns>
+    /// <seealso href="https://learn.microsoft.com/dotnet/api/system.int32.system-numerics-inumberbase-system-int32--isnormal"/>
+    /// <seealso href="https://github.com/dotnet/dotnet/blob/v11.0.0/src/runtime/src/libraries/System.Private.CoreLib/src/System/Int32.cs#L804"/>
+    public static bool IsIntegerNormal(int value) => value != 0;
+}


### PR DESCRIPTION
This PR continues the work started in #927, updating our grouped collection implementation to support `x:Bind` following the official [documentation](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/observablegroupedcollections#working-with-observablegroupedcollectiontkey-telement).

The `AlbumGroupHeaderTemplate` template has been streamlined to reflect the single supported group header placement and to reduce unnecessary layout complexity.

**Known Issue**

- The `GroupHeaderTemplate` screen reader name is still not working correctly. I had hoped this would finally allow us to fix it. Every example I've checked suffers from the same issue, so I have no idea how the Media Player gets it right.