### PR TITLE
chore(agents): add AGENTS.md referencing canonical instructions

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,0 +1,16 @@
+{
+  "xaml-auto-formatter": {
+    "PostToolUse": [
+      {
+        "matcher": "write_to_file|replace_file_content|multi_replace_file_content",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File ../scripts/format-xaml-hook.ps1",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.agents/skills/build-and-test/SKILL.md
+++ b/.agents/skills/build-and-test/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: build-and-test
+description: >-
+  Procedures for restoring packages, compiling Screenbox and Screenbox.Core,
+  running automated unit tests, and verifying XAML formatting. Use when the user
+  asks to build projects, run tests, or verify code changes.
+---
+
+# Build and Test Runbook
+
+Follow these structured procedures when restoring, compiling, testing, or validating formatting in the Screenbox solution.
+
+---
+
+## 1. Prerequisites & Package Restore
+
+Ensure local dotnet tools and NuGet packages are restored before building:
+
+### Restore Dotnet Tools (XAML Styler & LottieGen)
+```pwsh
+dotnet tool restore
+```
+
+### Restore NuGet Packages
+For the full solution:
+```pwsh
+msbuild Screenbox.slnx -t:restore -p:RestoreConfigFile=nuget.config -p:RestoreLockedMode=false -p:Platform=x64 -p:Configuration=Release
+```
+
+Or restore the main UWP app project individually:
+```pwsh
+msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Restore /m
+```
+
+---
+
+## 2. Compilation / Build
+
+Screenbox targets `x64` by default for local development.
+
+### Build Core Logic (`Screenbox.Core`)
+```pwsh
+msbuild Screenbox.Core/Screenbox.Core.csproj /t:Build /p:Configuration=Debug /p:Platform=x64 /m
+```
+
+### Build Main Application (`Screenbox`)
+```pwsh
+msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+```
+
+---
+
+## 3. Running Automated Tests
+
+### Run Full Test Suite
+```pwsh
+dotnet test Screenbox.Core.Tests/Screenbox.Core.Tests.csproj -v minimal
+```
+
+### Run Focused Database Service Tests
+```pwsh
+dotnet test Screenbox.Core.Tests/Screenbox.Core.Tests.csproj --filter "FullyQualifiedName~DatabaseServiceTests" -v n
+```
+
+### Testing Rules & Constraints
+- **Pure Logic Tests**: Use `[TestMethod]` in `Screenbox.Core.Tests`.
+- **XAML-Dependent Tests**: **NEVER** use plain test runners for tests that instantiate XAML types. Use the `UWP Unit Test App` runner with `[UITestMethod]`.
+- **No Boilerplate Comments**: Do not emit `// Arrange`, `// Act`, `// Assert` comments.
+- **Naming Style**: Mirror existing test method naming in nearby test classes.
+
+---
+
+## 4. XAML Formatting & Lint Verification
+
+Verify all XAML files adhere to XAML Styler rules:
+
+```pwsh
+pwsh ./scripts/lint-xaml.ps1
+```
+
+To format specific modified XAML files manually:
+```pwsh
+dotnet tool run xstyler -f Screenbox/Pages/PlayerPage.xaml
+```

--- a/.agents/skills/generate-assets/SKILL.md
+++ b/.agents/skills/generate-assets/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: generate-assets
+description: >-
+  Procedures for generating vector fonts and Lottie animation visual sources from assets.
+  Use when vector font definitions, font glyphs, or animation JSON files are modified.
+---
+
+# Asset Generation Runbook
+
+Use this runbook when updating icon glyphs, font files, or Lottie animation assets for Screenbox.
+
+---
+
+## 1. Prerequisites
+
+Ensure local dotnet tools are restored:
+```pwsh
+dotnet tool restore
+```
+
+---
+
+## 2. Generate Font Assets
+
+When font definitions in `assets/fonts/` are modified or new glyph icons are added:
+
+1. **Run the Font Generation Script**:
+   ```pwsh
+   pwsh ./scripts/Generate-Fonts.ps1
+   ```
+2. **Generated Output Location**:
+   - `Screenbox/Assets/Fonts/ScreenboxFluentIcons.ttf`
+   - `Screenbox/Assets/Fonts/ScreenboxMDL2Assets.ttf`
+3. **Verification**:
+   - Verify generated `.ttf` files under `Screenbox/Assets/Fonts/`.
+   - Ensure the new glyphs match the character codes referenced in XAML or code (e.g., `GlyphConverter.cs`).
+
+---
+
+## 3. Generate Lottie Animation Classes
+
+When animation JSON files in `assets/animations/` are added or modified:
+
+1. **Run the Lottie Generation Script**:
+   ```pwsh
+   pwsh ./scripts/generate-lottie.ps1
+   ```
+   This script runs `LottieGen` with parameters:
+   - `-GenerateColorBindings`
+   - `-GenerateDependencyObject`
+   - `-Language CSharp`
+   - `-MinimumUapVersion 8`
+   - `-Namespace Screenbox.Animations`
+   - `-Public`
+   - `-WinUIVersion 2.8`
+   - Target output: `Screenbox/Assets/Animations/`
+2. **Generated Output Location**:
+   - `Screenbox/Assets/Animations/*.cs` (e.g., `AnimatedPlayingVisualSource.cs`)
+3. **Verification**:
+   - Build `Screenbox` to ensure generated C# classes compile cleanly:
+     ```pwsh
+     msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+     ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Instructions & Guidelines
+
+This repository maintains its canonical AI agent instructions and coding guidelines under `.github/`. All AI assistants (Antigravity, GitHub Copilot, and other agentic tools) must adhere to these instructions.
+
+## 📋 General Guidelines & Workflows
+
+Refer to [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for:
+- **Git & PR Workflows**: Conventional Commits standard, PR title conventions, issue linking, and descriptive change summaries (context, motivation, impact).
+- **Build & Test Workflows**: MSBuild commands for `Screenbox` and `Screenbox.Core`, and `dotnet test` commands with `DatabaseServiceTests` filtering.
+- **Persistence Boundaries**: Ephemeral SQLite cache data (`library_folders`, `media_records`, `playback_progress`) vs. durable user data (`playlists`, `playlist_items`), and per-table database recovery rules.
+
+## 💻 C# and .NET 9+ Development
+
+When viewing, writing, or modifying C# code (`**/*.cs`), strictly follow [`.github/instructions/dotnet-uwp.instructions.md`](.github/instructions/dotnet-uwp.instructions.md) for:
+- **Language & Formatting**: C# 14 features, nullable reference types (`is null` / `is not null`), `.editorconfig` formatting, and XML doc comments.
+- **Architecture Layers**: Separation of Views, ViewModels, Contexts (observable state holders), Coordinators (stateful resource managers), and Services (stateless business logic).
+- **MVVM Patterns**: CommunityToolkit.Mvvm `ObservableObject`, `ObservableRecipient`, `[ObservableProperty]`, `[RelayCommand]`, and `Messenger`.
+- **Testing Constraints**: Mandatory `UWP Unit Test App` runner for XAML-dependent tests with `[UITestMethod]` vs `[TestMethod]`.
+
+## 🎨 XAML & UI Development
+
+When viewing, writing, or modifying XAML markup (`**/*.xaml`), strictly follow [`.github/instructions/uwp-xaml.instructions.md`](.github/instructions/uwp-xaml.instructions.md) for:
+- **Data Binding**: Compiled bindings (`{x:Bind}`), explicit modes (`OneWay`, `TwoWay`, `OneTime`), `x:DataType` on templates, and fallback handling.
+- **Localization**: ReswPlus strongly-typed strings in `Screenbox/Strings/en-US/`, with strict View-layer-only string access (never from ViewModels).
+- **Accessibility & Theming**: WCAG contrast, `AutomationProperties`, `{ThemeResource}` vs `{StaticResource}`, and UI collection virtualization (`ListView`/`GridView`, `ISupportIncrementalLoading`).

--- a/scripts/format-xaml-hook.ps1
+++ b/scripts/format-xaml-hook.ps1
@@ -27,10 +27,14 @@ try {
         }
 
         # Resolve full path if relative
-        $filePath = if (Test-Path $targetFile) { $targetFile } else { Join-Path (Split-Path -Parent $PSScriptRoot) $targetFile }
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        $filePath = if (Test-Path -LiteralPath $targetFile) { $targetFile } else { Join-Path $repoRoot $targetFile }
 
-        # Format only the targeted XAML file if it exists
-        if (Test-Path $filePath) {
+        $resolvedPath = Resolve-Path -LiteralPath $filePath -ErrorAction SilentlyContinue
+        $filePath = if ($resolvedPath) { $resolvedPath.Path } else { $null }
+
+        # Format only the targeted XAML file if it exists and is within the repo
+        if ($filePath -and $filePath.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase) -and (Test-Path -LiteralPath $filePath)) {
             dotnet tool run xstyler -f $filePath 2>&1 | Out-Null
         }
     }

--- a/scripts/format-xaml-hook.ps1
+++ b/scripts/format-xaml-hook.ps1
@@ -1,0 +1,27 @@
+param()
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+try {
+    # Resolve repository root
+    $repoRoot = git rev-parse --show-toplevel 2>$null
+    if (-not $repoRoot) {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+    }
+
+    # Find modified uncommitted XAML files (excluding obj/bin)
+    $modifiedXaml = git -C $repoRoot diff --name-only | Where-Object { 
+        $_ -like '*.xaml' -and 
+        $_ -notmatch "(\\obj\\)|(\\bin\\)" -and 
+        (Test-Path (Join-Path $repoRoot $_)) 
+    } | ForEach-Object { Join-Path $repoRoot $_ }
+
+    if ($modifiedXaml -and $modifiedXaml.Count -gt 0) {
+        dotnet tool run xstyler -f $modifiedXaml 2>&1 | Out-Null
+    }
+} catch {
+    # Fail silently to avoid blocking agent execution loop
+}
+
+# PostToolUse contract requires a JSON object output on stdout
+Write-Output "{}"

--- a/scripts/format-xaml-hook.ps1
+++ b/scripts/format-xaml-hook.ps1
@@ -38,23 +38,6 @@ try {
             dotnet tool run xstyler -f $filePath 2>&1 | Out-Null
         }
     }
-    else {
-        # Fallback if no specific TargetFile in payload: format modified XAML files from git diff
-        $repoRoot = git rev-parse --show-toplevel 2>$null
-        if (-not $repoRoot) {
-            $repoRoot = Split-Path -Parent $PSScriptRoot
-        }
-
-        $modifiedXaml = git -C $repoRoot diff --name-only | Where-Object { 
-            $_ -like '*.xaml' -and 
-            $_ -notmatch "(\\obj\\)|(\\bin\\)" -and 
-            (Test-Path (Join-Path $repoRoot $_)) 
-        } | ForEach-Object { Join-Path $repoRoot $_ }
-
-        if ($modifiedXaml -and $modifiedXaml.Count -gt 0) {
-            dotnet tool run xstyler -f $modifiedXaml 2>&1 | Out-Null
-        }
-    }
 } catch {
     # Fail silently to avoid blocking the agent execution loop
 }

--- a/scripts/format-xaml-hook.ps1
+++ b/scripts/format-xaml-hook.ps1
@@ -3,25 +3,57 @@ param()
 $ErrorActionPreference = 'SilentlyContinue'
 
 try {
-    # Resolve repository root
-    $repoRoot = git rev-parse --show-toplevel 2>$null
-    if (-not $repoRoot) {
-        $repoRoot = Split-Path -Parent $PSScriptRoot
+    $inputJson = $null
+
+    # Consume piped JSON payload from Antigravity hook runner
+    $rawInput = ($input | Out-String).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($rawInput)) {
+        $inputJson = $rawInput | ConvertFrom-Json
     }
 
-    # Find modified uncommitted XAML files (excluding obj/bin)
-    $modifiedXaml = git -C $repoRoot diff --name-only | Where-Object { 
-        $_ -like '*.xaml' -and 
-        $_ -notmatch "(\\obj\\)|(\\bin\\)" -and 
-        (Test-Path (Join-Path $repoRoot $_)) 
-    } | ForEach-Object { Join-Path $repoRoot $_ }
+    # Extract TargetFile from toolCall arguments if present
+    $targetFile = $null
+    if ($inputJson -and $inputJson.toolCall -and $inputJson.toolCall.args) {
+        if ($inputJson.toolCall.args.TargetFile) {
+            $targetFile = $inputJson.toolCall.args.TargetFile
+        }
+    }
 
-    if ($modifiedXaml -and $modifiedXaml.Count -gt 0) {
-        dotnet tool run xstyler -f $modifiedXaml 2>&1 | Out-Null
+    if ($targetFile) {
+        # Fast exit if the modified file is not a XAML file
+        if ($targetFile -notlike '*.xaml') {
+            Write-Output "{}"
+            exit 0
+        }
+
+        # Resolve full path if relative
+        $filePath = if (Test-Path $targetFile) { $targetFile } else { Join-Path (Split-Path -Parent $PSScriptRoot) $targetFile }
+
+        # Format only the targeted XAML file if it exists
+        if (Test-Path $filePath) {
+            dotnet tool run xstyler -f $filePath 2>&1 | Out-Null
+        }
+    }
+    else {
+        # Fallback if no specific TargetFile in payload: format modified XAML files from git diff
+        $repoRoot = git rev-parse --show-toplevel 2>$null
+        if (-not $repoRoot) {
+            $repoRoot = Split-Path -Parent $PSScriptRoot
+        }
+
+        $modifiedXaml = git -C $repoRoot diff --name-only | Where-Object { 
+            $_ -like '*.xaml' -and 
+            $_ -notmatch "(\\obj\\)|(\\bin\\)" -and 
+            (Test-Path (Join-Path $repoRoot $_)) 
+        } | ForEach-Object { Join-Path $repoRoot $_ }
+
+        if ($modifiedXaml -and $modifiedXaml.Count -gt 0) {
+            dotnet tool run xstyler -f $modifiedXaml 2>&1 | Out-Null
+        }
     }
 } catch {
-    # Fail silently to avoid blocking agent execution loop
+    # Fail silently to avoid blocking the agent execution loop
 }
 
-# PostToolUse contract requires a JSON object output on stdout
+# PostToolUse contract requires a JSON object on stdout
 Write-Output "{}"


### PR DESCRIPTION
## Context & Motivation
Enhances Antigravity usability for the Screenbox repository by creating a unified instruction entrypoint, custom workspace skills, and lifecycle auto-formatting hooks.

## Changes
- **Universal Agent Entrypoint**:
  - `AGENTS.md`: Canonical Antigravity rules referencing .github/ instruction files without duplication.
- **Workspace Skills**:
  - `.agents/skills/build-and-test/SKILL.md`: Runbook for restoring NuGet/tool packages, building Screenbox.Core and Screenbox, running test suites (with DatabaseServiceTests filters and UWP Unit Test App constraints), and XAML linting.
  - `.agents/skills/generate-assets/SKILL.md`: Runbook for generating vector fonts (`Generate-Fonts.ps1`) and Lottie animation C# classes (`generate-lottie.ps1` via LottieGen).
- **Lifecycle Hooks**:
  - `.agents/hooks.json`: PostToolUse hook (xaml-auto-formatter) triggered on file modification tools.
  - `scripts/format-xaml-hook.ps1`: Automatically formats modified XAML files using XAML Styler (xstyler).

## Impact
Maintains a Single Source of Truth (SSOT) across Copilot and Antigravity while providing autonomous skill execution and automated XAML formatting.