### PR TITLE
fix: revert .NET Native trimming

### DIFF
--- a/Screenbox.Core/Properties/Screenbox.Core.rd.xml
+++ b/Screenbox.Core/Properties/Screenbox.Core.rd.xml
@@ -29,7 +29,5 @@
 
   	<!-- add directives for your library here -->
 
-    <Type Name="CommunityToolkit.Mvvm.Messaging.IMessengerExtensions" Dynamic="Required All" />
-
   </Library>
 </Directives>

--- a/Screenbox.Lively/Properties/Screenbox.Lively.rd.xml
+++ b/Screenbox.Lively/Properties/Screenbox.Lively.rd.xml
@@ -29,9 +29,5 @@
 
   	<!-- add directives for your library here -->
 
-    <Namespace Name="Screenbox.Lively.Models" Serialize="Required PublicAndInternal" />
-    <Namespace Name="Screenbox.Lively.Models.Serialization" Serialize="Required PublicAndInternal" />
-    <Namespace Name="System.Text.Json" Serialize="All" />
-
   </Library>
 </Directives>

--- a/Screenbox/Properties/Default.rd.xml
+++ b/Screenbox/Properties/Default.rd.xml
@@ -21,7 +21,7 @@
       An Assembly element with Name="*Application*" applies to all assemblies in
       the application package. The asterisks are not wildcards.
     -->
-    <!--<Assembly Name="*Application*" Dynamic="Required All" />-->
+    <Assembly Name="*Application*" Dynamic="Required All" />
     
     
     <!-- Add your application specific runtime directives here. -->


### PR DESCRIPTION
This reverts commit ff568369db50c4b9066c7152d13d5fdc0fe6bb22.

Trimming was causing crashes after playback started.