### PR TITLE
style: add tool tips to trimmed chapter names

### DIFF
--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -1,4 +1,4 @@
-﻿using Screenbox.Core.Enums;
+using Screenbox.Core.Enums;
 using Windows.Media;
 
 namespace Screenbox.Core.Services;
@@ -8,6 +8,17 @@ public interface ISettingsService
     PlayerAutoResizeOption PlayerAutoResize { get; set; }
     bool UseIndexer { get; set; }
     bool PlayerShowControls { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether the remaining playback time
+    /// should be displayed in the player.
+    /// </summary>
+    /// <value>
+    /// <see langword="true"/> if the remaining playback time should be displayed;
+    /// otherwise, <see langword="false"/>.
+    /// </value>
+    bool PlayerShowRemainingTime { get; set; }
+
     bool PlayerShowChapters { get; set; }
     int PlayerControlsHideDelay { get; set; }
     int PersistentVolume { get; set; }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -17,7 +17,7 @@ public interface ISettingsService
     /// <see langword="true"/> if the remaining playback time should be displayed;
     /// otherwise, <see langword="false"/>.
     /// </value>
-    bool PlayerShowRemainingTime { get; set; }
+    bool PersistentShowRemainingTime { get; set; }
 
     bool PlayerShowChapters { get; set; }
     int PlayerControlsHideDelay { get; set; }

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Linq;
@@ -32,6 +32,7 @@ public sealed class SettingsService : ISettingsService
     private const string MaxVolumeKey = "Values/MaxVolume";
     private const string PersistentRepeatModeKey = "Values/RepeatMode";
     private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
+    private const string PlayerShowRemainingTimeKey = "Player/ShowRemainingTime";
     private const string PlayerShowChaptersKey = "Player/ShowChapters";
     private const string PrivacyPersistPlaybackPosition = "Privacy/PersistPlaybackPosition";
 
@@ -154,6 +155,12 @@ public sealed class SettingsService : ISettingsService
         set => SetValue(PlayerLivelyPathKey, value);
     }
 
+    public bool PlayerShowRemainingTime
+    {
+        get => GetValue<bool>(PlayerShowRemainingTimeKey);
+        set => SetValue(PlayerShowRemainingTimeKey, value);
+    }
+
     public bool PlayerShowChapters
     {
         get => GetValue<bool>(PlayerShowChaptersKey);
@@ -241,6 +248,7 @@ public sealed class SettingsService : ISettingsService
         SetDefault(AdvancedVideoUpscaleKey, (int)VideoUpscaleOption.Linear);
         SetDefault(AdvancedMultipleInstancesKey, false);
         SetDefault(GlobalArgumentsKey, string.Empty);
+        SetDefault(PlayerShowRemainingTimeKey, false);
         SetDefault(PlayerShowChaptersKey, true);
         SetDefault(PrivacyPersistPlaybackPosition, true);
         SetDefault(PlayerRewindStepKey, 5);

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -32,7 +32,7 @@ public sealed class SettingsService : ISettingsService
     private const string MaxVolumeKey = "Values/MaxVolume";
     private const string PersistentRepeatModeKey = "Values/RepeatMode";
     private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
-    private const string PlayerShowRemainingTimeKey = "Player/ShowRemainingTime";
+    private const string PersistentShowRemainingTimeKey = "Values/ShowRemainingTime";
     private const string PlayerShowChaptersKey = "Player/ShowChapters";
     private const string PrivacyPersistPlaybackPosition = "Privacy/PersistPlaybackPosition";
 
@@ -155,10 +155,10 @@ public sealed class SettingsService : ISettingsService
         set => SetValue(PlayerLivelyPathKey, value);
     }
 
-    public bool PlayerShowRemainingTime
+    public bool PersistentShowRemainingTime
     {
-        get => GetValue<bool>(PlayerShowRemainingTimeKey);
-        set => SetValue(PlayerShowRemainingTimeKey, value);
+        get => GetValue<bool>(PersistentShowRemainingTimeKey);
+        set => SetValue(PersistentShowRemainingTimeKey, value);
     }
 
     public bool PlayerShowChapters
@@ -248,7 +248,7 @@ public sealed class SettingsService : ISettingsService
         SetDefault(AdvancedVideoUpscaleKey, (int)VideoUpscaleOption.Linear);
         SetDefault(AdvancedMultipleInstancesKey, false);
         SetDefault(GlobalArgumentsKey, string.Empty);
