### PR TITLE
refactor: PropertyView bindings

### DIFF
--- a/Screenbox.Core/Common/ServiceHelpers.cs
+++ b/Screenbox.Core/Common/ServiceHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Coordinators;
 using Screenbox.Core.Factories;
@@ -13,6 +13,7 @@ public static class ServiceHelpers
     {
         // View models
         services.AddTransient<PlayerElementViewModel>();
+        services.AddTransient<PropertyViewModel>();
         services.AddTransient<ChapterViewModel>();
         services.AddTransient<CompositeTrackPickerViewModel>();
         services.AddTransient<SeekBarViewModel>();

--- a/Screenbox.Core/Enums/MediaProperty.cs
+++ b/Screenbox.Core/Enums/MediaProperty.cs
@@ -1,6 +1,6 @@
 namespace Screenbox.Core.Enums;
 
-public enum Property
+public enum MediaProperty
 {
     Title,
     Subtitle,

--- a/Screenbox.Core/Enums/Property.cs
+++ b/Screenbox.Core/Enums/Property.cs
@@ -1,0 +1,23 @@
+namespace Screenbox.Core.Enums;
+
+public enum Property
+{
+    Title,
+    Subtitle,
+    Year,
+    Producers,
+    Writers,
+    Length,
+    Resolution,
+    BitRate,
+    ContributingArtists,
+    Album,
+    AlbumArtist,
+    Composers,
+    Genre,
+    Track,
+    FileType,
+    ContentType,
+    Size,
+    LastModified,
+}

--- a/Screenbox.Core/Models/MediaMetadata.cs
+++ b/Screenbox.Core/Models/MediaMetadata.cs
@@ -11,7 +11,7 @@ public sealed record MediaMetadata
     /// Gets the key that identifies the media metadata entry.
     /// </summary>
     /// <value>A value indicating the metadata entry.</value>
-    public Property Key { get; }
+    public MediaProperty Key { get; }
 
     /// <summary>
     /// Gets the value of the media metadata entry.
@@ -25,7 +25,7 @@ public sealed record MediaMetadata
     /// </summary>
     /// <param name="key">The key that identifies the metadata entry.</param>
     /// <param name="value">The value associated with the metadata entry.</param>
-    public MediaMetadata(Property key, string value)
+    public MediaMetadata(MediaProperty key, string value)
     {
         Key = key;
         Value = value;

--- a/Screenbox.Core/Models/MediaMetadata.cs
+++ b/Screenbox.Core/Models/MediaMetadata.cs
@@ -1,0 +1,14 @@
+namespace Screenbox.Core.Models;
+
+public sealed record MediaMetadata
+{
+    public string Name { get; private set; }
+
+    public string Value { get; private set; }
+
+    public MediaMetadata(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+}

--- a/Screenbox.Core/Models/MediaMetadata.cs
+++ b/Screenbox.Core/Models/MediaMetadata.cs
@@ -1,14 +1,33 @@
+using Screenbox.Core.Enums;
+
 namespace Screenbox.Core.Models;
 
+/// <summary>
+/// Represents a media metadata entry with a key and its associated value.
+/// </summary>
 public sealed record MediaMetadata
 {
-    public string Name { get; private set; }
+    /// <summary>
+    /// Gets the key that identifies the media metadata entry.
+    /// </summary>
+    /// <value>A value indicating the metadata entry.</value>
+    public Property Key { get; }
 
-    public string Value { get; private set; }
+    /// <summary>
+    /// Gets the value of the media metadata entry.
+    /// </summary>
+    /// <value>The string value of the metadata entry.</value>
+    public string Value { get; }
 
-    public MediaMetadata(string name, string value)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediaMetadata"/> record
+    /// using the specified key and value.
+    /// </summary>
+    /// <param name="key">The key that identifies the metadata entry.</param>
+    /// <param name="value">The value associated with the metadata entry.</param>
+    public MediaMetadata(Property key, string value)
     {
-        Name = name;
+        Key = key;
         Value = value;
     }
 }

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Helpers\EnumExtensions.cs" />
     <Compile Include="Helpers\FilesHelpers.cs" />
     <Compile Include="Helpers\LanguageHelper.cs" />
+    <Compile Include="Models\MediaMetadata.cs" />
     <Compile Include="Models\MusicCacheRecordDto.cs" />
     <Compile Include="Models\RawCacheLoadResultDto.cs" />
     <Compile Include="Models\RawMediaRecordDto.cs" />

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Enums\NotificationLevel.cs" />
     <Compile Include="Enums\PlaybackActionKind.cs" />
     <Compile Include="Enums\PlayerVisibilityState.cs" />
+    <Compile Include="Enums\Property.cs" />
     <Compile Include="Enums\SearchSuggestionType.cs" />
     <Compile Include="Enums\SettingsOptions.cs" />
     <Compile Include="Enums\WindowViewMode.cs" />

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -133,10 +133,10 @@
     <Compile Include="Contexts\PlayQueueContext.cs" />
     <Compile Include="Contexts\WindowContext.cs" />
     <Compile Include="Enums\MediaPlaybackType.cs" />
+    <Compile Include="Enums\MediaProperty.cs" />
     <Compile Include="Enums\NotificationLevel.cs" />
     <Compile Include="Enums\PlaybackActionKind.cs" />
     <Compile Include="Enums\PlayerVisibilityState.cs" />
-    <Compile Include="Enums\Property.cs" />
     <Compile Include="Enums\SearchSuggestionType.cs" />
     <Compile Include="Enums\SettingsOptions.cs" />
     <Compile Include="Enums\WindowViewMode.cs" />

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -307,6 +307,7 @@
     <Compile Include="ViewModels\PlayQueuePanelViewModel.cs" />
     <Compile Include="ViewModels\PlaylistsPageViewModel.cs" />
     <Compile Include="ViewModels\PlayQueuePageViewModel.cs" />
+    <Compile Include="ViewModels\PropertyViewModel.cs" />
     <Compile Include="ViewModels\SearchResultPageViewModel.cs" />
     <Compile Include="ViewModels\SeekBarViewModel.cs" />
     <Compile Include="ViewModels\SelectionViewModel.cs" />

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -47,44 +47,44 @@ public sealed partial class PropertyViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Populates the property dictionaries with localized labels and values from the given <paramref name="media"/> item.
+    /// Populates the property collections with metadata keys and values from the given <paramref name="media"/> item.
     /// </summary>
     public void UpdateProperties(MediaViewModel media)
     {
         switch (media.MediaType)
         {
             case MediaPlaybackType.Video:
-                MediaProperties.Add(new MediaMetadata("PropertyTitle", string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
+                MediaProperties.Add(new MediaMetadata(Property.Title, string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
                     ? media.Name
                     : media.MediaInfo.VideoProperties.Title));
-                MediaProperties.Add(new MediaMetadata("PropertySubtitle", media.MediaInfo.VideoProperties.Subtitle));
-                MediaProperties.Add(new MediaMetadata("PropertyYear", media.MediaInfo.VideoProperties.Year > 0
+                MediaProperties.Add(new MediaMetadata(Property.Subtitle, media.MediaInfo.VideoProperties.Subtitle));
+                MediaProperties.Add(new MediaMetadata(Property.Year, media.MediaInfo.VideoProperties.Year > 0
                     ? media.MediaInfo.VideoProperties.Year.ToString()
                     : string.Empty));
-                MediaProperties.Add(new MediaMetadata("PropertyProducers", string.Join("; ", media.MediaInfo.VideoProperties.Producers)));
-                MediaProperties.Add(new MediaMetadata("PropertyWriters", string.Join("; ", media.MediaInfo.VideoProperties.Writers)));
-                MediaProperties.Add(new MediaMetadata("PropertyLength", Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration)));
+                MediaProperties.Add(new MediaMetadata(Property.Producers, string.Join("; ", media.MediaInfo.VideoProperties.Producers)));
+                MediaProperties.Add(new MediaMetadata(Property.Writers, string.Join("; ", media.MediaInfo.VideoProperties.Writers)));
+                MediaProperties.Add(new MediaMetadata(Property.Length, Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration)));
 
-                VideoProperties.Add(new MediaMetadata("PropertyResolution", $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}"));
-                VideoProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps"));
+                VideoProperties.Add(new MediaMetadata(Property.Resolution, $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}"));
+                VideoProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps"));
 
-                AudioProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
+                AudioProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
 
             case MediaPlaybackType.Music:
-                MediaProperties.Add(new MediaMetadata("PropertyTitle", media.MediaInfo.MusicProperties.Title));
-                MediaProperties.Add(new MediaMetadata("PropertyContributingArtists", media.MediaInfo.MusicProperties.Artist));
-                MediaProperties.Add(new MediaMetadata("PropertyAlbum", media.MediaInfo.MusicProperties.Album));
-                MediaProperties.Add(new MediaMetadata("PropertyAlbumArtist", media.MediaInfo.MusicProperties.AlbumArtist));
-                MediaProperties.Add(new MediaMetadata("PropertyComposers", string.Join("; ", media.MediaInfo.MusicProperties.Composers)));
-                MediaProperties.Add(new MediaMetadata("PropertyGenre", string.Join("; ", media.MediaInfo.MusicProperties.Genre)));
-                MediaProperties.Add(new MediaMetadata("PropertyTrack", media.MediaInfo.MusicProperties.TrackNumber.ToString()));
-                MediaProperties.Add(new MediaMetadata("PropertyYear", media.MediaInfo.MusicProperties.Year > 0
+                MediaProperties.Add(new MediaMetadata(Property.Title, media.MediaInfo.MusicProperties.Title));
+                MediaProperties.Add(new MediaMetadata(Property.ContributingArtists, media.MediaInfo.MusicProperties.Artist));
+                MediaProperties.Add(new MediaMetadata(Property.Album, media.MediaInfo.MusicProperties.Album));
+                MediaProperties.Add(new MediaMetadata(Property.AlbumArtist, media.MediaInfo.MusicProperties.AlbumArtist));
+                MediaProperties.Add(new MediaMetadata(Property.Composers, string.Join("; ", media.MediaInfo.MusicProperties.Composers)));
+                MediaProperties.Add(new MediaMetadata(Property.Genre, string.Join("; ", media.MediaInfo.MusicProperties.Genre)));
+                MediaProperties.Add(new MediaMetadata(Property.Track, media.MediaInfo.MusicProperties.TrackNumber.ToString()));
+                MediaProperties.Add(new MediaMetadata(Property.Year, media.MediaInfo.MusicProperties.Year > 0
                     ? media.MediaInfo.MusicProperties.Year.ToString()
                     : string.Empty));
-                MediaProperties.Add(new MediaMetadata("PropertyLength", Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration)));
+                MediaProperties.Add(new MediaMetadata(Property.Length, Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration)));
 
-                AudioProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
+                AudioProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
         }
 
@@ -93,10 +93,10 @@ public sealed partial class PropertyViewModel : ObservableObject
             case StorageFile file:
                 _mediaFile = file;
                 CanNavigateToFile = true;
-                FileProperties.Add(new MediaMetadata("PropertyFileType", _mediaFile.FileType));
-                FileProperties.Add(new MediaMetadata("PropertyContentType", _mediaFile.ContentType));
-                FileProperties.Add(new MediaMetadata("PropertySize", BytesToHumanReadable((long)media.MediaInfo.Size)));
-                FileProperties.Add(new MediaMetadata("PropertyLastModified", media.MediaInfo.DateModified.ToString()));
+                FileProperties.Add(new MediaMetadata(Property.FileType, _mediaFile.FileType));
+                FileProperties.Add(new MediaMetadata(Property.ContentType, _mediaFile.ContentType));
+                FileProperties.Add(new MediaMetadata(Property.Size, BytesToHumanReadable((long)media.MediaInfo.Size)));
+                FileProperties.Add(new MediaMetadata(Property.LastModified, media.MediaInfo.DateModified.ToString()));
                 break;
             case Uri uri:
                 _mediaUri = uri;

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -54,37 +54,37 @@ public sealed partial class PropertyViewModel : ObservableObject
         switch (media.MediaType)
         {
             case MediaPlaybackType.Video:
-                MediaProperties.Add(new MediaMetadata(Property.Title, string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Title, string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
                     ? media.Name
                     : media.MediaInfo.VideoProperties.Title));
-                MediaProperties.Add(new MediaMetadata(Property.Subtitle, media.MediaInfo.VideoProperties.Subtitle));
-                MediaProperties.Add(new MediaMetadata(Property.Year, media.MediaInfo.VideoProperties.Year > 0
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Subtitle, media.MediaInfo.VideoProperties.Subtitle));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Year, media.MediaInfo.VideoProperties.Year > 0
                     ? media.MediaInfo.VideoProperties.Year.ToString()
                     : string.Empty));
-                MediaProperties.Add(new MediaMetadata(Property.Producers, string.Join("; ", media.MediaInfo.VideoProperties.Producers)));
-                MediaProperties.Add(new MediaMetadata(Property.Writers, string.Join("; ", media.MediaInfo.VideoProperties.Writers)));
-                MediaProperties.Add(new MediaMetadata(Property.Length, Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Producers, string.Join("; ", media.MediaInfo.VideoProperties.Producers)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Writers, string.Join("; ", media.MediaInfo.VideoProperties.Writers)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Length, Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration)));
 
-                VideoProperties.Add(new MediaMetadata(Property.Resolution, $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}"));
-                VideoProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps"));
+                VideoProperties.Add(new MediaMetadata(MediaProperty.Resolution, $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}"));
+                VideoProperties.Add(new MediaMetadata(MediaProperty.BitRate, $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps"));
 
-                AudioProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
+                AudioProperties.Add(new MediaMetadata(MediaProperty.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
 
             case MediaPlaybackType.Music:
-                MediaProperties.Add(new MediaMetadata(Property.Title, media.MediaInfo.MusicProperties.Title));
-                MediaProperties.Add(new MediaMetadata(Property.ContributingArtists, media.MediaInfo.MusicProperties.Artist));
-                MediaProperties.Add(new MediaMetadata(Property.Album, media.MediaInfo.MusicProperties.Album));
-                MediaProperties.Add(new MediaMetadata(Property.AlbumArtist, media.MediaInfo.MusicProperties.AlbumArtist));
-                MediaProperties.Add(new MediaMetadata(Property.Composers, string.Join("; ", media.MediaInfo.MusicProperties.Composers)));
-                MediaProperties.Add(new MediaMetadata(Property.Genre, string.Join("; ", media.MediaInfo.MusicProperties.Genre)));
-                MediaProperties.Add(new MediaMetadata(Property.Track, media.MediaInfo.MusicProperties.TrackNumber.ToString()));
-                MediaProperties.Add(new MediaMetadata(Property.Year, media.MediaInfo.MusicProperties.Year > 0
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Title, media.MediaInfo.MusicProperties.Title));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.ContributingArtists, media.MediaInfo.MusicProperties.Artist));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Album, media.MediaInfo.MusicProperties.Album));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.AlbumArtist, media.MediaInfo.MusicProperties.AlbumArtist));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Composers, string.Join("; ", media.MediaInfo.MusicProperties.Composers)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Genre, string.Join("; ", media.MediaInfo.MusicProperties.Genre)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Track, media.MediaInfo.MusicProperties.TrackNumber.ToString()));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Year, media.MediaInfo.MusicProperties.Year > 0
                     ? media.MediaInfo.MusicProperties.Year.ToString()
                     : string.Empty));
-                MediaProperties.Add(new MediaMetadata(Property.Length, Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration)));
+                MediaProperties.Add(new MediaMetadata(MediaProperty.Length, Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration)));
 
-                AudioProperties.Add(new MediaMetadata(Property.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
+                AudioProperties.Add(new MediaMetadata(MediaProperty.BitRate, $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
         }
 
@@ -93,10 +93,10 @@ public sealed partial class PropertyViewModel : ObservableObject
             case StorageFile file:
                 _mediaFile = file;
                 CanNavigateToFile = true;
-                FileProperties.Add(new MediaMetadata(Property.FileType, _mediaFile.FileType));
-                FileProperties.Add(new MediaMetadata(Property.ContentType, _mediaFile.ContentType));
-                FileProperties.Add(new MediaMetadata(Property.Size, BytesToHumanReadable((long)media.MediaInfo.Size)));
-                FileProperties.Add(new MediaMetadata(Property.LastModified, media.MediaInfo.DateModified.ToString()));
+                FileProperties.Add(new MediaMetadata(MediaProperty.FileType, _mediaFile.FileType));
+                FileProperties.Add(new MediaMetadata(MediaProperty.ContentType, _mediaFile.ContentType));
+                FileProperties.Add(new MediaMetadata(MediaProperty.Size, BytesToHumanReadable((long)media.MediaInfo.Size)));
+                FileProperties.Add(new MediaMetadata(MediaProperty.LastModified, media.MediaInfo.DateModified.ToString()));
                 break;
             case Uri uri:
                 _mediaUri = uri;

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Screenbox.Core.Enums;
+using Screenbox.Core.Models;
 using Screenbox.Core.Services;
 using Windows.Storage;
 
@@ -12,13 +13,13 @@ namespace Screenbox.Core.ViewModels;
 
 public sealed partial class PropertyViewModel : ObservableObject
 {
-    public Dictionary<string, string> MediaProperties { get; }
+    public IList<MediaMetadata> MediaProperties { get; }
 
-    public Dictionary<string, string> VideoProperties { get; }
+    public IList<MediaMetadata> VideoProperties { get; }
 
-    public Dictionary<string, string> AudioProperties { get; }
+    public IList<MediaMetadata> AudioProperties { get; }
 
-    public Dictionary<string, string> FileProperties { get; }
+    public IList<MediaMetadata> FileProperties { get; }
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(OpenFileLocationCommand))]
@@ -31,10 +32,10 @@ public sealed partial class PropertyViewModel : ObservableObject
     public PropertyViewModel(IFilesService filesService)
     {
         _filesService = filesService;
-        MediaProperties = new Dictionary<string, string>();
-        VideoProperties = new Dictionary<string, string>();
-        AudioProperties = new Dictionary<string, string>();
-        FileProperties = new Dictionary<string, string>();
+        MediaProperties = new List<MediaMetadata>();
+        VideoProperties = new List<MediaMetadata>();
+        AudioProperties = new List<MediaMetadata>();
+        FileProperties = new List<MediaMetadata>();
     }
 
     /// <summary>
@@ -53,37 +54,37 @@ public sealed partial class PropertyViewModel : ObservableObject
         switch (media.MediaType)
         {
             case MediaPlaybackType.Video:
-                MediaProperties["PropertyTitle"] = string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
+                MediaProperties.Add(new MediaMetadata("PropertyTitle", string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
                     ? media.Name
-                    : media.MediaInfo.VideoProperties.Title;
-                MediaProperties["PropertySubtitle"] = media.MediaInfo.VideoProperties.Subtitle;
-                MediaProperties["PropertyYear"] = media.MediaInfo.VideoProperties.Year > 0
+                    : media.MediaInfo.VideoProperties.Title));
+                MediaProperties.Add(new MediaMetadata("PropertySubtitle", media.MediaInfo.VideoProperties.Subtitle));
+                MediaProperties.Add(new MediaMetadata("PropertyYear", media.MediaInfo.VideoProperties.Year > 0
                     ? media.MediaInfo.VideoProperties.Year.ToString()
-                    : string.Empty;
-                MediaProperties["PropertyProducers"] = string.Join("; ", media.MediaInfo.VideoProperties.Producers);
-                MediaProperties["PropertyWriters"] = string.Join("; ", media.MediaInfo.VideoProperties.Writers);
-                MediaProperties["PropertyLength"] = Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration);
+                    : string.Empty));
+                MediaProperties.Add(new MediaMetadata("PropertyProducers", string.Join("; ", media.MediaInfo.VideoProperties.Producers)));
+                MediaProperties.Add(new MediaMetadata("PropertyWriters", string.Join("; ", media.MediaInfo.VideoProperties.Writers)));
+                MediaProperties.Add(new MediaMetadata("PropertyLength", Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration)));
 
-                VideoProperties["PropertyResolution"] = $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}";
-                VideoProperties["PropertyBitRate"] = $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps";
+                VideoProperties.Add(new MediaMetadata("PropertyResolution", $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}"));
+                VideoProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps"));
 
-                AudioProperties["PropertyBitRate"] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
+                AudioProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
 
             case MediaPlaybackType.Music:
-                MediaProperties["PropertyTitle"] = media.MediaInfo.MusicProperties.Title;
-                MediaProperties["PropertyContributingArtists"] = media.MediaInfo.MusicProperties.Artist;
-                MediaProperties["PropertyAlbum"] = media.MediaInfo.MusicProperties.Album;
-                MediaProperties["PropertyAlbumArtist"] = media.MediaInfo.MusicProperties.AlbumArtist;
-                MediaProperties["PropertyComposers"] = string.Join("; ", media.MediaInfo.MusicProperties.Composers);
-                MediaProperties["PropertyGenre"] = string.Join("; ", media.MediaInfo.MusicProperties.Genre);
-                MediaProperties["PropertyTrack"] = media.MediaInfo.MusicProperties.TrackNumber.ToString();
-                MediaProperties["PropertyYear"] = media.MediaInfo.MusicProperties.Year > 0
+                MediaProperties.Add(new MediaMetadata("PropertyTitle", media.MediaInfo.MusicProperties.Title));
+                MediaProperties.Add(new MediaMetadata("PropertyContributingArtists", media.MediaInfo.MusicProperties.Artist));
+                MediaProperties.Add(new MediaMetadata("PropertyAlbum", media.MediaInfo.MusicProperties.Album));
+                MediaProperties.Add(new MediaMetadata("PropertyAlbumArtist", media.MediaInfo.MusicProperties.AlbumArtist));
+                MediaProperties.Add(new MediaMetadata("PropertyComposers", string.Join("; ", media.MediaInfo.MusicProperties.Composers)));
+                MediaProperties.Add(new MediaMetadata("PropertyGenre", string.Join("; ", media.MediaInfo.MusicProperties.Genre)));
+                MediaProperties.Add(new MediaMetadata("PropertyTrack", media.MediaInfo.MusicProperties.TrackNumber.ToString()));
+                MediaProperties.Add(new MediaMetadata("PropertyYear", media.MediaInfo.MusicProperties.Year > 0
                     ? media.MediaInfo.MusicProperties.Year.ToString()
-                    : string.Empty;
-                MediaProperties["PropertyLength"] = Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration);
+                    : string.Empty));
+                MediaProperties.Add(new MediaMetadata("PropertyLength", Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration)));
 
