### PR TITLE
feat: add chapter button with selectable chapter list

### DIFF
--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -43,7 +43,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     [ObservableProperty] private bool _isPlaying;
     [ObservableProperty] private bool _isFullscreen;
     [ObservableProperty] private string? _titleName; // TODO: Handle VLC title name
-    [ObservableProperty] private string? _chapterName;
     [ObservableProperty] private ChapterCue? _currentChapterCue;
     [ObservableProperty] private double _playbackRate;
     [ObservableProperty] private double _audioTimingOffset;
@@ -308,11 +307,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
 
     private void OnChapterChanged(IMediaPlayer sender, ValueChangedEventArgs<ChapterCue?> args)
     {
-        _dispatcherQueue.TryEnqueue(() =>
-        {
-            ChapterName = sender.Chapter?.Title;
-            CurrentChapterCue = args.NewValue;
-        });
+        _dispatcherQueue.TryEnqueue(() => { CurrentChapterCue = args.NewValue; });
     }
 
     public void Receive(PropertyChangedMessage<WindowViewMode> message)

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.ComponentModel;
@@ -11,11 +11,13 @@ using CommunityToolkit.Mvvm.Messaging.Messages;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Coordinators;
 using Screenbox.Core.Enums;
+using Screenbox.Core.Events;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
 using Windows.Foundation;
+using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage;
 using Windows.System;
@@ -42,6 +44,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     [ObservableProperty] private bool _isFullscreen;
     [ObservableProperty] private string? _titleName; // TODO: Handle VLC title name
     [ObservableProperty] private string? _chapterName;
+    [ObservableProperty] private ChapterCue? _currentChapterCue;
     [ObservableProperty] private double _playbackRate;
     [ObservableProperty] private double _audioTimingOffset;
     [ObservableProperty] private double _subtitleTimingOffset;
@@ -303,9 +306,13 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         });
     }
 
-    private void OnChapterChanged(IMediaPlayer sender, object? args)
+    private void OnChapterChanged(IMediaPlayer sender, ValueChangedEventArgs<ChapterCue?> args)
     {
-        _dispatcherQueue.TryEnqueue(() => ChapterName = sender.Chapter?.Title);
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            ChapterName = sender.Chapter?.Title;
+            CurrentChapterCue = args.NewValue;
+        });
     }
 
     public void Receive(PropertyChangedMessage<WindowViewMode> message)
@@ -431,6 +438,14 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         {
             MediaPlayer?.Play();
         }
+    }
+
+    [RelayCommand(CanExecute = nameof(HasActiveItem))]
+    private void NavigateToChapter(ChapterCue? chapter)
+    {
+        if (chapter is null || MediaPlayer is null) return;
+
+        MediaPlayer.Position = chapter.StartTime;
     }
 
     /// <summary>

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -11,13 +11,11 @@ using CommunityToolkit.Mvvm.Messaging.Messages;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Coordinators;
 using Screenbox.Core.Enums;
-using Screenbox.Core.Events;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Messages;
 using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
 using Windows.Foundation;
-using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage;
 using Windows.System;
@@ -43,7 +41,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     [ObservableProperty] private bool _isPlaying;
     [ObservableProperty] private bool _isFullscreen;
     [ObservableProperty] private string? _titleName; // TODO: Handle VLC title name
-    [ObservableProperty] private ChapterCue? _currentChapterCue;
     [ObservableProperty] private double _playbackRate;
     [ObservableProperty] private double _audioTimingOffset;
     [ObservableProperty] private double _subtitleTimingOffset;
@@ -97,7 +94,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         if (MediaPlayer != null)
         {
             MediaPlayer.PlaybackStateChanged += OnPlaybackStateChanged;
-            MediaPlayer.ChapterChanged += OnChapterChanged;
             MediaPlayer.NaturalVideoSizeChanged += OnNaturalVideoSizeChanged;
         }
 
@@ -123,14 +119,12 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         if (message.OldValue is { } oldPlayer)
         {
             oldPlayer.PlaybackStateChanged -= OnPlaybackStateChanged;
-            oldPlayer.ChapterChanged -= OnChapterChanged;
             oldPlayer.NaturalVideoSizeChanged -= OnNaturalVideoSizeChanged;
         }
 
         if (MediaPlayer != null)
         {
             MediaPlayer.PlaybackStateChanged += OnPlaybackStateChanged;
-            MediaPlayer.ChapterChanged += OnChapterChanged;
             MediaPlayer.NaturalVideoSizeChanged += OnNaturalVideoSizeChanged;
         }
     }
