### PR TITLE
fix: unnecessary selection when using keyboard navigation on some ListViewBase controls

### DIFF
--- a/Screenbox/Controls/PlayQueueControl.xaml
+++ b/Screenbox/Controls/PlayQueueControl.xaml
@@ -256,7 +256,7 @@
             IsItemClickEnabled="True"
             ItemsSource="{x:Bind ViewModel.Queue.Items}"
             KeyboardAcceleratorPlacementMode="Hidden"
-            SelectionMode="Extended"
+            SelectionMode="None"
             Style="{StaticResource MediaListViewStyle}">
             <ListView.Resources>
                 <x:Boolean x:Key="ListViewItemSelectionIndicatorVisualEnabled">False</x:Boolean>

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -237,7 +237,7 @@
             ItemTemplate="{StaticResource MediaGridViewItemTemplate}"
             ItemsSource="{x:Bind ViewModel.Recent}"
             KeyboardAcceleratorPlacementMode="Hidden"
-            SelectionMode="Extended">
+            SelectionMode="None">
             <GridView.Resources>
                 <commands:BindableCommand x:Key="MediaListViewItemPlayCommand" Command="{x:Bind ViewModel.PlayCommand}" />
             </GridView.Resources>

--- a/Screenbox/Pages/PlaylistsPage.xaml
+++ b/Screenbox/Pages/PlaylistsPage.xaml
@@ -202,7 +202,7 @@
             ItemTemplate="{StaticResource PlaylistGridViewItemTemplate}"
             ItemsSource="{x:Bind ViewModel.Playlists}"
             KeyboardAcceleratorPlacementMode="Hidden"
-            SelectionMode="Extended">
+            SelectionMode="None">
             <GridView.Resources>
                 <commands:BindableCommand x:Key="MediaListViewItemPlayCommand" Command="{x:Bind ViewModel.PlayCommand}" />
             </GridView.Resources>


### PR DESCRIPTION
On `ListViewBase` controls, selection follows focus when navigating with the keyboard or gamepad. This triggers multi-select mode on these controls, which is not intended.

https://github.com/user-attachments/assets/ee27379f-c376-4b7f-94d7-62e9dcc8908d


