### PR TITLE
chore: manually reference CsWinRT 2.3.1

### DIFF
--- a/Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
+++ b/Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageReference Include="xunit.v3.aot.mtp-v2" Version="4.0.0-pre.154" />
   </ItemGroup>
 

--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="LibVLCSharp" Version="3.10.1" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageReference Include="Sentry" Version="6.8.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="TagLibSharp" Version="2.3.0" />

--- a/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/FolderViewPageViewModel.cs
@@ -30,7 +30,7 @@ public partial class FolderViewPageViewModel : ObservableRecipient,
     // so we need to maintain a separate list of StorageFolder for navigation.
     public string[] Breadcrumbs { get; private set; } = [];
 
-    public IReadOnlyList<StorageFolder> BreadcrumbLocations { get; private set; } = [];
+    public StorageFolder[] BreadcrumbLocations { get; private set; } = [];
 
     internal NavigationMetadata? NavData { get; private set; }
 
@@ -100,7 +100,7 @@ public partial class FolderViewPageViewModel : ObservableRecipient,
         switch (parameter)
         {
             case IReadOnlyList<StorageFolder> { Count: > 0 } breadcrumbs:
-                BreadcrumbLocations = breadcrumbs;
+                BreadcrumbLocations = [.. breadcrumbs];
                 Breadcrumbs = breadcrumbs.Select(f => f.DisplayName).ToArray();
                 await FetchFolderContentAsync(breadcrumbs.Last());
                 break;

--- a/Screenbox.Lively/Screenbox.Lively.csproj
+++ b/Screenbox.Lively/Screenbox.Lively.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Screenbox.UI.Controls/Screenbox.UI.Controls.csproj
+++ b/Screenbox.UI.Controls/Screenbox.UI.Controls.csproj
@@ -17,5 +17,6 @@
     <PackageReference Include="CommunityToolkit.Uwp.Animations" Version="8.2.251219" />
     <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.251219" />
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/Screenbox.VideoView/Screenbox.VideoView.csproj
+++ b/Screenbox.VideoView/Screenbox.VideoView.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibVLCSharp" Version="3.10.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageReference Include="Silk.NET.Direct3D11" Version="2.23.0" />
   </ItemGroup>
 </Project>

--- a/Screenbox/Behaviors/AddToPlaylistFlyoutBehavior.cs
+++ b/Screenbox/Behaviors/AddToPlaylistFlyoutBehavior.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -99,14 +98,14 @@ internal sealed partial class AddToPlaylistFlyoutBehavior : Behavior<MenuFlyout>
         // If no DataContext is set at the behavior or sub-menu level, we can try to fall back to the target element's DataContext
         dataContext ??= _flyoutTarget?.DataContext;
 
-        IReadOnlyList<MediaViewModel> contextItems = dataContext switch
+        MediaViewModel[] contextItems = dataContext switch
         {
             StorageItemViewModel { Media: { } media } => [media],
             MediaViewModel vm => [vm],
-            IReadOnlyList<MediaViewModel> list => list,
-            IEnumerable<MediaViewModel> collection => collection.ToList(),
-            IEnumerable<object> objects => objects.OfType<MediaViewModel>().ToList(),
-            _ => Array.Empty<MediaViewModel>(),
+            IReadOnlyList<MediaViewModel> list => list.ToArray(),
+            IEnumerable<MediaViewModel> collection => collection.ToArray(),
+            IEnumerable<object> objects => objects.OfType<MediaViewModel>().ToArray(),
+            _ => [],
         };
 
         menuItems.Clear();

--- a/Screenbox/Screenbox.csproj
+++ b/Screenbox/Screenbox.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="LibVLC.UWP" Version="3.0.23-2608082208" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1" />
     <PackageReference Include="Starpine.ReswPlus" Version="0.3.2-202605101917" />
   </ItemGroup>


### PR DESCRIPTION
Manually reference the CsWinRT NuGet to get more up-to-date features rather than waiting for an SDK update.

Ref: https://discord.com/channels/372137812037730304/1360013646050099280/1536106749935882290