@@ -305,11 +299,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         });
     }
 
-    private void OnChapterChanged(IMediaPlayer sender, ValueChangedEventArgs<ChapterCue?> args)
-    {
-        _dispatcherQueue.TryEnqueue(() => { CurrentChapterCue = args.NewValue; });
-    }
-
     public void Receive(PropertyChangedMessage<WindowViewMode> message)
     {
         if (message.Sender is not WindowContext) return;
@@ -433,14 +422,6 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         {
             MediaPlayer?.Play();
         }
-    }
-
-    [RelayCommand(CanExecute = nameof(HasActiveItem))]
-    private void NavigateToChapter(ChapterCue? chapter)
-    {
-        if (chapter is null || MediaPlayer is null) return;
-
-        MediaPlayer.Position = chapter.StartTime;
     }
 
     /// <summary>

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -310,7 +310,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     {
         _dispatcherQueue.TryEnqueue(() =>
         {
-            ChapterName = sender.Chapter?.Title;
+            ChapterName = sender.Chapter?.Title.TrimStart();
             CurrentChapterCue = args.NewValue;
         });
     }

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -310,7 +310,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     {
         _dispatcherQueue.TryEnqueue(() =>
         {
-            ChapterName = sender.Chapter?.Title.TrimStart();
+            ChapterName = sender.Chapter?.Title;
             CurrentChapterCue = args.NewValue;
         });
     }

--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -229,12 +229,14 @@ public sealed partial class SeekBarViewModel :
         UpdateProgress(newPosition);
     }
 
+    /// <summary>
+    /// Seeks the media playback position to the specified chapter.
+    /// </summary>
+    /// <param name="chapter">The chapter to seek.</param>
     [RelayCommand]
-    private void SeekToChapter(ChapterCue? chapter)
+    private void SeekToChapter(ChapterCue chapter)
     {
-        if (chapter is null) return;
-
-        UpdatePosition(chapter.StartTime, isOffset: false, debounce: false);
+        Messenger.Send(new ChangeTimeRequestMessage(chapter.StartTime, debounce: false));
     }
 
     private void RestoreLastPosition(MediaViewModel media)

--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using CommunityToolkit.WinUI;
@@ -45,6 +46,8 @@ public sealed partial class SeekBarViewModel :
     [ObservableProperty] private bool _shouldShowPreview;
 
     [ObservableProperty] private bool _shouldHandleKeyDown;
+
+    [ObservableProperty] private ChapterCue? _currentChapterCue;
 
     public ObservableCollection<ChapterCue> Chapters { get; }
 
@@ -90,6 +93,7 @@ public sealed partial class SeekBarViewModel :
             MediaPlayer.PlaybackStateChanged += OnPlaybackStateChanged;
             MediaPlayer.NaturalDurationChanged += OnNaturalDurationChanged;
             MediaPlayer.PositionChanged += OnPositionChanged;
+            MediaPlayer.ChapterChanged += OnChapterChanged;
             MediaPlayer.MediaEnded += OnEndReached;
             MediaPlayer.BufferingStarted += OnBufferingStarted;
             MediaPlayer.BufferingEnded += OnBufferingEnded;
@@ -133,6 +137,7 @@ public sealed partial class SeekBarViewModel :
             oldPlayer.PlaybackStateChanged -= OnPlaybackStateChanged;
             oldPlayer.NaturalDurationChanged -= OnNaturalDurationChanged;
             oldPlayer.PositionChanged -= OnPositionChanged;
+            oldPlayer.ChapterChanged -= OnChapterChanged;
             oldPlayer.MediaEnded -= OnEndReached;
             oldPlayer.BufferingStarted -= OnBufferingStarted;
             oldPlayer.BufferingEnded -= OnBufferingEnded;
@@ -145,6 +150,7 @@ public sealed partial class SeekBarViewModel :
             MediaPlayer.PlaybackStateChanged += OnPlaybackStateChanged;
             MediaPlayer.NaturalDurationChanged += OnNaturalDurationChanged;
             MediaPlayer.PositionChanged += OnPositionChanged;