-                AudioProperties["PropertyBitRate"] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
+                AudioProperties.Add(new MediaMetadata("PropertyBitRate", $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps"));
                 break;
         }
 
@@ -92,10 +93,10 @@ public sealed partial class PropertyViewModel : ObservableObject
             case StorageFile file:
                 _mediaFile = file;
                 CanNavigateToFile = true;
-                FileProperties["PropertyFileType"] = _mediaFile.FileType;
-                FileProperties["PropertyContentType"] = _mediaFile.ContentType;
-                FileProperties["PropertySize"] = BytesToHumanReadable((long)media.MediaInfo.Size);
-                FileProperties["PropertyLastModified"] = media.MediaInfo.DateModified.ToString();
+                FileProperties.Add(new MediaMetadata("PropertyFileType", _mediaFile.FileType));
+                FileProperties.Add(new MediaMetadata("PropertyContentType", _mediaFile.ContentType));
+                FileProperties.Add(new MediaMetadata("PropertySize", BytesToHumanReadable((long)media.MediaInfo.Size)));
+                FileProperties.Add(new MediaMetadata("PropertyLastModified", media.MediaInfo.DateModified.ToString()));
                 break;
             case Uri uri:
                 _mediaUri = uri;

--- a/Screenbox.Core/ViewModels/PropertyViewModel.cs
+++ b/Screenbox.Core/ViewModels/PropertyViewModel.cs
@@ -1,17 +1,14 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Screenbox.Core;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Services;
-using Screenbox.Core.ViewModels;
-using Screenbox.Strings;
 using Windows.Storage;
 
-namespace Screenbox.ViewModels;
+namespace Screenbox.Core.ViewModels;
 
 public sealed partial class PropertyViewModel : ObservableObject
 {
@@ -56,37 +53,37 @@ public sealed partial class PropertyViewModel : ObservableObject
         switch (media.MediaType)
         {
             case MediaPlaybackType.Video:
-                MediaProperties[Resources.PropertyTitle] = string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
+                MediaProperties["PropertyTitle"] = string.IsNullOrEmpty(media.MediaInfo.VideoProperties.Title)
                     ? media.Name
                     : media.MediaInfo.VideoProperties.Title;
-                MediaProperties[Resources.PropertySubtitle] = media.MediaInfo.VideoProperties.Subtitle;
-                MediaProperties[Resources.PropertyYear] = media.MediaInfo.VideoProperties.Year > 0
+                MediaProperties["PropertySubtitle"] = media.MediaInfo.VideoProperties.Subtitle;
+                MediaProperties["PropertyYear"] = media.MediaInfo.VideoProperties.Year > 0
                     ? media.MediaInfo.VideoProperties.Year.ToString()
                     : string.Empty;
-                MediaProperties[Resources.PropertyProducers] = string.Join("; ", media.MediaInfo.VideoProperties.Producers);
-                MediaProperties[Resources.PropertyWriters] = string.Join("; ", media.MediaInfo.VideoProperties.Writers);
-                MediaProperties[Resources.PropertyLength] = Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration);
+                MediaProperties["PropertyProducers"] = string.Join("; ", media.MediaInfo.VideoProperties.Producers);
+                MediaProperties["PropertyWriters"] = string.Join("; ", media.MediaInfo.VideoProperties.Writers);
+                MediaProperties["PropertyLength"] = Humanizer.ToDuration(media.MediaInfo.VideoProperties.Duration);
 
-                VideoProperties[Resources.PropertyResolution] = $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}";
-                VideoProperties[Resources.PropertyBitRate] = $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps";
+                VideoProperties["PropertyResolution"] = $"{media.MediaInfo.VideoProperties.Width}×{media.MediaInfo.VideoProperties.Height}";
+                VideoProperties["PropertyBitRate"] = $"{media.MediaInfo.VideoProperties.Bitrate / 1000} kbps";
 
-                AudioProperties[Resources.PropertyBitRate] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
+                AudioProperties["PropertyBitRate"] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
                 break;
 
             case MediaPlaybackType.Music:
-                MediaProperties[Resources.PropertyTitle] = media.MediaInfo.MusicProperties.Title;
-                MediaProperties[Resources.PropertyContributingArtists] = media.MediaInfo.MusicProperties.Artist;
-                MediaProperties[Resources.PropertyAlbum] = media.MediaInfo.MusicProperties.Album;
-                MediaProperties[Resources.PropertyAlbumArtist] = media.MediaInfo.MusicProperties.AlbumArtist;
-                MediaProperties[Resources.PropertyComposers] = string.Join("; ", media.MediaInfo.MusicProperties.Composers);
-                MediaProperties[Resources.PropertyGenre] = string.Join("; ", media.MediaInfo.MusicProperties.Genre);
-                MediaProperties[Resources.PropertyTrack] = media.MediaInfo.MusicProperties.TrackNumber.ToString();
-                MediaProperties[Resources.PropertyYear] = media.MediaInfo.MusicProperties.Year > 0
+                MediaProperties["PropertyTitle"] = media.MediaInfo.MusicProperties.Title;
+                MediaProperties["PropertyContributingArtists"] = media.MediaInfo.MusicProperties.Artist;
+                MediaProperties["PropertyAlbum"] = media.MediaInfo.MusicProperties.Album;
+                MediaProperties["PropertyAlbumArtist"] = media.MediaInfo.MusicProperties.AlbumArtist;
+                MediaProperties["PropertyComposers"] = string.Join("; ", media.MediaInfo.MusicProperties.Composers);
+                MediaProperties["PropertyGenre"] = string.Join("; ", media.MediaInfo.MusicProperties.Genre);
+                MediaProperties["PropertyTrack"] = media.MediaInfo.MusicProperties.TrackNumber.ToString();
+                MediaProperties["PropertyYear"] = media.MediaInfo.MusicProperties.Year > 0
                     ? media.MediaInfo.MusicProperties.Year.ToString()
                     : string.Empty;
-                MediaProperties[Resources.PropertyLength] = Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration);
+                MediaProperties["PropertyLength"] = Humanizer.ToDuration(media.MediaInfo.MusicProperties.Duration);
 
