### PR TITLE
feat: allow users to set a custom save location for frame captures

### DIFF
--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -191,7 +191,12 @@ public sealed class FilesService : IFilesService
         return new MediaInfo(mediaType);
     }
 
-    public async Task<StorageFolder> GetFrameCaptureFolderAsync(string token)
+    public IAsyncOperation<StorageFolder> GetFrameCaptureFolderAsync(string token)
+    {
+        return GetFrameCaptureFolderFromTokenAsync(token).AsAsyncOperation();
+    }
+
+    private static async Task<StorageFolder> GetFrameCaptureFolderFromTokenAsync(string token)
     {
         if (!string.IsNullOrEmpty(token)
             && StorageApplicationPermissions.FutureAccessList.ContainsItem(token))

--- a/Screenbox.Core/Services/FilesService.cs
+++ b/Screenbox.Core/Services/FilesService.cs
@@ -191,6 +191,27 @@ public sealed class FilesService : IFilesService
         return new MediaInfo(mediaType);
     }
 
+    public async Task<StorageFolder> GetFrameCaptureFolderAsync(string token)
+    {
+        if (!string.IsNullOrEmpty(token)
+            && StorageApplicationPermissions.FutureAccessList.ContainsItem(token))
+        {
+            try
+            {
+                return await StorageApplicationPermissions.FutureAccessList.GetFolderAsync(token);
+            }
+            catch (Exception e) when (e is FileNotFoundException or UnauthorizedAccessException)
+            {
+                // Folder was moved, deleted, or access was revoked. Fall back to the default location.
+            }
+        }
+
+        StorageLibrary pictureLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
+        StorageFolder defaultSaveFolder = pictureLibrary.SaveFolder;
+
+        return await defaultSaveFolder.CreateFolderAsync("Screenbox", CreationCollisionOption.OpenIfExists);
+    }
+
     private static bool IsExpectedStoragePropertiesHResult(int hresult)
     {
         const int RPC_S_SERVER_UNAVAILABLE = unchecked((int)0x800706BA);

--- a/Screenbox.Core/Services/IFilesService.cs
+++ b/Screenbox.Core/Services/IFilesService.cs
@@ -28,5 +28,13 @@ public interface IFilesService
     public void AddToRecent(IStorageItem item);
     public Task<MediaInfo> GetMediaInfoAsync(StorageFile file);
 
-    Task<StorageFolder> GetFrameCaptureFolderAsync(string token);
+    /// <summary>
+    /// Retrieves the frame captures <see cref="StorageFolder"/> for the given token.
+    /// </summary>
+    /// <param name="token">The token of the frame captures folder.</param>
+    /// <returns>
+    /// When this method completes successfully, it returns the frame captures folder
+    /// that is associated with the specified token.
+    /// </returns>
+    IAsyncOperation<StorageFolder> GetFrameCaptureFolderAsync(string token);
 }

--- a/Screenbox.Core/Services/IFilesService.cs
+++ b/Screenbox.Core/Services/IFilesService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -27,4 +27,6 @@ public interface IFilesService
     public Task OpenFileLocationAsync(StorageFile file);
     public void AddToRecent(IStorageItem item);
     public Task<MediaInfo> GetMediaInfoAsync(StorageFile file);
+
+    Task<StorageFolder> GetFrameCaptureFolderAsync(string token);
 }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -37,6 +37,16 @@ public interface ISettingsService
     MediaPlaybackAutoRepeatMode PersistentRepeatMode { get; set; }
 
     /// <summary>
+    /// Gets or sets the access token used to retrieve the user-selected folder where
+    /// video frame captures are saved via <see cref="Windows.Storage.AccessCache.StorageApplicationPermissions"/>.
+    /// </summary>
+    /// <value>
+    /// The token of the <see cref="Windows.Storage.StorageFolder"/>, or an
+    /// empty string if the default location should be used.
+    /// </value>
+    string FrameCaptureFolderToken { get; set; }
+
+    /// <summary>
     /// Gets or sets a value that indicates whether the playback position should be saved
     /// and restored between sessions.
     /// </summary>

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -23,6 +23,7 @@ public sealed class SettingsService : ISettingsService
     private const string LibrariesSearchRemovableStorageKey = "Libraries/SearchRemovableStorage";
     private const string GeneralShowRecent = "General/ShowRecent";
     private const string GeneralEnqueueAllInFolder = "General/EnqueueAllInFolder";