-        SetDefault(PlayerShowRemainingTimeKey, false);
+        SetDefault(PersistentShowRemainingTimeKey, false);
         SetDefault(PlayerShowChaptersKey, true);
         SetDefault(PrivacyPersistPlaybackPosition, true);
         SetDefault(PlayerRewindStepKey, 5);

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -47,6 +47,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     [ObservableProperty] private bool _isAdvancedModeActive;
     [ObservableProperty] private bool _isMinimal;
     [ObservableProperty] private bool _playerShowChapters;
+    [ObservableProperty] private bool _isDisplayingRemainingTime;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShouldBeAdaptive))]
@@ -86,6 +87,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         _subtitleTimingOffset = 0.0;
         _isAdvancedModeActive = settingsService.AdvancedMode;
         _isMinimal = true;
+        IsDisplayingRemainingTime = settingsService.PlayerShowRemainingTime;
         _playerShowChapters = settingsService.PlayerShowChapters;
         PlayQueue = playQueue;
         PlayQueue.PropertyChanged += PlayQueueOnPropertyChanged;
@@ -246,6 +248,11 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     public void SendStatusMessage(string? message)
     {
         Messenger.Send(new UpdateStatusMessage(message));
+    }
+
+    partial void OnIsDisplayingRemainingTimeChanged(bool value)
+    {
+        _settingsService.PlayerShowRemainingTime = value;
     }
 
     partial void OnPlaybackRateChanged(double value)

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -87,7 +87,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         _subtitleTimingOffset = 0.0;
         _isAdvancedModeActive = settingsService.AdvancedMode;
         _isMinimal = true;
-        IsDisplayingRemainingTime = settingsService.PlayerShowRemainingTime;
+        IsDisplayingRemainingTime = settingsService.PersistentShowRemainingTime;
         _playerShowChapters = settingsService.PlayerShowChapters;
         PlayQueue = playQueue;
         PlayQueue.PropertyChanged += PlayQueueOnPropertyChanged;
@@ -252,7 +252,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
 
     partial void OnIsDisplayingRemainingTimeChanged(bool value)
     {
-        _settingsService.PlayerShowRemainingTime = value;
+        _settingsService.PersistentShowRemainingTime = value;
     }
 
     partial void OnPlaybackRateChanged(double value)

--- a/Screenbox/Controls/ChapterPickerControl.xaml
+++ b/Screenbox/Controls/ChapterPickerControl.xaml
@@ -2,8 +2,10 @@
     x:Class="Screenbox.Controls.ChapterPickerControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Screenbox.Behaviors"
     xmlns:core="using:Screenbox.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:Screenbox.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:mediaCore="using:Windows.Media.Core"
@@ -52,11 +54,18 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" Text="{x:Bind Title.TrimStart()}" />
+                        <TextBlock
+                            Grid.Column="0"
+                            Text="{x:Bind Title.TrimStart()}"
+                            TextTrimming="CharacterEllipsis">
+                            <interactivity:Interaction.Behaviors>
+                                <behaviors:OverflowTextToolTipBehavior />
+                            </interactivity:Interaction.Behaviors>
+                        </TextBlock>
 
                         <TextBlock
                             Grid.Column="1"
-                            Padding="4,2,0,0"
+                            Padding="8,2,0,0"
                             FontSize="{StaticResource CaptionTextBlockFontSize}"
                             Opacity="{ThemeResource TextFillColorSecondaryOpacity}"
                             Text="{x:Bind core:Humanizer.ToDuration(StartTime)}"

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -458,6 +458,7 @@
                 Margin="8,0,0,2"
                 VerticalAlignment="Center"
                 FontSize="{StaticResource BodyTextBlockFontSize}"
+                IsRemainingTimeVisible="{x:Bind ViewModel.IsDisplayingRemainingTime, Mode=TwoWay}"
                 Length="{x:Bind SeekBar.ViewModel.Length, Mode=OneWay}"
                 Time="{x:Bind SeekBar.ViewModel.Time, Mode=OneWay}" />
 

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:animatedVisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
+    xmlns:behaviors="using:Screenbox.Behaviors"
     xmlns:commands="using:Screenbox.Commands"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