+            MediaPlayer.ChapterChanged += OnChapterChanged;
             MediaPlayer.MediaEnded += OnEndReached;
             MediaPlayer.BufferingStarted += OnBufferingStarted;
             MediaPlayer.BufferingEnded += OnBufferingEnded;
@@ -221,6 +227,14 @@ public sealed partial class SeekBarViewModel :
         }
 
         UpdateProgress(newPosition);
+    }
+
+    [RelayCommand]
+    private void SeekToChapter(ChapterCue? chapter)
+    {
+        if (chapter is null) return;
+
+        UpdatePosition(chapter.StartTime, isOffset: false, debounce: false);
     }
 
     private void RestoreLastPosition(MediaViewModel media)
@@ -309,6 +323,7 @@ public sealed partial class SeekBarViewModel :
             {
                 IsSeekable = false;
                 Time = 0;
+                CurrentChapterCue = null;
                 Chapters.Clear();
             });
         }
@@ -317,6 +332,7 @@ public sealed partial class SeekBarViewModel :
             _dispatcherQueue.TryEnqueue(() =>
             {
                 Time = 0;
+                CurrentChapterCue = null;
                 Chapters.Clear();
             });
         }
@@ -345,6 +361,15 @@ public sealed partial class SeekBarViewModel :
         {
             Time = sender.Position.TotalMilliseconds;
         });
+    }
+
+    private void OnChapterChanged(IMediaPlayer sender, ValueChangedEventArgs<ChapterCue?> args)
+    {
+        // Small delay to prevent boundary retriggers.
+        _originalPositionTimer.Debounce(() =>
+        {
+            CurrentChapterCue = args.NewValue;
+        }, TimeSpan.FromMilliseconds(100));
     }
 
     private void OnNaturalDurationChanged(IMediaPlayer sender, object? args)

--- a/Screenbox/Controls/ChapterPickerControl.xaml
+++ b/Screenbox/Controls/ChapterPickerControl.xaml
@@ -1,0 +1,70 @@
+<UserControl
+    x:Class="Screenbox.Controls.ChapterPickerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:core="using:Screenbox.Core"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Screenbox.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mediaCore="using:Windows.Media.Core"
+    xmlns:strings="using:Screenbox.Strings"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    d:DesignHeight="224"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+
+    <Grid Width="224">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid
+            Grid.Row="0"
+            MinHeight="{StaticResource ListViewItemMinHeight}"
+            BorderBrush="{ThemeResource SystemControlForegroundTransparentBrush}"
+            BorderThickness="0,0,0,1">
+            <TextBlock
+                Padding="16,0,0,0"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="Chapters"
+                TextWrapping="NoWrap" />
+        </Grid>
+
+        <ListView
+            x:Name="ChapterList"
+            Grid.Row="1"
+            MaxHeight="400"
+            ui:ListViewExtensions.Command="{x:Bind ChapterSelectedCommand}"
+            IsItemClickEnabled="True"
+            ItemContainerTransitions="{x:Null}"
+            ItemsSource="{x:Bind ChaptersSource}"
+            Loaded="ChapterList_OnLoaded"
+            SelectedItem="{x:Bind SelectedChapter, Mode=TwoWay}"
+            SelectionMode="Single"
+            SingleSelectionFollowsFocus="False">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="mediaCore:ChapterCue">
+                    <Grid AutomationProperties.Name="{x:Bind Title}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0" Text="{x:Bind Title}" />
+
+                        <TextBlock
+                            Grid.Column="1"
+                            Padding="4,2,0,0"
+                            FontSize="{StaticResource CaptionTextBlockFontSize}"
+                            Opacity="{ThemeResource TextFillColorSecondaryOpacity}"
+                            Text="{x:Bind core:Humanizer.ToDuration(StartTime)}"
+                            Typography.NumeralAlignment="Tabular" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+</UserControl>

--- a/Screenbox/Controls/ChapterPickerControl.xaml
+++ b/Screenbox/Controls/ChapterPickerControl.xaml
@@ -53,7 +53,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" Text="{x:Bind Title}" />
+                        <TextBlock Grid.Column="0" Text="{x:Bind Title.TrimStart()}" />
 
                         <TextBlock
                             Grid.Column="1"

--- a/Screenbox/Controls/ChapterPickerControl.xaml
+++ b/Screenbox/Controls/ChapterPickerControl.xaml
@@ -8,7 +8,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:mediaCore="using:Windows.Media.Core"
     xmlns:strings="using:Screenbox.Strings"
