### PR TITLE
refactor: register message handlers explicity in ObservableRecipients

### DIFF
--- a/Screenbox.Core/Coordinators/PlayQueueCoordinator.cs
+++ b/Screenbox.Core/Coordinators/PlayQueueCoordinator.cs
@@ -128,7 +128,12 @@ public sealed partial class PlayQueueCoordinator : ObservableRecipient, IPlayQue
             MediaPlayer.PlaybackStateChanged += OnPlaybackStateChanged;
         }
 
-        IsActive = true;
+        Messenger.Register<PlayMediaMessage>(this);
+        Messenger.Register<PlayFilesMessage>(this);
+        Messenger.Register<SetQueueMessage>(this);
+        Messenger.Register<ClearQueueMessage>(this);
+        Messenger.Register<QueueRequestMessage>(this);
+        Messenger.Register<PropertyChangedMessage<IMediaPlayer?>>(this);
     }
 
     #region Message Handlers

--- a/Screenbox.Core/Services/PlaybackProgressTracker.cs
+++ b/Screenbox.Core/Services/PlaybackProgressTracker.cs
@@ -29,7 +29,7 @@ public sealed class PlaybackProgressTracker : ObservableRecipient, IPlaybackProg
     {
         _databaseService = databaseService;
 
-        IsActive = true;
+        Messenger.Register<SuspendingMessage>(this);
     }
 
     public void Receive(SuspendingMessage message)

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -39,7 +39,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue.CreateTimer();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)

--- a/Screenbox.Core/ViewModels/AllVideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AllVideosPageViewModel.cs
@@ -36,7 +36,7 @@ public sealed partial class AllVideosPageViewModel : ObservableRecipient,
         _timer = _dispatcherQueue.CreateTimer();
         Videos = new ObservableCollection<MediaViewModel>();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<VideosLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<VideosLibrary> message)

--- a/Screenbox.Core/ViewModels/ArtistsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/ArtistsPageViewModel.cs
@@ -34,7 +34,7 @@ public sealed partial class ArtistsPageViewModel : BaseMusicContentViewModel,
         _refreshTimer = _dispatcherQueue.CreateTimer();
         PopulateGroups();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)

--- a/Screenbox.Core/ViewModels/CommonViewModel.cs
+++ b/Screenbox.Core/ViewModels/CommonViewModel.cs
@@ -54,8 +54,9 @@ public sealed partial class CommonViewModel : ObservableRecipient,
         NavigationStates = new Dictionary<Type, string>();
         _pageStates = new Dictionary<string, object>();
 
-        // Activate the view model's messenger
-        IsActive = true;
+        Messenger.Register<SettingsChangedMessage>(this);
+        Messenger.Register<PropertyChangedMessage<NavigationViewDisplayMode>>(this);
+        Messenger.Register<PropertyChangedMessage<PlayerVisibilityState>>(this);
     }
 
     public void Receive(SettingsChangedMessage message)

--- a/Screenbox.Core/ViewModels/CompositeTrackPickerViewModel.cs
+++ b/Screenbox.Core/ViewModels/CompositeTrackPickerViewModel.cs
@@ -75,7 +75,7 @@ public sealed partial class CompositeTrackPickerViewModel : ObservableRecipient,
         AudioTracks = new ObservableCollection<string>();
         VideoTracks = new ObservableCollection<string>();
 
-        IsActive = true;
+        Messenger.Register<QueueCurrentItemChangedMessage>(this);
     }
 
     /// <summary>

--- a/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
@@ -56,7 +56,7 @@ public partial class FolderViewPageViewModel : ObservableRecipient,
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _loadingTimer = _dispatcherQueue.CreateTimer();
 
-        IsActive = true;
+        Messenger.Register<RefreshFolderMessage>(this);
     }
 
     public void Receive(RefreshFolderMessage message)

--- a/Screenbox.Core/ViewModels/HomePageViewModel.cs
+++ b/Screenbox.Core/ViewModels/HomePageViewModel.cs
@@ -55,8 +55,7 @@ public sealed partial class HomePageViewModel : ObservableRecipient,
         Selection.SetItemsSource(Recent);
         Selection.PropertyChanged += Selection_OnPropertyChanged;
 
-        // Activate the view model's messenger
-        IsActive = true;
+        Messenger.Register<QueueCurrentItemChangedMessage>(this);
     }
 
     public void Receive(QueueCurrentItemChangedMessage message)

