### PR TITLE
fix: use LibVLCSharp.UWP instead of the core LibVLCSharp

### DIFF
--- a/Screenbox.Core/Screenbox.Core.csproj
+++ b/Screenbox.Core/Screenbox.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.Uwp.Extensions" Version="8.2.251219" />
-    <PackageReference Include="LibVLCSharp" Version="3.10.1" />
+    <PackageReference Include="LibVLCSharp.UWP" Version="3.10.1" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />

--- a/Screenbox.VideoView/Screenbox.VideoView.csproj
+++ b/Screenbox.VideoView/Screenbox.VideoView.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibVLCSharp" Version="3.10.1" />
+    <PackageReference Include="LibVLCSharp.UWP" Version="3.10.1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageReference Include="Silk.NET.Direct3D11" Version="2.23.0" />
   </ItemGroup>


### PR DESCRIPTION
Although we use our own NAOT VideoView and don't need any UWP-specific controls, some code paths are compiled exclusively for UWP in the `LibVLCSharp.UWP` package.

One issue is that the `LibVLC.Log` event is never triggered on ARM64, which was discovered while working on #1050 