### PR TITLE
chore: bump nuget packages and resolve SQLite vulnerabilities

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -329,7 +329,7 @@
       <Version>5.0.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-      <Version>10.0.9</Version>
+      <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
@@ -344,13 +344,13 @@
       <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite">
-      <Version>10.0.9</Version>
+      <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>5.16.3</Version>
     </PackageReference>
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3">
-      <Version>3.53.3</Version>
+      <Version>2.1.12</Version>
     </PackageReference>
     <PackageReference Include="TagLibSharp">
       <Version>2.3.0</Version>

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -349,6 +349,9 @@
     <PackageReference Include="Sentry">
       <Version>5.16.3</Version>
     </PackageReference>
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3">
+      <Version>3.53.3</Version>
+    </PackageReference>
     <PackageReference Include="TagLibSharp">
       <Version>2.3.0</Version>
     </PackageReference>

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -329,7 +329,7 @@
       <Version>5.0.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-      <Version>10.0.5</Version>
+      <Version>10.0.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>
@@ -344,7 +344,7 @@
       <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite">
-      <Version>8.0.6</Version>
+      <Version>10.0.9</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>5.16.3</Version>

--- a/Screenbox.Lively/Screenbox.Lively.csproj
+++ b/Screenbox.Lively/Screenbox.Lively.csproj
@@ -140,7 +140,7 @@
       <Version>8.4.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-      <Version>10.0.9</Version>
+      <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/Screenbox.Lively/Screenbox.Lively.csproj
+++ b/Screenbox.Lively/Screenbox.Lively.csproj
@@ -140,7 +140,7 @@
       <Version>8.4.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-      <Version>10.0.5</Version>
+      <Version>10.0.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -827,7 +827,7 @@
       <Version>5.0.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>10.0.5</Version>
+      <Version>10.0.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -827,7 +827,7 @@
       <Version>5.0.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>10.0.9</Version>
+      <Version>10.0.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>


### PR DESCRIPTION
Also pin the `SQLitePCLRaw.lib.e_sqlite3` package to 2.1.12 to avoid SQLite vulnerabilities.