-                AudioProperties[Resources.PropertyBitRate] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
+                AudioProperties["PropertyBitRate"] = $"{media.MediaInfo.MusicProperties.Bitrate / 1000} kbps";
                 break;
         }
 
@@ -95,10 +92,10 @@ public sealed partial class PropertyViewModel : ObservableObject
             case StorageFile file:
                 _mediaFile = file;
                 CanNavigateToFile = true;
-                FileProperties[Resources.PropertyFileType] = _mediaFile.FileType;
-                FileProperties[Resources.PropertyContentType] = _mediaFile.ContentType;
-                FileProperties[Resources.PropertySize] = BytesToHumanReadable((long)media.MediaInfo.Size);
-                FileProperties[Resources.PropertyLastModified] = media.MediaInfo.DateModified.ToString();
+                FileProperties["PropertyFileType"] = _mediaFile.FileType;
+                FileProperties["PropertyContentType"] = _mediaFile.ContentType;
+                FileProperties["PropertySize"] = BytesToHumanReadable((long)media.MediaInfo.Size);
+                FileProperties["PropertyLastModified"] = media.MediaInfo.DateModified.ToString();
                 break;
             case Uri uri:
                 _mediaUri = uri;

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -109,7 +109,6 @@ sealed partial class App : Application
 
         // View models
         services.AddTransient<Screenbox.ViewModels.NotificationViewModel>();
