### PR TITLE
feat: ChapterPickerControl handles empty chapter name

### DIFF
--- a/Screenbox/Controls/ChapterPickerControl.xaml
+++ b/Screenbox/Controls/ChapterPickerControl.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Screenbox.Behaviors"
+    xmlns:converters="using:Screenbox.Converters"
     xmlns:core="using:Screenbox.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -13,6 +14,9 @@
     d:DesignHeight="224"
     d:DesignWidth="400"
     mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:ChapterTitleConverter x:Key="ChapterTitleConverter" Chapters="{x:Bind ChaptersSource}" />
+    </UserControl.Resources>
 
     <Grid Width="224">
         <Grid.RowDefinitions>
@@ -48,7 +52,7 @@
             SingleSelectionFollowsFocus="False">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="mediaCore:ChapterCue">
-                    <Grid AutomationProperties.Name="{x:Bind Title}">
+                    <Grid AutomationProperties.Name="{x:Bind Converter={StaticResource ChapterTitleConverter}, Mode=OneWay}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
@@ -56,7 +60,7 @@
 
                         <TextBlock
                             Grid.Column="0"
-                            Text="{x:Bind Title.TrimStart()}"
+                            Text="{x:Bind Converter={StaticResource ChapterTitleConverter}, Mode=OneWay}"
                             TextTrimming="CharacterEllipsis">
                             <interactivity:Interaction.Behaviors>
                                 <behaviors:OverflowTextToolTipBehavior />

--- a/Screenbox/Controls/ChapterPickerControl.xaml.cs
+++ b/Screenbox/Controls/ChapterPickerControl.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class ChapterPickerControl : UserControl
     /// Gets or sets the chapters.
     /// </summary>
     /// <value>A collection of <see cref="ChapterCue"/> classes.</value>
-    public IReadOnlyList<ChapterCue>? ChaptersSource { get; set; }
+    public IList<ChapterCue>? ChaptersSource { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ChapterPickerControl"/> class.

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -478,7 +478,7 @@
                 Grid.Column="5"
                 Width="Auto"
                 Padding="4,0,4,1"
-                AutomationProperties.Name="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
+                AutomationProperties.Name="{x:Bind GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue), Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
@@ -490,7 +490,7 @@
 
                     <TextBlock
                         Grid.Column="0"
-                        Text="{x:Bind SeekBar.ViewModel.CurrentChapterCue.Title.TrimStart(), Mode=OneWay}"
+                        Text="{x:Bind GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue), Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         Typography.NumeralAlignment="Tabular">
                         <interactivity:Interaction.Behaviors>

--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -478,7 +478,7 @@
                 Grid.Column="5"
                 Width="Auto"
                 Padding="4,0,4,1"
-                AutomationProperties.Name="{x:Bind GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue), Mode=OneWay}"
+                AutomationProperties.Name="{x:Bind converters:ChapterTitleConverter.GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue, SeekBar.ViewModel.Chapters), Mode=OneWay}"
                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                 Style="{StaticResource PlayerButtonStyle}"
                 Visibility="{x:Bind GetChapterVisibility(ViewModel.PlayerShowChapters, SeekBar.ViewModel.Chapters.Count), Mode=OneWay}">
@@ -490,7 +490,7 @@
 
                     <TextBlock
                         Grid.Column="0"
-                        Text="{x:Bind GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue), Mode=OneWay}"
+                        Text="{x:Bind converters:ChapterTitleConverter.GetChapterTitle(SeekBar.ViewModel.CurrentChapterCue, SeekBar.ViewModel.Chapters), Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         Typography.NumeralAlignment="Tabular">
                         <interactivity:Interaction.Behaviors>

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -7,7 +7,6 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using Screenbox.Core.ViewModels;
 using Screenbox.Helpers;
-using Windows.Media.Core;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -176,14 +176,4 @@ public sealed partial class PlayerControls : UserControl
     {
         return isEnabled && count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
-
-    // Due the init time order mismatch between SeekBar view model and ChapterTitleConverter resource
-    // we cannot use the ChapterTitleConverter in the XAML, so we have to duplicate the logic here.
-    private string GetChapterTitle(ChapterCue? chapterCue)
-    {
-        if (chapterCue is null) return string.Empty;
-        return !string.IsNullOrWhiteSpace(chapterCue.Title)
-            ? chapterCue.Title.TrimStart()
-            : Screenbox.Strings.Resources.ChapterName(SeekBar.ViewModel.Chapters.IndexOf(chapterCue) + 1);
-    }
 }

--- a/Screenbox/Controls/PlayerControls.xaml.cs
+++ b/Screenbox/Controls/PlayerControls.xaml.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using Screenbox.Core.ViewModels;
 using Screenbox.Helpers;
+using Windows.Media.Core;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -175,5 +176,14 @@ public sealed partial class PlayerControls : UserControl
     {
         return isEnabled && count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
-}
 
+    // Due the init time order mismatch between SeekBar view model and ChapterTitleConverter resource
+    // we cannot use the ChapterTitleConverter in the XAML, so we have to duplicate the logic here.
+    private string GetChapterTitle(ChapterCue? chapterCue)
+    {
+        if (chapterCue is null) return string.Empty;
+        return !string.IsNullOrWhiteSpace(chapterCue.Title)
+            ? chapterCue.Title.TrimStart()
+            : Screenbox.Strings.Resources.ChapterName(SeekBar.ViewModel.Chapters.IndexOf(chapterCue) + 1);
+    }
+}