@@ -10,6 +11,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Screenbox.Extensions"
     xmlns:helpers="using:Screenbox.Helpers"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
@@ -386,14 +388,22 @@
             VerticalAlignment="Center"
             Background="Transparent"
             Foreground="Transparent" />
-        <!--  Primary Panel  -->
-        <StackPanel
-            Grid.Row="1"
-            Grid.Column="0"
-            Orientation="Horizontal">
+
+        <!--#region Primary Controls-->
+        <Grid Grid.Row="1" Grid.Column="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
             <!--  Play/Pause  -->
             <Button
                 x:Name="PlayPauseButton"
+                Grid.Column="0"
                 Margin="0,0,4,0"
                 extensions:AcceleratorService.ToolTip="{x:Bind helpers:ItemLabelHelper.GetPlayPauseLabel(ViewModel.IsPlaying), Mode=OneWay}"
                 AccessKey="{strings:KeyboardResources Key=PlayerPlayPauseKey}"
@@ -407,59 +417,96 @@
                     <KeyboardAccelerator Key="Space" Invoked="PlayPauseKeyboardAccelerator_OnInvoked" />
                 </Button.KeyboardAccelerators>
             </Button>
-            <!--  Previous/Next  -->
-            <StackPanel FlowDirection="LeftToRight" Orientation="Horizontal">
-                <Button
-                    x:Name="PreviousButton"
-                    extensions:AcceleratorService.ToolTip="{x:Bind strings:Resources.Previous}"
-                    AccessKey="{strings:KeyboardResources Key=PlayerPreviousKey}"
-                    AutomationProperties.Name="{x:Bind PreviousButton.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
-                    Command="{x:Bind ViewModel.PreviousCommand}"
-                    CornerRadius="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
-                    Style="{StaticResource PlayerButtonStyle}">
-                    <FontIcon Glyph="&#xE892;" />
-                    <Button.KeyboardAccelerators>
-                        <KeyboardAccelerator Key="PageUp" />
-                        <KeyboardAccelerator Key="P" Modifiers="Shift" />
-                    </Button.KeyboardAccelerators>
-                </Button>
-                <Button
-                    x:Name="NextButton"
-                    extensions:AcceleratorService.ToolTip="{x:Bind strings:Resources.Next}"
-                    AccessKey="{strings:KeyboardResources Key=PlayerNextKey}"
-                    AutomationProperties.Name="{x:Bind NextButton.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
-                    Command="{x:Bind ViewModel.NextCommand}"
-                    CornerRadius="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}"
-                    Style="{StaticResource PlayerButtonStyle}">
-                    <FontIcon Glyph="&#xE893;" />
-                    <Button.KeyboardAccelerators>
-                        <KeyboardAccelerator Key="PageDown" />
-                        <KeyboardAccelerator Key="N" Modifiers="Shift" />
-                    </Button.KeyboardAccelerators>
-                </Button>
-            </StackPanel>
-            <!--  Time & Chapter  -->
+
+            <!--  Previous + Next  -->
+            <Button
+                x:Name="PreviousButton"
+                Grid.Column="1"
+                extensions:AcceleratorService.ToolTip="{x:Bind strings:Resources.Previous}"
+                AccessKey="{strings:KeyboardResources Key=PlayerPreviousKey}"
+                AutomationProperties.Name="{x:Bind PreviousButton.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
+                Command="{x:Bind ViewModel.PreviousCommand}"
+                CornerRadius="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
+                Style="{StaticResource PlayerButtonStyle}">
+                <FontIcon Glyph="&#xE892;" />
+                <Button.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="PageUp" />
+                    <KeyboardAccelerator Key="P" Modifiers="Shift" />
+                </Button.KeyboardAccelerators>
+            </Button>
+            <Button
+                x:Name="NextButton"
+                Grid.Column="2"
+                extensions:AcceleratorService.ToolTip="{x:Bind strings:Resources.Next}"
+                AccessKey="{strings:KeyboardResources Key=PlayerNextKey}"
+                AutomationProperties.Name="{x:Bind NextButton.(extensions:AcceleratorService.ToolTip), Mode=OneWay}"
+                Command="{x:Bind ViewModel.NextCommand}"
+                CornerRadius="{Binding Source={StaticResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                Style="{StaticResource PlayerButtonStyle}">
+                <FontIcon Glyph="&#xE893;" />
+                <Button.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="PageDown" />
+                    <KeyboardAccelerator Key="N" Modifiers="Shift" />
+                </Button.KeyboardAccelerators>
+            </Button>
+
+            <!--  Time  -->
             <controls:TimeDisplay
                 x:Name="TimeDisplay"