-        services.AddTransient<Screenbox.ViewModels.PropertyViewModel>();
 
         // Services
         services.AddSingleton<IVlcDialogService, VlcDialogService>();

--- a/Screenbox/Controls/PropertiesView.xaml
+++ b/Screenbox/Controls/PropertiesView.xaml
@@ -32,7 +32,7 @@
                         Margin="0,0,8,0"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind converters:ResourceNameToResourceStringConverter.FromName(Name)}"
+                        Text="{x:Bind converters:ResourceNameToResourceStringConverter.FromEnum(Key)}"
                         TextTrimming="CharacterEllipsis" />
 
                     <TextBlock

--- a/Screenbox/Controls/PropertiesView.xaml
+++ b/Screenbox/Controls/PropertiesView.xaml
@@ -5,6 +5,7 @@
     xmlns:converters="using:Screenbox.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Screenbox.Core.Models"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:strings="using:Screenbox.Strings"
     xmlns:triggers="using:CommunityToolkit.WinUI"
@@ -12,50 +13,54 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
     <UserControl.Resources>
-        <converters:ResourceNameToResourceStringConverter x:Key="PropertyStringToResourceStringConverter" />
-
-        <DataTemplate x:Key="PropertyItemTemplate">
+        <DataTemplate x:Key="PropertyItemTemplate" x:DataType="models:MediaMetadata">
             <UserControl>