-    xmlns:ui="using:CommunityToolkit.WinUI"
     d:DesignHeight="224"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -37,12 +36,12 @@
             x:Name="ChapterList"
             Grid.Row="1"
             MaxHeight="400"
-            ui:ListViewExtensions.Command="{x:Bind ChapterSelectedCommand}"
             IsItemClickEnabled="True"
+            ItemClick="ChapterList_OnItemClick"
             ItemContainerTransitions="{x:Null}"
             ItemsSource="{x:Bind ChaptersSource}"
             Loaded="ChapterList_OnLoaded"
-            SelectedItem="{x:Bind SelectedChapter, Mode=TwoWay}"
+            SelectedItem="{x:Bind SelectedChapter, Mode=OneWay}"
             SelectionMode="Single"
             SingleSelectionFollowsFocus="False">
             <ListView.ItemTemplate>

--- a/Screenbox/Controls/ChapterPickerControl.xaml.cs
+++ b/Screenbox/Controls/ChapterPickerControl.xaml.cs
@@ -32,10 +32,10 @@ public sealed partial class ChapterPickerControl : UserControl
     }
 
     /// <summary>
-    /// Identifies the <see cref="ChapterSelectedCommand"/> dependency property.
+    /// Identifies the <see cref="ChapterCommand"/> dependency property.
     /// </summary>
-    public static readonly DependencyProperty ChapterSelectedCommandProperty = DependencyProperty.Register(
-        nameof(ChapterSelectedCommand),
+    public static readonly DependencyProperty ChapterCommandProperty = DependencyProperty.Register(
+        nameof(ChapterCommand),
         typeof(ICommand),
         typeof(ChapterPickerControl),
         new PropertyMetadata(null));
@@ -44,10 +44,10 @@ public sealed partial class ChapterPickerControl : UserControl
     /// Gets or sets the command to invoke when the chapter item is pressed.
     /// </summary>
     /// <value>The command to invoke when the chapter item is pressed.</value>
-    public ICommand ChapterSelectedCommand
+    public ICommand ChapterCommand
     {
-        get { return (ICommand)GetValue(ChapterSelectedCommandProperty); }
-        set { SetValue(ChapterSelectedCommandProperty, value); }
+        get { return (ICommand)GetValue(ChapterCommandProperty); }
+        set { SetValue(ChapterCommandProperty, value); }
     }
 
     /// <summary>
@@ -67,5 +67,11 @@ public sealed partial class ChapterPickerControl : UserControl
     private void ChapterList_OnLoaded(object sender, RoutedEventArgs e)
     {
         ChapterList.ScrollIntoView(SelectedChapter);
+    }
+
+    private void ChapterList_OnItemClick(object sender, ItemClickEventArgs e)
+    {
+        var cue = (ChapterCue)e.ClickedItem;
+        ChapterCommand.Execute(cue);
     }
 }