+                Grid.Column="3"
                 MinWidth="0"
                 Margin="8,0,0,2"
                 VerticalAlignment="Center"
                 FontSize="{StaticResource BodyTextBlockFontSize}"
                 Length="{x:Bind SeekBar.ViewModel.Length, Mode=OneWay}"
                 Time="{x:Bind SeekBar.ViewModel.Time, Mode=OneWay}" />
+
+            <!--  Chapter  -->
             <TextBlock
-                Margin="4,0,0,2"
+                Grid.Column="4"
+                Margin="5,0,0,2"
                 VerticalAlignment="Center"
                 Text="•"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}" />
+
             <Button
                 x:Name="ChapterButton"
+                Grid.Column="5"
                 Width="Auto"
                 Padding="4,0,4,1"
                 AutomationProperties.Name="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Column="0"
+                        Text="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        Typography.NumeralAlignment="Tabular">
+                        <interactivity:Interaction.Behaviors>
+                            <behaviors:OverflowTextToolTipBehavior />
+                        </interactivity:Interaction.Behaviors>
+                    </TextBlock>
+
+                    <muxc:AnimatedIcon
+                        Grid.Column="1"
+                        Width="12"
+                        Margin="2,4,0,0">
+                        <animatedVisuals:AnimatedChevronDownSmallVisualSource />
+                        <muxc:AnimatedIcon.FallbackIconSource>
+                            <muxc:FontIconSource FontSize="12" Glyph="&#xE974;" />
+                        </muxc:AnimatedIcon.FallbackIconSource>
+                        <muxc:AnimatedIcon.RenderTransform>
+                            <RotateTransform Angle="-90" />
+                        </muxc:AnimatedIcon.RenderTransform>
+                    </muxc:AnimatedIcon>
+                </Grid>
                 <Button.Flyout>
                     <Flyout ShouldConstrainToRootBounds="True">
                         <Flyout.FlyoutPresenterStyle>
@@ -476,21 +523,11 @@
                             SelectedChapter="{x:Bind SeekBar.ViewModel.CurrentChapterCue, Mode=TwoWay}" />
                     </Flyout>
                 </Button.Flyout>
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}" Typography.NumeralAlignment="Tabular" />
-                    <muxc:AnimatedIcon Width="12" Margin="2,4,0,0">
-                        <animatedVisuals:AnimatedChevronDownSmallVisualSource />
-                        <muxc:AnimatedIcon.FallbackIconSource>
-                            <muxc:FontIconSource FontSize="12" Glyph="&#xE974;" />
-                        </muxc:AnimatedIcon.FallbackIconSource>
-                        <muxc:AnimatedIcon.RenderTransform>
-                            <RotateTransform Angle="-90" />
-                        </muxc:AnimatedIcon.RenderTransform>
-                    </muxc:AnimatedIcon>
-                </StackPanel>
             </Button>
-        </StackPanel>
-        <!--  Secondary Panel  -->
+        </Grid>
+        <!--#endregion-->
+
+        <!--#region Secondary Controls-->
         <StackPanel
             Grid.Row="1"
             Grid.Column="1"
@@ -632,6 +669,7 @@
                 <FontIcon Glyph="&#xE712;" />
             </Button>
         </StackPanel>
+        <!--#endregion-->
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="AdaptiveControlStates">
@@ -726,6 +764,20 @@
                         <Setter Target="CompactOverlayButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="FullscreenButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
                         <Setter Target="MoreButton.Style" Value="{StaticResource SmallPlayerButtonStyle}" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+
+            <VisualStateGroup x:Name="FlowDirectionStates">
+                <VisualState x:Name="LeftToRight" />
+
+                <VisualState x:Name="RightToLeft">
+                    <VisualState.StateTriggers>
+                        <StateTrigger IsActive="{x:Bind helpers:GlobalizationHelper.IsRightToLeftLanguage}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="PreviousButton.(Grid.Column)" Value="2" />
+                        <Setter Target="NextButton.(Grid.Column)" Value="1" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Controls/TimeDisplay.xaml
+++ b/Screenbox/Controls/TimeDisplay.xaml
@@ -1,7 +1,8 @@
-﻿<UserControl
+<UserControl
     x:Class="Screenbox.Controls.TimeDisplay"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:core="using:Screenbox.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:strings="using:Screenbox.Strings"
