### PR TITLE
feat: update LibVLC to 3.0.23 and LibVLCSharp to 3.10.0

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -323,6 +323,9 @@
     <PackageReference Include="CommunityToolkit.Uwp.Extensions">
       <Version>8.2.251219</Version>
     </PackageReference>
+    <PackageReference Include="LibVLCSharp.UWP">
+      <Version>3.10.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>5.0.7</Version>
     </PackageReference>
@@ -340,9 +343,6 @@
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm">
       <Version>8.4.2</Version>
-    </PackageReference>
-    <PackageReference Include="LibVLCSharp">
-      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite">
       <Version>10.0.10</Version>

--- a/Screenbox.Core/Services/PlayerService.cs
+++ b/Screenbox.Core/Services/PlayerService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -186,15 +186,15 @@ public sealed class PlayerService : IPlayerService
 #else
             "--verbose=0",
 #endif
-            // "--aout=winstore",
+            "--aout=winstore",
             //"--sout-chromecast-conversion-quality=0",
             "--no-osd"
         };
         options.AddRange(swapChainOptions);
 #if DEBUG
-        LibVLC libVlc = new(true, options.ToArray());
+        LibVLC libVlc = new(true, false, options.ToArray());
 #else
-        LibVLC libVlc = new(false, options.ToArray());
+        LibVLC libVlc = new(false, false, options.ToArray());
 #endif
         LogService.RegisterLibVlcLogging(libVlc);
         _vlcDialogService.SetVlcDialogHandlers(libVlc);

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -849,7 +849,7 @@
       <Version>0.3.1.5</Version>
     </PackageReference>
     <PackageReference Include="LibVLC.UWP">
-      <Version>3.0.21-2505100334</Version>
+      <Version>3.0.23-2607192200</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
       <Version>5.16.3</Version>


### PR DESCRIPTION
Upgrade LibVLCSharp to use the UWP-specific variation.

Upgrade LibVLC for added features and stability. Fixed ARM64 web URL playback crashes. See https://github.com/huynhsontung/libvlc-nuget/pull/30

> On Windows ARM64 (`aarch64`), the **`x18` register** is strictly reserved by the OS as the "platform register", and it specifically points to the **Thread Environment Block (TEB)**. If a user-mode application or a DLL compiled with GCC clobbers the `x18` register (e.g. by using it as a general-purpose scratch register), any subsequent Windows API calls (like memory allocation inside `ntdll!RtlpHpAllocateHeap` called via GnuTLS `malloc()`) will try to read from the corrupted TEB pointer and crash with an `0xc0000005` (Access Violation).
>
> GCC and Clang, when cross-compiling to `aarch64-w64-mingw32`, do not always implicitly reserve the `x18` register by default. To fix this, we must explicitly pass the `-ffixed-x18` compiler flag to ensure the compiler treats `x18` as a fixed register and never modifies it. 