--- a/Screenbox/Controls/ChapterPickerControl.xaml.cs
+++ b/Screenbox/Controls/ChapterPickerControl.xaml.cs
@@ -1,0 +1,71 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Windows.Input;
+using Windows.Media.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Screenbox.Controls;
+
+public sealed partial class ChapterPickerControl : UserControl
+{
+    /// <summary>
+    /// Identifies the <see cref="SelectedChapter"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty SelectedChapterProperty = DependencyProperty.Register(
+        nameof(SelectedChapter),
+        typeof(ChapterCue),
+        typeof(ChapterPickerControl),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets or sets the selected chapter.
+    /// </summary>
+    /// <value>The selected chapter. The default is <see langword="null"/>.</value>
+    public ChapterCue SelectedChapter
+    {
+        get { return (ChapterCue)GetValue(SelectedChapterProperty); }
+        set { SetValue(SelectedChapterProperty, value); }
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="ChapterSelectedCommand"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ChapterSelectedCommandProperty = DependencyProperty.Register(
+        nameof(ChapterSelectedCommand),
+        typeof(ICommand),
+        typeof(ChapterPickerControl),
+        new PropertyMetadata(null));
+
+    /// <summary>
+    /// Gets or sets the command to invoke when the chapter item is pressed.
+    /// </summary>
+    /// <value>The command to invoke when the chapter item is pressed.</value>
+    public ICommand ChapterSelectedCommand
+    {
+        get { return (ICommand)GetValue(ChapterSelectedCommandProperty); }
+        set { SetValue(ChapterSelectedCommandProperty, value); }
+    }
+
+    /// <summary>
+    /// Gets or sets the chapters.
+    /// </summary>
+    /// <value>A collection of <see cref="ChapterCue"/> classes.</value>
+    public IReadOnlyList<ChapterCue>? ChaptersSource { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChapterPickerControl"/> class.
+    /// </summary>
+    public ChapterPickerControl()
+    {
+        this.InitializeComponent();
+    }
+
+    private void ChapterList_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ChapterList.ScrollIntoView(SelectedChapter);
+    }
+}

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -443,12 +443,32 @@
                 MinWidth="0"
                 Margin="8,0,0,2"
                 VerticalAlignment="Center"
-                ChapterName="{x:Bind ViewModel.ChapterName, Mode=OneWay}"
                 FontSize="{StaticResource BodyTextBlockFontSize}"
                 Length="{x:Bind SeekBar.ViewModel.Length, Mode=OneWay}"
-                ShowChapterName="{x:Bind ViewModel.PlayerShowChapters, Mode=OneWay}"
-                Time="{x:Bind SeekBar.ViewModel.Time, Mode=OneWay}"
-                TitleName="{x:Bind ViewModel.TitleName, Mode=OneWay}" />
+                Time="{x:Bind SeekBar.ViewModel.Time, Mode=OneWay}" />
+            <TextBlock
+                Margin="4,0,0,2"
+                VerticalAlignment="Center"
+                Text="•"
+                Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}" />
+            <Button
+                x:Name="ChapterButton"
+                Height="40"
+                Padding="4,0,4,2"
+                BorderThickness="0"
+                Content="{x:Bind ViewModel.ChapterName, Mode=OneWay}"
+                IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
+                Style="{StaticResource SubtleButtonStyle}"
+                Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
+                <Button.Flyout>
+                    <Flyout FlyoutPresenterStyle="{StaticResource FlyoutPresenterMenuFlyoutStyle}" ShouldConstrainToRootBounds="True">
+                        <controls:ChapterPickerControl
+                            ChapterSelectedCommand="{x:Bind ViewModel.NavigateToChapterCommand}"
+                            ChaptersSource="{x:Bind SeekBar.ViewModel.Chapters}"
+                            SelectedChapter="{x:Bind ViewModel.CurrentChapterCue, Mode=TwoWay}" />
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
         </StackPanel>
         <!--  Secondary Panel  -->
         <StackPanel
@@ -655,7 +675,9 @@
                         <Setter Target="PreviousButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="NextButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="TimeDisplay.Margin" Value="4,0,0,0" />
-                        <Setter Target="TimeDisplay.FontSize" Value="13" />
+                        <Setter Target="TimeDisplay.FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
+                        <Setter Target="ChapterButton.Height" Value="36" />
+                        <Setter Target="ChapterButton.FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
                         <Setter Target="RepeatButton.Visibility" Value="Collapsed" />
                         <Setter Target="ShuffleButton.Visibility" Value="Collapsed" />
                         <Setter Target="CompactOverlayButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
@@ -675,6 +697,7 @@
                         <Setter Target="PlayPauseButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="PreviousButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="NextButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
+                        <Setter Target="ChapterButton.Height" Value="36" />
                         <Setter Target="VolumeButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="VolumeControl.VolumeToggleButtonStyle" Value="{StaticResource SmallPlayerToggleButtonStyle}" />
                         <Setter Target="ShuffleButton.Style" Value="{StaticResource SmallPlayerToggleButtonStyle}" />

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -456,7 +456,7 @@
                 x:Name="ChapterButton"
                 Width="Auto"
                 Padding="4,0,4,1"
-                AutomationProperties.Name="{x:Bind ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
+                AutomationProperties.Name="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
@@ -470,13 +470,13 @@
                             </Style>
                         </Flyout.FlyoutPresenterStyle>
                         <controls:ChapterPickerControl
-                            ChapterSelectedCommand="{x:Bind ViewModel.NavigateToChapterCommand}"
+                            ChapterSelectedCommand="{x:Bind SeekBar.ViewModel.SeekToChapterCommand}"
                             ChaptersSource="{x:Bind SeekBar.ViewModel.Chapters}"