-                <Grid x:Name="PropertyGrid">
+                <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition x:Name="FirstColumn" Width="0.6*" />
+                        <ColumnDefinition Width="0.6*" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
+
                     <TextBlock
                         x:Name="TitleText"
                         Grid.Row="0"
                         Grid.Column="0"
                         Margin="0,0,8,0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Top"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Key, Converter={StaticResource PropertyStringToResourceStringConverter}}"
+                        Text="{x:Bind converters:ResourceNameToResourceStringConverter.FromName(Name)}"
                         TextTrimming="CharacterEllipsis" />
+
                     <TextBlock
                         x:Name="ValueText"
                         Grid.Row="0"
                         Grid.Column="1"
-                        HorizontalAlignment="Left"
-                        Text="{Binding Value}"
+                        IsTextSelectionEnabled="True"
+                        Text="{x:Bind Value}"
                         TextWrapping="Wrap" />
 
                     <VisualStateManager.VisualStateGroups>
                         <VisualStateGroup x:Name="LayoutGroup">
-                            <VisualState x:Name="Horizontal" />
+                            <VisualState x:Name="Horizontal">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="720" />
+                                </VisualState.StateTriggers>
+                            </VisualState>
+
                             <VisualState x:Name="Vertical">
                                 <VisualState.StateTriggers>