+    private const string GeneralFrameCaptureFolderTokenKey = "General/FrameCaptureFolderToken";
     private const string GeneralRestorePlaybackPosition = "General/RestorePlaybackPosition";
     private const string AdvancedModeKey = "Advanced/IsEnabled";
     private const string AdvancedVideoUpscaleKey = "Advanced/VideoUpscale";
@@ -93,6 +94,12 @@ public sealed class SettingsService : ISettingsService
     {
         get => GetValue<bool>(GeneralEnqueueAllInFolder);
         set => SetValue(GeneralEnqueueAllInFolder, value);
+    }
+
+    public string FrameCaptureFolderToken
+    {
+        get => GetValue<string>(GeneralFrameCaptureFolderTokenKey) ?? string.Empty;
+        set => SetValue(GeneralFrameCaptureFolderTokenKey, value);
     }
 
     public bool RestorePlaybackPosition
@@ -242,6 +249,7 @@ public sealed class SettingsService : ISettingsService
         SetDefault(MaxVolumeKey, 100);
         SetDefault(LibrariesUseIndexerKey, true);
         SetDefault(LibrariesSearchRemovableStorageKey, true);
+        SetDefault(GeneralFrameCaptureFolderTokenKey, string.Empty);
         SetDefault(GeneralShowRecent, true);
         SetDefault(PersistentRepeatModeKey, (int)MediaPlaybackAutoRepeatMode.None);
         SetDefault(AdvancedModeKey, false);

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -67,11 +67,14 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     private readonly IWindowService _windowService;
     private readonly ISettingsService _settingsService;
     private readonly PlayerContext _playerContext;
+    private readonly IFilesService _filesService;
     private readonly IPlayQueueCoordinator _coordinator;
+
     private Size _aspectRatio;
 
     public PlayerControlsViewModel(
         PlayQueueContext playQueue,
+        IFilesService filesService,
         IPlayQueueCoordinator coordinator,
         ISettingsService settingsService,
         IWindowService windowService,
@@ -81,6 +84,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         _windowService = windowService;
         _settingsService = settingsService;
         _playerContext = playerContext;
+        _filesService = filesService;
         _coordinator = coordinator;
         _playbackRate = 1.0;
         _audioTimingOffset = 0.0;
@@ -432,7 +436,8 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
     }
 
     /// <summary>
-    /// Saves a snapshot of the current video frame to the Pictures library.
+    /// Saves a snapshot of the current video frame to the configured folder, falling back
+    /// to the Pictures library when the folder is not set or cannot be accessed.
     /// Sends a <see cref="FailedToSaveFrameNotificationMessage"/> on failure.
     /// </summary>
     [RelayCommand(CanExecute = nameof(HasVideo))]
@@ -454,7 +459,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
         }
     }
 
-    private static async Task<StorageFile> SaveSnapshotInternalAsync(IMediaPlayer mediaPlayer)
+    private async Task<StorageFile> SaveSnapshotInternalAsync(IMediaPlayer mediaPlayer)
     {
         if (mediaPlayer is not VlcMediaPlayer player)
         {
@@ -471,11 +476,7 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
                 throw new Exception("VLC failed to save snapshot");
 
             StorageFile file = (await tempFolder.GetFilesAsync())[0];
-            StorageLibrary pictureLibrary = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
-            StorageFolder defaultSaveFolder = pictureLibrary.SaveFolder;
-            StorageFolder destFolder =
-                await defaultSaveFolder.CreateFolderAsync("Screenbox",
-                    CreationCollisionOption.OpenIfExists);
+            StorageFolder destFolder = await _filesService.GetFrameCaptureFolderAsync(_settingsService.FrameCaptureFolderToken);
             return await file.CopyAsync(destFolder, $"Screenbox_{DateTimeOffset.Now:yyyyMMdd_HHmmss}{file.FileType}",
                 NameCollisionOption.GenerateUniqueName);
         }

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -56,7 +56,7 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
     [ObservableProperty] private bool _persistPlaybackPosition;
 
     [ObservableProperty]
-    private string _frameCaptureFolderPath;
+    private StorageFolder? _frameCaptureFolder;
 
     public ObservableCollection<StorageFolder> MusicLocations { get; }
 
@@ -158,8 +158,6 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
             >= 125 => 1,
             _ => 0
         };
-
-        _frameCaptureFolderPath = string.Empty;
 
         string currentLanguage = ApplicationLanguages.PrimaryLanguageOverride;
         _selectedLanguage = AvailableLanguages.FindIndex(l => l.LanguageTag.Equals(currentLanguage));