-                            SelectedChapter="{x:Bind ViewModel.CurrentChapterCue, Mode=TwoWay}" />
+                            SelectedChapter="{x:Bind SeekBar.ViewModel.CurrentChapterCue, Mode=TwoWay}" />
                     </Flyout>
                 </Button.Flyout>
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{x:Bind ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}" Typography.NumeralAlignment="Tabular" />
+                    <TextBlock Text="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}" Typography.NumeralAlignment="Tabular" />
                     <muxc:AnimatedIcon Width="12" Margin="2,4,0,0">
                         <animatedVisuals:AnimatedChevronDownSmallVisualSource />
                         <muxc:AnimatedIcon.FallbackIconSource>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -455,7 +455,7 @@
             <Button
                 x:Name="ChapterButton"
                 Height="40"
-                Padding="4,0,4,0"
+                Padding="4,0,4,2"
                 BorderThickness="0"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource SubtleButtonStyle}"
@@ -476,8 +476,8 @@
                     </Flyout>
                 </Button.Flyout>
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,2,2" Text="{x:Bind ViewModel.ChapterName, Mode=OneWay}" />
-                    <muxc:AnimatedIcon Width="12" Height="12">
+                    <TextBlock Text="{x:Bind ViewModel.ChapterName.TrimStart(), Mode=OneWay}" />
+                    <muxc:AnimatedIcon Width="12" Margin="2,4,0,0">
                         <animatedVisuals:AnimatedChevronDownSmallVisualSource />
                         <muxc:AnimatedIcon.FallbackIconSource>
                             <muxc:FontIconSource FontSize="12" Glyph="&#xE974;" />

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -2,6 +2,7 @@
     x:Class="Screenbox.Controls.PlayerControls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animatedVisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
@@ -454,9 +455,8 @@
             <Button
                 x:Name="ChapterButton"
                 Height="40"
-                Padding="4,0,4,2"
+                Padding="4,0,4,0"
                 BorderThickness="0"
-                Content="{x:Bind ViewModel.ChapterName, Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource SubtleButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
@@ -475,6 +475,18 @@
                             SelectedChapter="{x:Bind ViewModel.CurrentChapterCue, Mode=TwoWay}" />
                     </Flyout>
                 </Button.Flyout>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="0,0,2,2" Text="{x:Bind ViewModel.ChapterName, Mode=OneWay}" />
+                    <muxc:AnimatedIcon Width="12" Height="12">
+                        <animatedVisuals:AnimatedChevronDownSmallVisualSource />
+                        <muxc:AnimatedIcon.FallbackIconSource>
+                            <muxc:FontIconSource FontSize="12" Glyph="&#xE974;" />
+                        </muxc:AnimatedIcon.FallbackIconSource>
+                        <muxc:AnimatedIcon.RenderTransform>
+                            <RotateTransform Angle="-90" />
+                        </muxc:AnimatedIcon.RenderTransform>
+                    </muxc:AnimatedIcon>
+                </StackPanel>
             </Button>
         </StackPanel>
         <!--  Secondary Panel  -->

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -454,11 +454,11 @@
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}" />
             <Button
                 x:Name="ChapterButton"
-                Height="40"
-                Padding="4,0,4,2"
-                BorderThickness="0"
+                Width="Auto"
+                Padding="4,0,4,1"
+                AutomationProperties.Name="{x:Bind ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
-                Style="{StaticResource SubtleButtonStyle}"
+                Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
                 <Button.Flyout>
                     <Flyout ShouldConstrainToRootBounds="True">
@@ -476,7 +476,7 @@
                     </Flyout>
                 </Button.Flyout>
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{x:Bind ViewModel.ChapterName.TrimStart(), Mode=OneWay}" />
+                    <TextBlock Text="{x:Bind ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}" Typography.NumeralAlignment="Tabular" />
                     <muxc:AnimatedIcon Width="12" Margin="2,4,0,0">
                         <animatedVisuals:AnimatedChevronDownSmallVisualSource />
                         <muxc:AnimatedIcon.FallbackIconSource>
@@ -695,7 +695,7 @@
                         <Setter Target="NextButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="TimeDisplay.Margin" Value="4,0,0,0" />
                         <Setter Target="TimeDisplay.FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
-                        <Setter Target="ChapterButton.Height" Value="36" />
+                        <Setter Target="ChapterButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="ChapterButton.FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
                         <Setter Target="RepeatButton.Visibility" Value="Collapsed" />
                         <Setter Target="ShuffleButton.Visibility" Value="Collapsed" />