@@ -9,82 +10,57 @@
     d:DesignWidth="256"
     mc:Ignorable="d">
 
-    <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-        <StackPanel
-            FlowDirection="LeftToRight"
-            Orientation="Horizontal"
-            Tapped="TimeDisplay_OnTapped">
-            <TextBlock
-                x:Name="TimeText"
-                d:Text="43:21"
-                Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-                Text="{x:Bind Time, Mode=OneWay, Converter={StaticResource HumanizedDurationConverter}}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeElapsed}"
-                Typography.NumeralAlignment="Tabular" />
-            <TextBlock
-                x:Name="RemainingText"
-                d:Text="-58:39"
-                Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-                Text="{x:Bind GetRemainingTime(Time), Mode=OneWay}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeRemaining}"
-                Typography.NumeralAlignment="Tabular"
-                Visibility="Collapsed" />
-            <TextBlock
-                Margin="2,0"
-                Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-                Text="/" />
-            <TextBlock
-                d:Text="1:23:45"
-                Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-                Text="{x:Bind Length, Mode=OneWay, Converter={StaticResource HumanizedDurationConverter}}"
-                ToolTipService.ToolTip="{strings:Resources Key=TimeLength}"
-                Typography.NumeralAlignment="Tabular" />
-        </StackPanel>
+    <Grid
+        x:Name="RootGrid"
+        FlowDirection="LeftToRight"
+        Tapped="RootGrid_OnTapped"
+        Typography.NumeralAlignment="Tabular">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
 
         <TextBlock
-            x:Name="SeparatorText"
-            d:Visibility="Visible"
+            x:Name="TimeText"
+            Grid.Column="0"
+            d:Text="43:21"
             Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-            Text=" •"
+            Text="{x:Bind core:Humanizer.ToDuration(Time), Mode=OneWay}"
+            ToolTipService.ToolTip="{x:Bind strings:Resources.TimeElapsed}" />
+        <TextBlock
+            x:Name="RemainingText"
+            Grid.Column="0"
+            d:Text="-58:39"
+            Style="{x:Bind TextBlockStyle, Mode=OneWay}"
+            Text="{x:Bind GetRemainingTime(Time), Mode=OneWay}"
+            ToolTipService.ToolTip="{x:Bind strings:Resources.TimeRemaining}"
             Visibility="Collapsed" />
 
         <TextBlock
-            x:Name="NameText"
-            MinWidth="0"
-            Margin="2,0,0,0"
-            d:Visibility="Visible"
+            Grid.Column="1"
+            Margin="2,0"
             Style="{x:Bind TextBlockStyle, Mode=OneWay}"
-            Visibility="Collapsed">
-            <Run d:Text="Title" Text="{x:Bind TitleName, Mode=OneWay}" /><Run x:Name="Separator" Text=": " /><Run d:Text="Chapter 1" Text="{x:Bind ChapterName, Mode=OneWay}" />
-        </TextBlock>
+            Text="/" />
+
+        <TextBlock
+            Grid.Column="2"
+            d:Text="1:23:45"
+            Style="{x:Bind TextBlockStyle, Mode=OneWay}"
+            Text="{x:Bind core:Humanizer.ToDuration(Length), Mode=OneWay}"
+            ToolTipService.ToolTip="{x:Bind strings:Resources.TimeLength}" />
 
         <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="TimeTextVisibility">
-                <VisualState x:Name="ShowElapsed" />
-                <VisualState x:Name="ShowRemaining">
+            <VisualStateGroup x:Name="TimeDisplayStates">
+                <VisualState x:Name="ElapsedTime" />
+
+                <VisualState x:Name="RemainingTime">
                     <VisualState.Setters>
                         <Setter Target="TimeText.Visibility" Value="Collapsed" />
                         <Setter Target="RemainingText.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