--- a/Screenbox.Core/ViewModels/MainPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MainPageViewModel.cs
@@ -79,7 +79,9 @@ public sealed partial class MainPageViewModel : ObservableRecipient,
         CriticalErrorMessage = string.Empty;
         SearchSuggestions = new ObservableCollection<SearchSuggestion>();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<PlayerVisibilityState>>(this);
+        Messenger.Register<NavigationViewDisplayModeRequestMessage>(this);
+        Messenger.Register<CriticalErrorMessage>(this);
     }
 
     public void Receive(CriticalErrorMessage message)

--- a/Screenbox.Core/ViewModels/MusicPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/MusicPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Threading.Tasks;
@@ -30,7 +30,7 @@ public sealed partial class MusicPageViewModel : ObservableRecipient,
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         HasContent = true;
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)

--- a/Screenbox.Core/ViewModels/NotificationViewModel.cs
+++ b/Screenbox.Core/ViewModels/NotificationViewModel.cs
@@ -70,8 +70,22 @@ public sealed partial class NotificationViewModel : ObservableRecipient,
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _timer = _dispatcherQueue.CreateTimer();
 
-        // Activate the view model's messenger
-        IsActive = true;
+        Messenger.Register<RaiseFrameSavedNotificationMessage>(this);
+        Messenger.Register<RaiseResumePositionNotificationMessage>(this);
+        Messenger.Register<RaiseLibraryAccessDeniedNotificationMessage>(this);
+        Messenger.Register<MediaLoadFailedNotificationMessage>(this);
+        Messenger.Register<CloseNotificationMessage>(this);
+        Messenger.Register<SubtitleAddedNotificationMessage>(this);
+        Messenger.Register<ErrorMessage>(this);
+        Messenger.Register<FailedToSaveFrameNotificationMessage>(this);
+        Messenger.Register<FailedToLoadSubtitleNotificationMessage>(this);
+        Messenger.Register<FailedToOpenFilesNotificationMessage>(this);
+        Messenger.Register<FailedToAddFolderNotificationMessage>(this);
+        Messenger.Register<FailedToInitializeNotificationMessage>(this);
+        Messenger.Register<PlaylistCreatedNotificationMessage>(this);
+        Messenger.Register<PlaylistDeletedNotificationMessage>(this);
+        Messenger.Register<PlaylistRenamedNotificationMessage>(this);
+        Messenger.Register<PlaylistItemsAddedNotificationMessage>(this);
     }
 
     /// <summary>

--- a/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerControlsViewModel.cs
@@ -103,7 +103,12 @@ public sealed partial class PlayerControlsViewModel : ObservableRecipient,
             MediaPlayer.NaturalVideoSizeChanged += OnNaturalVideoSizeChanged;
         }
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<IMediaPlayer?>>(this);
+        Messenger.Register<SettingsChangedMessage>(this);
+        Messenger.Register<TogglePlayPauseMessage>(this);
+        Messenger.Register<ChangePlaybackRateRequestMessage>(this);
+        Messenger.Register<PropertyChangedMessage<PlayerVisibilityState>>(this);
+        Messenger.Register<PropertyChangedMessage<WindowViewMode>>(this);
     }
 
     public void Receive(SettingsChangedMessage message)

--- a/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerElementViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -96,8 +96,8 @@ public sealed partial class PlayerElementViewModel : ObservableRecipient,
         transportControlsService.TransportControls.ButtonPressed += TransportControlsOnButtonPressed;
         transportControlsService.TransportControls.PlaybackPositionChangeRequested += TransportControlsOnPlaybackPositionChangeRequested;
 
-        // View model does not receive any message
-        IsActive = true;
+        Messenger.Register<ChangeAspectRatioMessage>(this);
+        Messenger.Register<SettingsChangedMessage>(this);
     }
 
     public void Receive(SettingsChangedMessage message)

--- a/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/PlayerPageViewModel.cs
@@ -131,8 +131,17 @@ public sealed partial class PlayerPageViewModel : ObservableRecipient,
             MediaPlayer.NaturalVideoSizeChanged += OnNaturalVideoSizeChanged;
         }
 