-                                    <triggers:ControlSizeTrigger MaxWidth="400" TargetElement="{Binding ElementName=PropertyGrid}" />
+                                    <AdaptiveTrigger MinWindowWidth="0" />
                                 </VisualState.StateTriggers>
                                 <VisualState.Setters>
+                                    <Setter Target="TitleText.Margin" Value="0,0,0,0" />
+                                    <Setter Target="TitleText.(Grid.ColumnSpan)" Value="2" />
                                     <Setter Target="ValueText.(Grid.Row)" Value="1" />
                                     <Setter Target="ValueText.(Grid.Column)" Value="0" />
-                                    <Setter Target="TitleText.Margin" Value="0,0,0,0" />
-                                    <Setter Target="FirstColumn.Width" Value="*" />
+                                    <Setter Target="ValueText.(Grid.ColumnSpan)" Value="2" />
                                 </VisualState.Setters>
                             </VisualState>
                         </VisualStateGroup>
@@ -67,13 +72,13 @@
         <muxc:StackLayout
             x:Key="PropertyStackLayout"
             Orientation="Vertical"
-            Spacing="10" />
+            Spacing="12" />
     </UserControl.Resources>
 
     <ScrollViewer HorizontalScrollMode="Disabled" ZoomMode="Disabled">
         <StackPanel Orientation="Vertical">
             <muxc:Expander