-
-            <VisualStateGroup x:Name="NameStates">
-                <VisualState x:Name="None" />
-                <VisualState x:Name="Both">
-                    <VisualState.Setters>
-                        <Setter Target="SeparatorText.Visibility" Value="Visible" />
-                        <Setter Target="NameText.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="Either">
-                    <VisualState.Setters>
-                        <Setter Target="SeparatorText.Visibility" Value="Visible" />
-                        <Setter Target="NameText.Visibility" Value="Visible" />
-                        <Setter Target="Separator.Text" Value="{x:Null}" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/Screenbox/Controls/TimeDisplay.xaml.cs
+++ b/Screenbox/Controls/TimeDisplay.xaml.cs
@@ -1,117 +1,123 @@
-﻿using Windows.UI.Xaml;
+#nullable enable
+
+using Screenbox.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Screenbox.Core;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
-namespace Screenbox.Controls
+namespace Screenbox.Controls;
+
+/// <summary>
+/// Represents a control that displays playback time information for a media item.
+/// </summary>
+[StyleTypedProperty(Property = nameof(TextBlockStyle), StyleTargetType = typeof(TextBlock))]
+public sealed partial class TimeDisplay : UserControl
 {
-    public sealed partial class TimeDisplay : UserControl
+    /// <summary>
+    /// Identifies the <see cref="Time"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty TimeProperty = DependencyProperty.Register(
+        nameof(Time),
+        typeof(double),
+        typeof(TimeDisplay),
+        new PropertyMetadata(0d));
+
+    /// <summary>
+    /// Gets or sets the current elapsed playback time.
+    /// </summary>
+    /// <value>The current elapsed playback time in milliseconds. The default is <b>0</b>.</value>
+    public double Time
     {
-        public static readonly DependencyProperty TimeProperty = DependencyProperty.Register(
-            nameof(Time),
-            typeof(double),
-            typeof(TimeDisplay),
-            new PropertyMetadata(0d));
-        public static readonly DependencyProperty LengthProperty = DependencyProperty.Register(
-            nameof(Length),
-            typeof(double),
-            typeof(TimeDisplay),
-            new PropertyMetadata(0d));
-        public static readonly DependencyProperty TitleNameProperty = DependencyProperty.Register(
-            nameof(TitleName),
-            typeof(string),
-            typeof(TimeDisplay),
-            new PropertyMetadata(string.Empty, OnNameChanged));
-        public static readonly DependencyProperty ChapterNameProperty = DependencyProperty.Register(
-            nameof(ChapterName),
-            typeof(string),
-            typeof(TimeDisplay),
-            new PropertyMetadata(string.Empty, OnNameChanged));
-        public static readonly DependencyProperty TextBlockStyleProperty = DependencyProperty.Register(
-            nameof(TextBlockStyle),
-            typeof(Style),
-            typeof(TimeDisplay),
-            new PropertyMetadata(null));
-        public static readonly DependencyProperty ShowChapterNameProperty = DependencyProperty.Register(
-            nameof(ShowChapterName),
-            typeof(bool),
-            typeof(TimeDisplay),
-            new PropertyMetadata(true, OnNameChanged));
+        get => (double)GetValue(TimeProperty);
+        set => SetValue(TimeProperty, value);
+    }
 
-        public double Time
-        {
-            get => (double)GetValue(TimeProperty);
-            set => SetValue(TimeProperty, value);
-        }
+    /// <summary>
+    /// Identifies the <see cref="Length"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty LengthProperty = DependencyProperty.Register(
+        nameof(Length),
+        typeof(double),
+        typeof(TimeDisplay),
+        new PropertyMetadata(0d));
 
-        public double Length
-        {
-            get => (double)GetValue(LengthProperty);
-            set => SetValue(LengthProperty, value);
-        }
+    /// <summary>
+    /// Gets or sets the total playback length.
+    /// </summary>
+    /// <value>The total playback length in milliseconds. The default is <b>0</b>.</value>
+    public double Length
+    {
+        get => (double)GetValue(LengthProperty);
+        set => SetValue(LengthProperty, value);
+    }
 
-        public string TitleName
-        {
-            get => (string)GetValue(TitleNameProperty);
-            set => SetValue(TitleNameProperty, value);
-        }
+    /// <summary>
+    /// Identifies the <see cref="TextBlockStyle"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty TextBlockStyleProperty = DependencyProperty.Register(
+        nameof(TextBlockStyle),
+        typeof(Style),
+        typeof(TimeDisplay),
+        new PropertyMetadata(null));
 