@@ -442,7 +440,21 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
 
         string newToken = StorageApplicationPermissions.FutureAccessList.Add(folder);
         _settingsService.FrameCaptureFolderToken = newToken;
-        FrameCaptureFolderPath = folder.Path;
+        FrameCaptureFolder = folder;
+    }
+
+    [RelayCommand]
+    private async Task OpenFrameCaptureFolderAsync()
+    {
+        try
+        {
+            await LoadFrameCaptureFolderAsync();
+            await Launcher.LaunchFolderAsync(FrameCaptureFolder);
+        }
+        catch (Exception e)
+        {
+            LogService.Log(e);
+        }
     }
 
     [RelayCommand]
@@ -495,12 +507,11 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
         await UpdateRemovableStorageFoldersAsync();
     }
 
-    public async Task LoadFrameCaptureFolderPathAsync()
+    public async Task LoadFrameCaptureFolderAsync()
     {
         try
         {
-            var destFolder = await _filesService.GetFrameCaptureFolderAsync(_settingsService.FrameCaptureFolderToken);
-            FrameCaptureFolderPath = destFolder.Path;
+            FrameCaptureFolder = await _filesService.GetFrameCaptureFolderAsync(_settingsService.FrameCaptureFolderToken);
         }
         catch (Exception e)
         {

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -438,7 +438,7 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
             StorageApplicationPermissions.FutureAccessList.Remove(oldToken);
         }
 
-        string newToken = StorageApplicationPermissions.FutureAccessList.Add(folder);
+        string newToken = StorageApplicationPermissions.FutureAccessList.Add(folder, "frame-capture");
         _settingsService.FrameCaptureFolderToken = newToken;
         FrameCaptureFolder = folder;
     }

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -55,6 +55,9 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
     [ObservableProperty] private int _selectedLanguage;
     [ObservableProperty] private bool _persistPlaybackPosition;
 
+    [ObservableProperty]
+    private string _frameCaptureFolderPath;
+
     public ObservableCollection<StorageFolder> MusicLocations { get; }
 
     public ObservableCollection<StorageFolder> VideoLocations { get; }
@@ -70,6 +73,7 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
     public IReadOnlyList<PlaybackActionKind> GestureOptions { get; } = (PlaybackActionKind[])Enum.GetValues(typeof(PlaybackActionKind));
 
     private readonly ISettingsService _settingsService;
+    private readonly IFilesService _filesService;
     private readonly LibraryContext _libraryContext;
     private readonly ILibraryCoordinator _libraryCoordinator;
     private readonly DispatcherQueue _dispatcherQueue;
@@ -90,11 +94,13 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
 
     public SettingsPageViewModel(
         ISettingsService settingsService,
+        IFilesService filesService,
         LibraryContext libraryContext,
         ILibraryCoordinator libraryCoordinator,
         IPlaybackProgressTracker playbackProgressTracker)
     {
         _settingsService = settingsService;
+        _filesService = filesService;
         _libraryContext = libraryContext;
         _libraryCoordinator = libraryCoordinator;
         _playbackProgressTracker = playbackProgressTracker;
@@ -152,6 +158,8 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
             >= 125 => 1,
             _ => 0
         };
+
+        _frameCaptureFolderPath = string.Empty;
 
         string currentLanguage = ApplicationLanguages.PrimaryLanguageOverride;
         _selectedLanguage = AvailableLanguages.FindIndex(l => l.LanguageTag.Equals(currentLanguage));
@@ -420,6 +428,24 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
     }
 
     [RelayCommand]
+    private async Task ChangeFrameCaptureLocationAsync()
+    {
+        StorageFolder? folder = await _filesService.PickFolderAsync();
+        if (folder is null) return;
+
+        // Release the previous entry so the FutureAccessList (capped at 1000 items) doesn't accumulate stale folders.
+        string oldToken = _settingsService.FrameCaptureFolderToken;
+        if (!string.IsNullOrEmpty(oldToken) && StorageApplicationPermissions.FutureAccessList.ContainsItem(oldToken))
+        {
+            StorageApplicationPermissions.FutureAccessList.Remove(oldToken);
+        }
+
+        string newToken = StorageApplicationPermissions.FutureAccessList.Add(folder);
+        _settingsService.FrameCaptureFolderToken = newToken;
+        FrameCaptureFolderPath = folder.Path;
+    }
+
+    [RelayCommand]
     private void ClearRecentHistory()
     {
         StorageApplicationPermissions.MostRecentlyUsedList.Clear();
@@ -467,6 +493,19 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
 
         UpdateLibraryLocations();
         await UpdateRemovableStorageFoldersAsync();
+    }
+
+    public async Task LoadFrameCaptureFolderPathAsync()
+    {
+        try
+        {
+            var destFolder = await _filesService.GetFrameCaptureFolderAsync(_settingsService.FrameCaptureFolderToken);
+            FrameCaptureFolderPath = destFolder.Path;
+        }
+        catch (Exception e)
+        {
+            LogService.Log(e);
+        }
     }
 
     private void LibraryOnDefinitionChanged(StorageLibrary sender, object args)

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:behaviors="using:Screenbox.Behaviors"
     xmlns:commands="using:Screenbox.Commands"