-        // Activate the view model's messenger
-        IsActive = true;
+        Messenger.Register<UpdateStatusMessage>(this);
+        Messenger.Register<UpdateVolumeStatusMessage>(this);
+        Messenger.Register<TogglePlayerVisibilityMessage>(this);
+        Messenger.Register<PropertyChangedMessage<IMediaPlayer?>>(this);
+        Messenger.Register<QueueCurrentItemChangedMessage>(this);
+        Messenger.Register<ShowPlayPauseBadgeMessage>(this);
+        Messenger.Register<OverrideControlsHideDelayMessage>(this);
+        Messenger.Register<DragDropMessage>(this);
+        Messenger.Register<VisualizerChangedMessage>(this);
+        Messenger.Register<PropertyChangedMessage<NavigationViewDisplayMode>>(this);
+        Messenger.Register<PropertyChangedMessage<WindowViewMode>>(this);
     }
 
     public async void Receive(DragDropMessage message)

--- a/Screenbox.Core/ViewModels/SeekBarViewModel.cs
+++ b/Screenbox.Core/ViewModels/SeekBarViewModel.cs
@@ -99,8 +99,12 @@ public sealed partial class SeekBarViewModel :
             MediaPlayer.CanSeekChanged += OnCanSeekChanged;
         }
 
-        // Activate the view model's messenger
-        IsActive = true;
+        Messenger.Register<TimeChangeOverrideMessage>(this);
+        Messenger.Register<ChangeTimeRequestMessage>(this);
+        Messenger.Register<PlayerControlsVisibilityChangedMessage>(this);
+        Messenger.Register<QueueCurrentItemChangedMessage>(this);
+        Messenger.Register<PropertyChangedMessage<PlayerVisibilityState>>(this);
+        Messenger.Register<PropertyChangedMessage<IMediaPlayer?>>(this);
     }
 
     public void Receive(QueueCurrentItemChangedMessage message)

--- a/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SettingsPageViewModel.cs
@@ -165,8 +165,6 @@ public sealed partial class SettingsPageViewModel : ObservableRecipient
         // Setting initial values for relaunch check
         _initialValues ??= new InitialValues(GlobalArguments, AdvancedMode, VideoUpscaling, SelectedLanguage);
         CheckForRelaunch();
-
-        IsActive = true;
     }
 
     partial void OnThemeChanged(int value)

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -35,7 +35,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue.CreateTimer();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)

--- a/Screenbox.Core/ViewModels/VideosPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/VideosPageViewModel.cs
@@ -39,7 +39,7 @@ public sealed partial class VideosPageViewModel : ObservableRecipient,
         HasVideos = true;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<VideosLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<VideosLibrary> message)

--- a/Screenbox.Core/ViewModels/VolumeViewModel.cs
+++ b/Screenbox.Core/ViewModels/VolumeViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -10,113 +10,113 @@ using Screenbox.Core.Playback;
 using Screenbox.Core.Services;
 using Windows.System;
 