@@ -716,7 +716,7 @@
                         <Setter Target="PlayPauseButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="PreviousButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="NextButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
-                        <Setter Target="ChapterButton.Height" Value="36" />
+                        <Setter Target="ChapterButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="VolumeButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="VolumeControl.VolumeToggleButtonStyle" Value="{StaticResource SmallPlayerToggleButtonStyle}" />
                         <Setter Target="ShuffleButton.Style" Value="{StaticResource SmallPlayerToggleButtonStyle}" />

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -463,14 +463,15 @@
                 <Button.Flyout>
                     <Flyout ShouldConstrainToRootBounds="True">
                         <Flyout.FlyoutPresenterStyle>
-                            <Style BasedOn="{StaticResource FlyoutPresenterMenuFlyoutStyle}" TargetType="FlyoutPresenter">
+                            <Style BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" TargetType="FlyoutPresenter">
+                                <Setter Property="Padding" Value="{StaticResource MenuFlyoutPresenterThemePadding}" />
                                 <!--  Let the ListView in the picker handle scrolling itself.  -->
                                 <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
                                 <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
                             </Style>
                         </Flyout.FlyoutPresenterStyle>
                         <controls:ChapterPickerControl
-                            ChapterSelectedCommand="{x:Bind SeekBar.ViewModel.SeekToChapterCommand}"
+                            ChapterCommand="{x:Bind SeekBar.ViewModel.SeekToChapterCommand}"
                             ChaptersSource="{x:Bind SeekBar.ViewModel.Chapters}"
                             SelectedChapter="{x:Bind SeekBar.ViewModel.CurrentChapterCue, Mode=TwoWay}" />
                     </Flyout>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -461,7 +461,14 @@
                 Style="{StaticResource SubtleButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
                 <Button.Flyout>
-                    <Flyout FlyoutPresenterStyle="{StaticResource FlyoutPresenterMenuFlyoutStyle}" ShouldConstrainToRootBounds="True">
+                    <Flyout ShouldConstrainToRootBounds="True">
+                        <Flyout.FlyoutPresenterStyle>
+                            <Style BasedOn="{StaticResource FlyoutPresenterMenuFlyoutStyle}" TargetType="FlyoutPresenter">
+                                <!--  Let the ListView in the picker handle scrolling itself.  -->
+                                <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
+                                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+                            </Style>
+                        </Flyout.FlyoutPresenterStyle>
                         <controls:ChapterPickerControl
                             ChapterSelectedCommand="{x:Bind ViewModel.NavigateToChapterCommand}"
                             ChaptersSource="{x:Bind SeekBar.ViewModel.Chapters}"

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Linq;
@@ -169,6 +169,11 @@ public sealed partial class PlayerControls : UserControl
                 : Screenbox.Strings.Resources.None;
             ViewModel.SendStatusMessage(Screenbox.Strings.Resources.SubtitleStatus(label));
         }
+    }
+
+    private Visibility GetChapterVisibility(bool isEnabled, int count)
+    {
+        return isEnabled && count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 }
 

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -158,6 +158,9 @@
     <Compile Include="Commands\SelectDeselectAllCommand.cs" />
     <Compile Include="Commands\SetPlaybackOptionsCommand.cs" />
     <Compile Include="Commands\ShowPropertiesCommand.cs" />
+    <Compile Include="Controls\ChapterPickerControl.xaml.cs">
+      <DependentUpon>ChapterPickerControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\CommandBarEx\CommandBarEx.cs" />
     <Compile Include="Controls\CompositeTrackPicker.xaml.cs">
       <DependentUpon>CompositeTrackPicker.xaml</DependentUpon>
@@ -561,6 +564,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Controls\ChapterPickerControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Controls\CompositeTrackPicker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Closes #217, #508, and partially #947. Adds a chapter menu button to the playback controls, allowing seamless browsing and chapter navigation.

I left the `TimeDisplay` control untouched, though we should strip out the chapter and title bits. I also didn't add a dedicated view model for the `ChapterPickerControl`, opting instead for a simpler implementation.

PS. Not sure what causes the leading space in `ChapterCue` names, but it appeared in all my test files, so I added a `TrimStart()` fix.

https://github.com/user-attachments/assets/735c7683-84c1-404f-a762-001765480b32