-                Margin="0,0,0,8"
+                Margin="{StaticResource BottomLargeMargin}"
                 HorizontalAlignment="Stretch"
                 Header="{strings:Resources Key=Media}"
                 IsExpanded="True">
@@ -84,7 +89,7 @@
             </muxc:Expander>
 
             <muxc:Expander
-                Margin="0,8"
+                Margin="{StaticResource BottomLargeMargin}"
                 HorizontalAlignment="Stretch"
                 Header="{strings:Resources Key=Video}"
                 IsExpanded="True"
@@ -96,7 +101,7 @@
             </muxc:Expander>
 
             <muxc:Expander
-                Margin="0,8"
+                Margin="{StaticResource BottomLargeMargin}"
                 HorizontalAlignment="Stretch"
                 Header="{strings:Resources Key=Music}"
                 IsExpanded="True"
@@ -108,8 +113,9 @@
             </muxc:Expander>
 
             <muxc:Expander
-                Margin="0,8"
+                Margin="{StaticResource BottomLargeMargin}"
                 HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
                 Header="{strings:Resources Key=File}"
                 IsExpanded="True">
                 <StackPanel Orientation="Vertical">
@@ -121,7 +127,7 @@
 
                     <TextBlock
                         x:Name="LocationTitleText"
-                        Margin="0,10,0,0"
+                        Margin="{StaticResource TopMediumMargin}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -131,12 +137,14 @@
 
                     <TextBlock
                         x:Name="LocationText"
+                        Margin="{StaticResource BottomMediumMargin}"
                         HorizontalAlignment="Left"
+                        IsTextSelectionEnabled="True"
                         Text="{x:Bind Media.Location}"
                         TextWrapping="Wrap" />
 
                     <HyperlinkButton