-    xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
+    xmlns:contract14Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,14)"
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:ctBehaviors="using:CommunityToolkit.WinUI.Behaviors"
@@ -332,14 +332,36 @@
                 <ctc:SettingsCard
                     Margin="{StaticResource SettingsCardMargin}"
                     AutomationProperties.Name="{x:Bind strings:Resources.SettingsFrameCaptureLocationDescription}"
-                    Description="{x:Bind ViewModel.FrameCaptureFolderPath, Mode=OneWay}"
                     Header="{x:Bind strings:Resources.SettingsFrameCaptureLocationHeader}"
                     HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                              Glyph={StaticResource ImageExportGlyph}}">
+                    <ctc:SettingsCard.Description>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{x:Bind ViewModel.FrameCaptureFolder.Path, Mode=OneWay}" />
+                            <HyperlinkButton
+                                Padding="4,0"
+                                contract14Present:AutomationProperties.AutomationControlType="Button"
+                                AutomationProperties.Name="{x:Bind strings:Resources.ChangeFolder}"
+                                BorderThickness="0"
+                                Command="{x:Bind ViewModel.ChangeFrameCaptureLocationCommand}"
+                                Content="{x:Bind strings:Resources.Change}"
+                                FocusVisualMargin="0,-3"
+                                FontWeight="Normal">
+                                <HyperlinkButton.Resources>
+                                    <StaticResource x:Key="HyperlinkButtonBackgroundPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+                                    <StaticResource x:Key="HyperlinkButtonBackgroundPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+                                    <StaticResource x:Key="HyperlinkButtonBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+                                </HyperlinkButton.Resources>
+                            </HyperlinkButton>
+                        </StackPanel>
+                    </ctc:SettingsCard.Description>
                     <Button
                         MinWidth="{StaticResource SettingsCardButtonMinWidth}"
-                        Command="{x:Bind ViewModel.ChangeFrameCaptureLocationCommand}"
-                        Content="{x:Bind strings:Resources.ChangeFolder}" />
+                        Command="{x:Bind ViewModel.OpenFrameCaptureFolderCommand}"
+                        Content="{x:Bind strings:Resources.OpenFolder}" />
                 </ctc:SettingsCard>
                 <!--#endregion-->
 
@@ -788,10 +810,10 @@
                         <StateTrigger IsActive="{x:Bind helpers:GlobalizationHelper.IsRightToLeftLanguage}" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <contract13Present:Setter Target="MusicLibrarySettingsExpanderIcon.Glyph" Value="{StaticResource MusicLibraryMirroredGlyph}" />
-                        <contract13Present:Setter Target="SettingsExpanderAddMusicFolderButtonIcon.Glyph" Value="{StaticResource NewFolderMirroredGlyph}" />
-                        <contract13Present:Setter Target="VideoLibrarySettingsExpanderIcon.Glyph" Value="{StaticResource MoviesLibraryMirroredGlyph}" />
-                        <contract13Present:Setter Target="SettingsExpanderAddVideoFolderButtonIcon.Glyph" Value="{StaticResource NewFolderMirroredGlyph}" />
+                        <contract14Present:Setter Target="MusicLibrarySettingsExpanderIcon.Glyph" Value="{StaticResource MusicLibraryMirroredGlyph}" />
+                        <contract14Present:Setter Target="SettingsExpanderAddMusicFolderButtonIcon.Glyph" Value="{StaticResource NewFolderMirroredGlyph}" />
+                        <contract14Present:Setter Target="VideoLibrarySettingsExpanderIcon.Glyph" Value="{StaticResource MoviesLibraryMirroredGlyph}" />
+                        <contract14Present:Setter Target="SettingsExpanderAddVideoFolderButtonIcon.Glyph" Value="{StaticResource NewFolderMirroredGlyph}" />
                         <Setter Target="SettingsEnqueueAllFilesInFolderCard.HeaderIcon" Value="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily}, Glyph={StaticResource FolderListMirroredGlyph}}" />
                         <Setter Target="SettingsAudioVisualExpander.HeaderIcon" Value="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily}, Glyph={StaticResource MusicVisualizerMirroredGlyph}}" />
                     </VisualState.Setters>

