### PR TITLE
chore: update test project to use xunit v3 with MTP v2 and AOT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,18 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v3
 
+    - uses: actions/cache/restore@v6
+      with:
+        path: ~\.nuget\packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
     - name: Run tests
       run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -t:Test
   
   build:
-    runs-on: windows-2025-vs2026
+    runs-on: windows-latest
     strategy:
       matrix:
         platform: [x64, x86, arm64]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v3
 
-    - uses: actions/cache/restore@v6
+    - uses: actions/cache@v6
       with:
         path: ~\.nuget\packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        key: ${{ runner.os }}-nuget-test-${{ hashFiles('**/*.csproj') }}
         restore-keys: |
-          ${{ runner.os }}-nuget-
+          ${{ runner.os }}-nuget-test-
 
     - name: Build tests
       run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -p:OutDir=C:\BuildOutput\ -restore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           ${{ runner.os }}-nuget-
 
     - name: Build tests
-      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -p:OutDir=C:\BuildOutput\
+      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -p:OutDir=C:\BuildOutput\ -restore
 
     - name: Run tests
       run: C:\BuildOutput\Screenbox.Core.Tests.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,8 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v3
 
-    - name: Build tests
-      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -restore
-
     - name: Run tests
-      run: dotnet test Screenbox.Core.Tests\bin\x64\Release\*\Screenbox.Core.Tests.dll
+      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -t:Test
   
   build:
     runs-on: windows-2025-vs2026

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
 
+    - name: Build tests
+      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -p:OutDir=C:\BuildOutput\
+
     - name: Run tests
-      run: msbuild Screenbox.Core.Tests\Screenbox.Core.Tests.csproj -p:Configuration=Release -p:Platform=x64 -t:Test
+      run: C:\BuildOutput\Screenbox.Core.Tests.exe
   
   build:
     runs-on: windows-latest

--- a/Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
+++ b/Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;ARM64</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -13,6 +13,7 @@
     <AssetTargetFallback>$(AssetTargetFallback);uap10.0.18362;uap10.0.26100;uap10.0</AssetTargetFallback>
     <NoWarn>$(NoWarn);NETSDK1218;CS0618</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
 
     <!-- Native AOT and Trimming Analyzers -->
     <IsAotCompatible>true</IsAotCompatible>
@@ -24,14 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
+    <PackageReference Include="xunit.v3.aot.mtp-v2" Version="4.0.0-pre.154" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Screenbox.slnx
+++ b/Screenbox.slnx
@@ -4,6 +4,11 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Project Path="Screenbox.Core.Tests/Screenbox.Core.Tests.csproj">
+    <Platform Solution="*|arm64" Project="ARM64" />
+    <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="*|x86" Project="x86" />
+  </Project>
   <Project Path="Screenbox.Core/Screenbox.Core.csproj">
     <Platform Solution="*|arm64" Project="arm64" />
     <Platform Solution="*|x64" Project="x64" />
@@ -24,7 +29,7 @@
     <Platform Solution="*|x64" Project="x64" />
     <Platform Solution="*|x86" Project="x86" />
   </Project>
-  <Project DefaultStartup="true" Path="Screenbox/Screenbox.csproj">
+  <Project Path="Screenbox/Screenbox.csproj">
     <Platform Solution="*|arm64" Project="arm64" />
     <Platform Solution="*|x64" Project="x64" />
     <Platform Solution="*|x86" Project="x86" />


### PR DESCRIPTION
Adopt test project into the Solution. Update test project dependencies to be AOT compatible and uses Microsoft Testing Platform v2