-namespace Screenbox.Core.ViewModels
+namespace Screenbox.Core.ViewModels;
+
+public sealed partial class VolumeViewModel : ObservableRecipient,
+    IRecipient<ChangeVolumeRequestMessage>,
+    IRecipient<SettingsChangedMessage>,
+    IRecipient<PropertyChangedMessage<IMediaPlayer?>>
 {
-    public sealed partial class VolumeViewModel : ObservableRecipient,
-        IRecipient<ChangeVolumeRequestMessage>,
-        IRecipient<SettingsChangedMessage>,
-        IRecipient<PropertyChangedMessage<IMediaPlayer?>>
+    [ObservableProperty] public partial int MaxVolume { get; set; }
+    [ObservableProperty] public partial int Volume { get; set; }
+    [ObservableProperty] public partial bool IsMute { get; set; }
+
+    private IMediaPlayer? MediaPlayer => _playerContext.MediaPlayer;
+
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly ISettingsService _settingsService;
+    private readonly PlayerContext _playerContext;
+
+    public VolumeViewModel(ISettingsService settingsService, PlayerContext playerContext)
     {
-        [ObservableProperty] public partial int MaxVolume { get; set; }
-        [ObservableProperty] public partial int Volume { get; set; }
-        [ObservableProperty] public partial bool IsMute { get; set; }
+        _settingsService = settingsService;
+        _playerContext = playerContext;
+        Volume = settingsService.PersistentVolume;
+        MaxVolume = settingsService.MaxVolume;
+        IsMute = Volume == 0;
+        _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
-        private IMediaPlayer? MediaPlayer => _playerContext.MediaPlayer;
-
-        private readonly DispatcherQueue _dispatcherQueue;
-        private readonly ISettingsService _settingsService;
-        private readonly PlayerContext _playerContext;
-
-        public VolumeViewModel(ISettingsService settingsService, PlayerContext playerContext)
+        if (MediaPlayer != null)
         {
-            _settingsService = settingsService;
-            _playerContext = playerContext;
-            Volume = settingsService.PersistentVolume;
-            MaxVolume = settingsService.MaxVolume;
-            IsMute = Volume == 0;
-            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-
-            if (MediaPlayer != null)
-            {
-                MediaPlayer.VolumeChanged += OnVolumeChanged;
-                MediaPlayer.IsMutedChanged += OnIsMutedChanged;
-            }
-
-            // View model doesn't receive any messages
-            IsActive = true;
+            MediaPlayer.VolumeChanged += OnVolumeChanged;
+            MediaPlayer.IsMutedChanged += OnIsMutedChanged;
         }
 
-        public void Receive(PropertyChangedMessage<IMediaPlayer?> message)
+        Messenger.Register<ChangeVolumeRequestMessage>(this);
+        Messenger.Register<SettingsChangedMessage>(this);
+        Messenger.Register<PropertyChangedMessage<IMediaPlayer?>>(this);
+    }
+
+    public void Receive(PropertyChangedMessage<IMediaPlayer?> message)
+    {
+        if (message.Sender is not PlayerContext) return;
+
+        if (message.OldValue is { } oldPlayer)
         {
-            if (message.Sender is not PlayerContext) return;
-
-            if (message.OldValue is { } oldPlayer)
-            {
-                oldPlayer.VolumeChanged -= OnVolumeChanged;
-                oldPlayer.IsMutedChanged -= OnIsMutedChanged;
-            }
-
-            if (MediaPlayer != null)
-            {
-                MediaPlayer.VolumeChanged += OnVolumeChanged;
-                MediaPlayer.IsMutedChanged += OnIsMutedChanged;
-            }
+            oldPlayer.VolumeChanged -= OnVolumeChanged;
+            oldPlayer.IsMutedChanged -= OnIsMutedChanged;
         }
 
-        public void Receive(SettingsChangedMessage message)
+        if (MediaPlayer != null)
         {
-            if (message.SettingsName != nameof(SettingsPageViewModel.VolumeBoost)) return;
-            MaxVolume = _settingsService.MaxVolume;
+            MediaPlayer.VolumeChanged += OnVolumeChanged;
+            MediaPlayer.IsMutedChanged += OnIsMutedChanged;
         }
+    }
 
-        public void Receive(ChangeVolumeRequestMessage message)
-        {
-            SetVolume(message.Value, message.IsOffset);
-            message.Reply(Volume);
-        }
+    public void Receive(SettingsChangedMessage message)
+    {
+        if (message.SettingsName != nameof(SettingsPageViewModel.VolumeBoost)) return;
+        MaxVolume = _settingsService.MaxVolume;
+    }
 
-        partial void OnVolumeChanged(int value)
-        {
-            if (MediaPlayer == null) return;
-            double newValue = value / 100d;
-            // bool stayMute = IsMute && newValue - MediaPlayer.Volume < 0.005;
-            MediaPlayer.Volume = newValue;
-            if (value > 0) IsMute = false;
-            _settingsService.PersistentVolume = value;
-        }
+    public void Receive(ChangeVolumeRequestMessage message)
+    {
+        SetVolume(message.Value, message.IsOffset);
+        message.Reply(Volume);
+    }
 
-        partial void OnIsMuteChanged(bool value)
-        {
-            if (MediaPlayer == null) return;
-            MediaPlayer.IsMuted = value;
-        }
+    partial void OnVolumeChanged(int value)
+    {
+        if (MediaPlayer == null) return;
+        double newValue = value / 100d;
+        // bool stayMute = IsMute && newValue - MediaPlayer.Volume < 0.005;
+        MediaPlayer.Volume = newValue;
+        if (value > 0) IsMute = false;
+        _settingsService.PersistentVolume = value;
+    }
 
-        private void OnVolumeChanged(IMediaPlayer sender, object? args)
-        {
-            double normalizedVolume = Volume / 100d;
-            if (Math.Abs(sender.Volume - normalizedVolume) > 0.001)
-            {
-                _dispatcherQueue.TryEnqueue(() => sender.Volume = normalizedVolume);
-            }
-        }
+    partial void OnIsMuteChanged(bool value)
+    {
+        if (MediaPlayer == null) return;
+        MediaPlayer.IsMuted = value;
+    }
 
-        private void OnIsMutedChanged(IMediaPlayer sender, object? args)
+    private void OnVolumeChanged(IMediaPlayer sender, object? args)
+    {
+        double normalizedVolume = Volume / 100d;
+        if (Math.Abs(sender.Volume - normalizedVolume) > 0.001)
         {
-            if (sender.IsMuted != IsMute)
-            {
-                _dispatcherQueue.TryEnqueue(() => sender.IsMuted = IsMute);
-            }
+            _dispatcherQueue.TryEnqueue(() => sender.Volume = normalizedVolume);
         }
+    }
 
-        /// <summary>
-        /// Sets the volume to a specified value or adjusts it by a given amount.
-        /// </summary>
-        /// <param name="value">The target volume to set or the offset amount to adjust.</param>
-        /// <param name="isOffset">If <see langword="true"/>, adjusts the current volume by the specified <paramref name="value"/>;
-        /// otherwise, sets the volume directly. The default value is <see langword="false"/>.</param>
-        public void SetVolume(int value, bool isOffset = false)
+    private void OnIsMutedChanged(IMediaPlayer sender, object? args)
+    {
+        if (sender.IsMuted != IsMute)
         {
-            Volume = Math.Clamp(isOffset ? Volume + value : value, 0, MaxVolume);
+            _dispatcherQueue.TryEnqueue(() => sender.IsMuted = IsMute);
         }
+    }
+
+    /// <summary>
+    /// Sets the volume to a specified value or adjusts it by a given amount.
+    /// </summary>
+    /// <param name="value">The target volume to set or the offset amount to adjust.</param>
+    /// <param name="isOffset">If <see langword="true"/>, adjusts the current volume by the specified <paramref name="value"/>;
+    /// otherwise, sets the volume directly. The default value is <see langword="false"/>.</param>
+    public void SetVolume(int value, bool isOffset = false)
+    {
+        Volume = Math.Clamp(isOffset ? Volume + value : value, 0, MaxVolume);
     }
 }