--- a/Screenbox/Pages/SettingsPage.xaml
+++ b/Screenbox/Pages/SettingsPage.xaml
@@ -316,9 +316,9 @@
                     </ComboBox>
                 </ctc:SettingsCard>
 
-                <!--  General section  -->
+                <!--#region General Section-->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryGeneral}" />
-
+                <!--  Enqueue All Files In Folder  -->
                 <ctc:SettingsCard
                     x:Name="SettingsEnqueueAllFilesInFolderCard"
                     Margin="{StaticResource SettingsCardMargin}"
@@ -328,6 +328,20 @@
                                              Glyph={StaticResource FolderListGlyph}}">
                     <ToggleSwitch AutomationProperties.HelpText="{strings:Resources Key=SettingsEnqueueAllFilesInFolderDescription}" IsOn="{x:Bind ViewModel.EnqueueAllFilesInFolder, Mode=TwoWay}" />
                 </ctc:SettingsCard>
+                <!--  Frame Capture Location  -->
+                <ctc:SettingsCard
+                    Margin="{StaticResource SettingsCardMargin}"
+                    AutomationProperties.Name="{x:Bind strings:Resources.SettingsFrameCaptureLocationDescription}"
+                    Description="{x:Bind ViewModel.FrameCaptureFolderPath, Mode=OneWay}"
+                    Header="{x:Bind strings:Resources.SettingsFrameCaptureLocationHeader}"
+                    HeaderIcon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
+                                             Glyph={StaticResource ImageExportGlyph}}">
+                    <Button
+                        MinWidth="{StaticResource SettingsCardButtonMinWidth}"
+                        Command="{x:Bind ViewModel.ChangeFrameCaptureLocationCommand}"
+                        Content="{x:Bind strings:Resources.ChangeFolder}" />
+                </ctc:SettingsCard>
+                <!--#endregion-->
 
                 <!--  Player section  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{strings:Resources Key=SettingsCategoryPlayer}" />

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class SettingsPage : Page
     {
         base.OnNavigatedTo(e);
         await ViewModel.LoadLibraryLocations();
-        await ViewModel.LoadFrameCaptureFolderPathAsync();
+        await ViewModel.LoadFrameCaptureFolderAsync();
         await AudioVisualSelector.ViewModel.InitializeVisualizers();
     }
 

--- a/Screenbox/Pages/SettingsPage.xaml.cs
+++ b/Screenbox/Pages/SettingsPage.xaml.cs
@@ -40,6 +40,7 @@ public sealed partial class SettingsPage : Page
     {
         base.OnNavigatedTo(e);
         await ViewModel.LoadLibraryLocations();
+        await ViewModel.LoadFrameCaptureFolderPathAsync();
         await AudioVisualSelector.ViewModel.InitializeVisualizers();
     }
 

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1144,4 +1144,13 @@
   <data name="NoPlaylistItems" xml:space="preserve">
     <value>There are no items in this playlist.</value>
   </data>
+  <data name="SettingsFrameCaptureLocationHeader" xml:space="preserve">
+    <value>Frame captures will save to</value>
+  </data>
+  <data name="SettingsFrameCaptureLocationDescription" xml:space="preserve">
+    <value>Frame captures location</value>
+  </data>
+  <data name="ChangeFolder" xml:space="preserve">
+    <value>Change folder</value>
+  </data>
 </root>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -1153,4 +1153,7 @@
   <data name="ChangeFolder" xml:space="preserve">
     <value>Change folder</value>
   </data>
+  <data name="Change" xml:space="preserve">
+    <value>Change</value>
+  </data>
 </root>


### PR DESCRIPTION
Closes #827. Inspired by #828, adds support for choosing a custom folder where frame captures are saved, instead of relying on a fixed default directory.

The design draws inspiration from both the **Gaming > Captures** "Captures location" and the equivalent setting used in the **Screen Recorder**. I added the `Open folder` button as a convenience feature for XBOX users.

<img width="1280" height="480" alt="Screenbox general settings" src="https://github.com/user-attachments/assets/2c40d1af-3e96-4d0e-b7c4-f78bf5fd6446" />

https://github.com/user-attachments/assets/3001298d-b96b-4e8e-b1be-30edd872f46f