-                        Margin="-11,10,0,0"
+                        Margin="{StaticResource InfoBarHyperlinkButtonMargin}"
                         HorizontalAlignment="Left"
                         Command="{x:Bind ViewModel.OpenFileLocationCommand}"
                         Content="{x:Bind strings:Resources.OpenFileLocation}" />

--- a/Screenbox/Controls/PropertiesView.xaml
+++ b/Screenbox/Controls/PropertiesView.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Screenbox.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Screenbox.Core.Models"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -32,7 +33,7 @@
                         Margin="0,0,8,0"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind converters:ResourceNameToResourceStringConverter.FromEnum(Key)}"
+                        Text="{x:Bind helpers:ItemLabelHelper.GetMediaPropertyResourceString(Key)}"
                         TextTrimming="CharacterEllipsis" />
 
                     <TextBlock

--- a/Screenbox/Controls/PropertiesView.xaml
+++ b/Screenbox/Controls/PropertiesView.xaml
@@ -1,7 +1,8 @@
-﻿<UserControl
+<UserControl
     x:Class="Screenbox.Controls.PropertiesView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Screenbox.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -11,6 +12,8 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
     <UserControl.Resources>
+        <converters:ResourceNameToResourceStringConverter x:Key="PropertyStringToResourceStringConverter" />
+
         <DataTemplate x:Key="PropertyItemTemplate">
             <UserControl>
                 <Grid x:Name="PropertyGrid">
@@ -31,7 +34,7 @@
                         VerticalAlignment="Top"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{Binding Key}"
+                        Text="{Binding Key, Converter={StaticResource PropertyStringToResourceStringConverter}}"
                         TextTrimming="CharacterEllipsis" />
                     <TextBlock
                         x:Name="ValueText"

--- a/Screenbox/Controls/PropertiesView.xaml.cs
+++ b/Screenbox/Controls/PropertiesView.xaml.cs
@@ -1,8 +1,7 @@
-﻿#nullable enable
+#nullable enable
 
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Screenbox.Core.ViewModels;
-using Screenbox.ViewModels;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 

--- a/Screenbox/Dialogs/PropertiesDialog.xaml
+++ b/Screenbox/Dialogs/PropertiesDialog.xaml
@@ -1,4 +1,4 @@
-﻿<ContentDialog
+<ContentDialog
     x:Class="Screenbox.Dialogs.PropertiesDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,6 +13,6 @@
     mc:Ignorable="d">
 
     <Grid>
-        <controls:PropertiesView MinWidth="400" Media="{x:Bind Media, Mode=OneWay}" />
+        <controls:PropertiesView Media="{x:Bind Media, Mode=OneWay}" />
     </Grid>
 </ContentDialog>

--- a/Screenbox/Helpers/ItemLabelHelper.cs
+++ b/Screenbox/Helpers/ItemLabelHelper.cs
@@ -113,6 +113,37 @@ public static class ItemLabelHelper
     }
 
     /// <summary>
+    /// Gets the localized label for a media property.
+    /// </summary>
+    /// <param name="property">The media property to localize.</param>
+    /// <returns>The localized media property label.</returns>
+    public static string GetMediaPropertyResourceString(MediaProperty property)
+    {
+        return property switch
+        {
+            MediaProperty.Title => Strings.Resources.PropertyTitle,
+            MediaProperty.Subtitle => Strings.Resources.PropertySubtitle,
+            MediaProperty.Year => Strings.Resources.PropertyYear,
+            MediaProperty.Producers => Strings.Resources.PropertyProducers,
+            MediaProperty.Writers => Strings.Resources.PropertyWriters,
+            MediaProperty.Length => Strings.Resources.PropertyLength,
+            MediaProperty.Resolution => Strings.Resources.PropertyResolution,
+            MediaProperty.BitRate => Strings.Resources.PropertyBitRate,
+            MediaProperty.ContributingArtists => Strings.Resources.PropertyContributingArtists,
+            MediaProperty.Album => Strings.Resources.PropertyAlbum,
+            MediaProperty.AlbumArtist => Strings.Resources.PropertyAlbumArtist,
+            MediaProperty.Composers => Strings.Resources.PropertyComposers,
+            MediaProperty.Genre => Strings.Resources.PropertyGenre,
+            MediaProperty.Track => Strings.Resources.PropertyTrack,
+            MediaProperty.FileType => Strings.Resources.PropertyFileType,
+            MediaProperty.ContentType => Strings.Resources.PropertyContentType,
+            MediaProperty.Size => Strings.Resources.PropertySize,
+            MediaProperty.LastModified => Strings.Resources.PropertyLastModified,
+            _ => property.ToString()
+        };
+    }
+
+    /// <summary>
     /// Gets the localized label for a play/pause command.
     /// </summary>
     /// <param name="isPlaying"><see langword="true"/> if the media is playing; otherwise, <see langword="false"/>.</param>

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -342,7 +342,6 @@
     </Compile>
     <Compile Include="Templates\SearchSuggestionTemplateSelector.cs" />
     <Compile Include="ViewModels\NotificationViewModel.cs" />
-    <Compile Include="ViewModels\PropertyViewModel.cs" />
     <Compile Include="Triggers\WindowActivationModeTrigger.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Restores `PropertyViewModel` to the **Core** project, partially reverting the modifications from #794.