--- a/Screenbox.Lively/ViewModels/LivelyWallpaperPlayerViewModel.cs
+++ b/Screenbox.Lively/ViewModels/LivelyWallpaperPlayerViewModel.cs
@@ -63,7 +63,8 @@ public partial class LivelyWallpaperPlayerViewModel : ObservableRecipient,
         _settingsService = settingsService;
         _timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<LivelyWallpaperModel?>>(this);
+        Messenger.Register<QueueCurrentItemChangedMessage>(this);
     }
 
     public void Receive(PropertyChangedMessage<LivelyWallpaperModel?> message)

--- a/Screenbox.Lively/ViewModels/LivelyWallpaperSelectorViewModel.cs
+++ b/Screenbox.Lively/ViewModels/LivelyWallpaperSelectorViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -57,7 +57,7 @@ public sealed partial class LivelyWallpaperSelectorViewModel : ObservableRecipie
         _settingsService = settingsService;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
-        IsActive = true;
+        Messenger.Register<PropertyChangedMessage<LivelyWallpaperModel?>>(this);
     }
 
     public async Task InitializeVisualizers()


### PR DESCRIPTION
`ObservableRecipient.IsActive` throw IL2026 and IL3050 warnings when building in Native AOT. Explicitly register them to remove these warnings.


> Using member 'CommunityToolkit.Mvvm.ComponentModel.ObservableRecipient.IsActive.set' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. When this property is set to true, the OnActivated() method will be invoked, which will register all necessary message handlers for this recipient. This method requires the generated CommunityToolkit.Mvvm.Messaging.__Internals.__IMessengerExtensions type not to be removed to use the fast path. If this type is removed by the linker, or if the target recipient was created dynamically and was missed by the source generator, a slower fallback path using a compiled LINQ expression will be used. This will have more overhead in the first invocation of this method for any given recipient type. Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.
> 
> Using member 'CommunityToolkit.Mvvm.ComponentModel.ObservableRecipient.IsActive.set' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. When this property is set to true, the OnActivated() method will be invoked, which will register all necessary message handlers for this recipient. This method requires the generated CommunityToolkit.Mvvm.Messaging.__Internals.__IMessengerExtensions type not to be removed to use the fast path. If that is present, the method is AOT safe, as the only methods being invoked to register the messages will be the ones produced by the source generator. If it isn't, this method will need to dynamically create the generic methods to register messages, which might not be available at runtime. Alternatively, OnActivated() can be manually overwritten, and registration can be done individually for each required message for this recipient.