--- a/Screenbox/Converters/ChapterTitleConverter.cs
+++ b/Screenbox/Converters/ChapterTitleConverter.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Windows.Media.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace Screenbox.Converters;
+
+public sealed class ChapterTitleConverter : DependencyObject, IValueConverter
+{
+    public static readonly DependencyProperty ChaptersProperty = DependencyProperty.Register(
+    nameof(Chapters),
+    typeof(IList<ChapterCue>),
+    typeof(ChapterTitleConverter),
+    new PropertyMetadata(null));
+
+    public IList<ChapterCue>? Chapters
+    {
+        get => (IList<ChapterCue>?)GetValue(ChaptersProperty);
+        set => SetValue(ChaptersProperty, value);
+    }
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        return GetChapterTitle(value as ChapterCue);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+
+    private string GetChapterTitle(ChapterCue? chapterCue)
+    {
+        if (chapterCue is null) return string.Empty;
+        return !string.IsNullOrWhiteSpace(chapterCue.Title) || Chapters is null
+            ? chapterCue.Title.TrimStart()
+            : Screenbox.Strings.Resources.ChapterName(Chapters.IndexOf(chapterCue) + 1);
+    }
+}

--- a/Screenbox/Converters/ChapterTitleConverter.cs
+++ b/Screenbox/Converters/ChapterTitleConverter.cs
@@ -11,10 +11,10 @@ namespace Screenbox.Converters;
 public sealed class ChapterTitleConverter : DependencyObject, IValueConverter
 {
     public static readonly DependencyProperty ChaptersProperty = DependencyProperty.Register(
-    nameof(Chapters),
-    typeof(IList<ChapterCue>),
-    typeof(ChapterTitleConverter),
-    new PropertyMetadata(null));
+        nameof(Chapters),
+        typeof(IList<ChapterCue>),
+        typeof(ChapterTitleConverter),
+        new PropertyMetadata(null));
 
     public IList<ChapterCue>? Chapters
     {
@@ -22,21 +22,32 @@ public sealed class ChapterTitleConverter : DependencyObject, IValueConverter
         set => SetValue(ChaptersProperty, value);
     }
 
+    /// <summary>
+    /// Gets a display-ready title for the specified chapter cue.
+    /// </summary>
+    /// <param name="chapterCue">The chapter cue for which to get the title.</param>
+    /// <param name="chapters">The list of chapter cues.</param>
+    /// <returns>
+    /// The chapter title with leading whitespace removed if available; otherwise,
+    /// a fallback title derived from the chapter index.
+    /// </returns>
+    public static string GetChapterTitle(ChapterCue? chapterCue, IList<ChapterCue>? chapters)
+    {
+        if (chapterCue is null) return string.Empty;
+        return !string.IsNullOrWhiteSpace(chapterCue.Title) || chapters is null
+            ? chapterCue.Title.TrimStart()
+            : Strings.Resources.ChapterName(chapters.IndexOf(chapterCue) + 1);
+    }
+
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        return GetChapterTitle(value as ChapterCue);
+        return value is not ChapterCue chapter
+            ? DependencyProperty.UnsetValue
+            : GetChapterTitle(chapter, Chapters);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
         throw new NotImplementedException();
-    }
-
-    private string GetChapterTitle(ChapterCue? chapterCue)
-    {
-        if (chapterCue is null) return string.Empty;
-        return !string.IsNullOrWhiteSpace(chapterCue.Title) || Chapters is null
-            ? chapterCue.Title.TrimStart()
-            : Screenbox.Strings.Resources.ChapterName(Chapters.IndexOf(chapterCue) + 1);
     }
 }

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Controls\VolumeControl.xaml.cs">
       <DependentUpon>VolumeControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converters\ChapterTitleConverter.cs" />
     <Compile Include="Converters\FirstOrDefaultConverter.cs" />
     <Compile Include="Converters\GlyphConverter.cs" />
     <Compile Include="Converters\HumanizedDurationConverter.cs" />


### PR DESCRIPTION
Before

<img width="288" height="615" alt="image" src="https://github.com/user-attachments/assets/4d50f370-06c4-40cc-ba5f-df719256b86a" />

After
<img width="293" height="623" alt="image" src="https://github.com/user-attachments/assets/cf80d2b5-d963-4347-a211-848cfcbee272" />