-        public string ChapterName
-        {
-            get => (string)GetValue(ChapterNameProperty);
-            set => SetValue(ChapterNameProperty, value);
-        }
+    /// <summary>
+    /// Gets or sets the style that defines the look of the text elements.
+    /// </summary>
+    /// <value>The style that defines the look of the text elements. The default is <b>null</b>.</value>
+    public Style TextBlockStyle
+    {
+        get => (Style)GetValue(TextBlockStyleProperty);
+        set => SetValue(TextBlockStyleProperty, value);
+    }
 
-        public Style TextBlockStyle
-        {
-            get => (Style)GetValue(TextBlockStyleProperty);
-            set => SetValue(TextBlockStyleProperty, value);
-        }
+    /// <summary>
+    /// Identifies the <see cref="IsRemainingTimeVisible"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IsRemainingTimeVisibleProperty = DependencyProperty.Register(
+        nameof(IsRemainingTimeVisible),
+        typeof(bool),
+        typeof(TimeDisplay),
+        new PropertyMetadata(false, OnIsRemainingTimeVisiblePropertyChanged));
 
-        public bool ShowChapterName
-        {
-            get => (bool)GetValue(ShowChapterNameProperty);
-            set => SetValue(ShowChapterNameProperty, value);
-        }
+    /// <summary>
+    /// Gets or sets a value that indicates whether the control displays remaining time
+    /// instead of elapsed time.
+    /// </summary>
+    /// <value>
+    /// <see langword="true"/> if the control displays remaining time;
+    /// otherwise, <see langword="false"/>. The default is <b>false</b>.
+    /// </value>
+    public bool IsRemainingTimeVisible
+    {
+        get => (bool)GetValue(IsRemainingTimeVisibleProperty);
+        set => SetValue(IsRemainingTimeVisibleProperty, value);
+    }
 
-        private bool _showRemaining;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeDisplay"/> class.
+    /// </summary>
+    public TimeDisplay()
+    {
+        this.InitializeComponent();
+    }
 
-        public TimeDisplay()
-        {
-            this.InitializeComponent();
-        }
+    private void RootGrid_OnTapped(object sender, TappedRoutedEventArgs e)
+    {
+        IsRemainingTimeVisible = !IsRemainingTimeVisible;
+    }
 
-        private static void OnNameChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            TimeDisplay view = (TimeDisplay)d;
-            if (!view.ShowChapterName)
-            {
-                VisualStateManager.GoToState(view, "None", false);
-                return;
-            }
-            
-            if (string.IsNullOrEmpty(view.TitleName) && string.IsNullOrEmpty(view.ChapterName))
-            {
-                VisualStateManager.GoToState(view, "None", false);
-            }
-            else if (string.IsNullOrEmpty(view.TitleName) || string.IsNullOrEmpty(view.ChapterName))
-            {
-                VisualStateManager.GoToState(view, "Either", false);
-            }
-            else
-            {
-                VisualStateManager.GoToState(view, "Both", false);
-            }
-        }
+    private static void OnIsRemainingTimeVisiblePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var control = (TimeDisplay)d;
+        control.UpdateVisualState();
+    }
 
-        private string GetRemainingTime(double currentTime) => Humanizer.ToDuration(currentTime - Length);
+    private string GetRemainingTime(double currentTime) => Humanizer.ToDuration(currentTime - Length);
 
-        private void TimeDisplay_OnTapped(object sender, TappedRoutedEventArgs e)
-        {
-            _showRemaining = !_showRemaining;
-            VisualStateManager.GoToState(this, _showRemaining ? "ShowRemaining" : "ShowElapsed", true);
-        }
+    private void UpdateVisualState()
+    {
+        VisualStateManager.GoToState(this, IsRemainingTimeVisible ? nameof(RemainingTime) : nameof(ElapsedTime), true);
     }
 }


### PR DESCRIPTION
Continuation of #951. 

- Adds tooltips to chapter titles when they’re truncated in the picker list or in the controls
- Streamlines the `TimeDisplayControl`, since it no longer manages any chapter‑related logic
- Adds persistence setting for the time display preference, allowing users to keep their choice between remaining and elapsed time
- Unwraps the Previous/Next buttons from the panel that enforced a fixed ordering, shifting their ordering logic into a visual state to correctly handle RTL layouts