### PR TITLE
feat: add genre filter for songs and albums

### DIFF
--- a/Screenbox.Core.Tests/DispatcherQueueTests.cs
+++ b/Screenbox.Core.Tests/DispatcherQueueTests.cs
@@ -14,4 +14,18 @@ public class DispatcherQueueTests
         var timer = queue!.CreateTimer();
         await Assert.That(timer).IsNotNull();
     }
+
+    [Test]
+    public async Task DispatcherQueue_ShouldExecuteEnqueuedWork_WhenPumpingEvents()
+    {
+        var queue = DispatcherQueue.GetForCurrentThread();
+        await Assert.That(queue).IsNotNull();
+
+        var executed = false;
+        queue!.TryEnqueue(() => executed = true);
+
+        DispatcherQueueTestHelper.PumpEvents();
+
+        await Assert.That(executed).IsTrue();
+    }
 }

--- a/Screenbox.Core.Tests/DispatcherQueueTests.cs
+++ b/Screenbox.Core.Tests/DispatcherQueueTests.cs
@@ -1,0 +1,17 @@
+using Screenbox.Core.Tests.Helpers;
+using Windows.System;
+
+namespace Screenbox.Core.Tests;
+
+public class DispatcherQueueTests
+{
+    [Test]
+    public async Task DispatcherQueue_ShouldNotBeNull_WhenInitializedByGlobalHook()
+    {
+        var queue = DispatcherQueue.GetForCurrentThread();
+        await Assert.That(queue).IsNotNull();
+
+        var timer = queue!.CreateTimer();
+        await Assert.That(timer).IsNotNull();
+    }
+}

--- a/Screenbox.Core.Tests/DispatcherQueueTests.cs
+++ b/Screenbox.Core.Tests/DispatcherQueueTests.cs
@@ -14,18 +14,4 @@ public class DispatcherQueueTests
         var timer = queue!.CreateTimer();
         await Assert.That(timer).IsNotNull();
     }
-
-    [Test]
-    public async Task DispatcherQueue_ShouldExecuteEnqueuedWork_WhenPumpingEvents()
-    {
-        var queue = DispatcherQueue.GetForCurrentThread();
-        await Assert.That(queue).IsNotNull();
-
-        var executed = false;
-        queue!.TryEnqueue(() => executed = true);
-
-        DispatcherQueueTestHelper.PumpEvents();
-
-        await Assert.That(executed).IsTrue();
-    }
 }

--- a/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
+++ b/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
@@ -1,0 +1,43 @@
+using System.Runtime.InteropServices;
+using Windows.System;
+
+namespace Screenbox.Core.Tests.Helpers;
+
+public static partial class DispatcherQueueTestHelper
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DispatcherQueueOptions
+    {
+        public int dwSize;
+        public int threadType;
+        public int apartmentType;
+    }
+
+    [LibraryImport("CoreMessaging.dll")]
+    private static partial int CreateDispatcherQueueController(
+        DispatcherQueueOptions options,
+        out nint dispatcherQueueController);
+
+    public static void EnsureDispatcherQueue()
+    {
+        if (DispatcherQueue.GetForCurrentThread() is not null)
+        {
+            return;
+        }
+
+        var options = new DispatcherQueueOptions
+        {
+            dwSize = Marshal.SizeOf<DispatcherQueueOptions>(),
+            threadType = 2, // DQTYPE_THREAD_CURRENT
+            apartmentType = 2 // DQTAT_COM_STA
+        };
+
+        CreateDispatcherQueueController(options, out _);
+
+        var queue = DispatcherQueue.GetForCurrentThread();
+        if (queue is not null)
+        {
+            SynchronizationContext.SetSynchronizationContext(new DispatcherQueueSynchronizationContext(queue));
+        }
+    }
+}

--- a/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
+++ b/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
@@ -32,7 +32,8 @@ public static partial class DispatcherQueueTestHelper
             apartmentType = 2 // DQTAT_COM_STA
         };
 
-        CreateDispatcherQueueController(options, out _);
+        var hr = CreateDispatcherQueueController(options, out _);
+        Marshal.ThrowExceptionForHR(hr);
 
         var queue = DispatcherQueue.GetForCurrentThread();
         if (queue is not null)

--- a/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
+++ b/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
@@ -13,10 +13,39 @@ public static partial class DispatcherQueueTestHelper
         public int apartmentType;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MSG
+    {
+        public nint hwnd;
+        public uint message;
+        public nuint wParam;
+        public nint lParam;
+        public uint time;
+        public int pt_x;
+        public int pt_y;
+        public uint lPrivate;
+    }
+
     [LibraryImport("CoreMessaging.dll")]
     private static partial int CreateDispatcherQueueController(
         DispatcherQueueOptions options,
         out nint dispatcherQueueController);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool PeekMessageW(
+        out MSG lpMsg,
+        nint hWnd,
+        uint wMsgFilterMin,
+        uint wMsgFilterMax,
+        uint wRemoveMsg);
+
+    [LibraryImport("user32.dll")]
+    private static partial nint DispatchMessageW(in MSG lpMsg);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool TranslateMessage(in MSG lpMsg);
 
     public static void EnsureDispatcherQueue()
     {
@@ -39,6 +68,15 @@ public static partial class DispatcherQueueTestHelper
         if (queue is not null)
         {
             SynchronizationContext.SetSynchronizationContext(new DispatcherQueueSynchronizationContext(queue));
+        }
+    }
+
+    public static void PumpEvents()
+    {
+        while (PeekMessageW(out var msg, nint.Zero, 0, 0, 1)) // PM_REMOVE = 1
+        {
+            TranslateMessage(in msg);
+            DispatchMessageW(in msg);
         }
     }
 }

--- a/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
+++ b/Screenbox.Core.Tests/Helpers/DispatcherQueueTestHelper.cs
@@ -13,39 +13,10 @@ public static partial class DispatcherQueueTestHelper
         public int apartmentType;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MSG
-    {
-        public nint hwnd;
-        public uint message;
-        public nuint wParam;
-        public nint lParam;
-        public uint time;
-        public int pt_x;
-        public int pt_y;
-        public uint lPrivate;
-    }
-
     [LibraryImport("CoreMessaging.dll")]
     private static partial int CreateDispatcherQueueController(
         DispatcherQueueOptions options,
         out nint dispatcherQueueController);
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool PeekMessageW(
-        out MSG lpMsg,
-        nint hWnd,
-        uint wMsgFilterMin,
-        uint wMsgFilterMax,
-        uint wRemoveMsg);
-
-    [LibraryImport("user32.dll")]
-    private static partial nint DispatchMessageW(in MSG lpMsg);
-
-    [LibraryImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool TranslateMessage(in MSG lpMsg);
 
     public static void EnsureDispatcherQueue()
     {
@@ -68,15 +39,6 @@ public static partial class DispatcherQueueTestHelper
         if (queue is not null)
         {
             SynchronizationContext.SetSynchronizationContext(new DispatcherQueueSynchronizationContext(queue));
-        }
-    }
-
-    public static void PumpEvents()
-    {
-        while (PeekMessageW(out var msg, nint.Zero, 0, 0, 1)) // PM_REMOVE = 1
-        {
-            TranslateMessage(in msg);
-            DispatchMessageW(in msg);
         }
     }
 }

--- a/Screenbox.Core.Tests/Helpers/TestInitializer.cs
+++ b/Screenbox.Core.Tests/Helpers/TestInitializer.cs
@@ -1,0 +1,12 @@
+using TUnit.Core;
+
+namespace Screenbox.Core.Tests.Helpers;
+
+public static class TestInitializer
+{
+    [BeforeEvery(HookType.Test)]
+    public static void InitializeTest()
+    {
+        DispatcherQueueTestHelper.EnsureDispatcherQueue();
+    }
+}

--- a/Screenbox.Core.Tests/Helpers/TestPlayerService.cs
+++ b/Screenbox.Core.Tests/Helpers/TestPlayerService.cs
@@ -1,0 +1,15 @@
+using Screenbox.Core.Playback;
+using Screenbox.Core.Services;
+
+namespace Screenbox.Core.Tests.Helpers;
+
+public class TestPlayerService : IPlayerService
+{
+    public IMediaPlayer Initialize(string[] swapChainOptions) => throw new NotImplementedException();
+
+    public PlaybackItem CreatePlaybackItem(IMediaPlayer player, object source, params string[] options) => throw new NotImplementedException();
+
+    public void DisposePlaybackItem(PlaybackItem item) { }
+
+    public void DisposePlayer(IMediaPlayer player) { }
+}

--- a/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
+++ b/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
@@ -1,0 +1,43 @@
+using Screenbox.Core.Enums;
+using Screenbox.Core.Services;
+using Windows.Media;
+
+namespace Screenbox.Core.Tests.Helpers;
+
+public class TestSettingsService : ISettingsService
+{
+    public PlayerAutoResizeOption PlayerAutoResize { get; set; } = PlayerAutoResizeOption.Never;
+    public bool UseIndexer { get; set; } = true;
+    public bool PlayerShowControls { get; set; } = true;
+    public bool PersistentShowRemainingTime { get; set; }
+    public bool PlayerShowChapters { get; set; } = true;
+    public int PlayerControlsHideDelay { get; set; } = 3;
+    public int PersistentVolume { get; set; } = 100;
+    public string PersistentSubtitleLanguage { get; set; } = string.Empty;
+    public bool ShowRecent { get; set; } = true;
+    public ThemeOption Theme { get; set; } = ThemeOption.Auto;
+    public bool EnqueueAllFilesInFolder { get; set; }
+    public bool RestorePlaybackPosition { get; set; }
+    public bool SearchRemovableStorage { get; set; } = true;
+    public int MaxVolume { get; set; } = 100;
+    public string GlobalArguments { get; set; } = string.Empty;
+    public bool AdvancedMode { get; set; }
+    public VideoUpscaleOption VideoUpscale { get; set; } = VideoUpscaleOption.Linear;
+    public bool UseMultipleInstances { get; set; }
+    public string LivelyActivePath { get; set; } = string.Empty;
+    public MediaPlaybackAutoRepeatMode PersistentRepeatMode { get; set; } = MediaPlaybackAutoRepeatMode.None;
+    public string FrameCaptureFolderToken { get; set; } = string.Empty;
+    public bool PersistPlaybackPosition { get; set; } = true;
+    public int PlayerRewindStep { get; set; } = 5;
+    public int PlayerFastForwardStep { get; set; } = 5;
+    public PlaybackActionKind PlayerGestureTap { get; set; } = PlaybackActionKind.PlayPause;
+    public PlaybackActionKind PlayerGestureSwipeUp { get; set; } = PlaybackActionKind.IncreaseVolume;
+    public PlaybackActionKind PlayerGestureSwipeDown { get; set; } = PlaybackActionKind.DecreaseVolume;
+    public PlaybackActionKind PlayerGestureSwipeLeft { get; set; } = PlaybackActionKind.Rewind;
+    public PlaybackActionKind PlayerGestureSwipeRight { get; set; } = PlaybackActionKind.FastForward;
+    public bool PlayerGestureSlideVertical { get; set; } = true;
+    public bool PlayerGestureSlideHorizontal { get; set; } = true;
+    public bool PlayerGesturePressAndHold { get; set; } = true;
+    public string PersistentSongsSortBy { get; set; } = "title";
+    public string PersistentAlbumsSortBy { get; set; } = "title";
+}

--- a/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
+++ b/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
@@ -38,6 +38,6 @@ public class TestSettingsService : ISettingsService
     public bool PlayerGestureSlideVertical { get; set; } = true;
     public bool PlayerGestureSlideHorizontal { get; set; } = true;
     public bool PlayerGesturePressAndHold { get; set; } = true;
-    public SongSortOrder SongsSortOrder { get; set; } = SongSortOrder.Title;
-    public AlbumSortOrder AlbumsSortOrder { get; set; } = AlbumSortOrder.Title;
+    public SongSortOrder PersistentSongsSortOrder { get; set; } = SongSortOrder.Title;
+    public AlbumSortOrder PersistentAlbumsSortOrder { get; set; } = AlbumSortOrder.Title;
 }

--- a/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
+++ b/Screenbox.Core.Tests/Helpers/TestSettingsService.cs
@@ -38,6 +38,6 @@ public class TestSettingsService : ISettingsService
     public bool PlayerGestureSlideVertical { get; set; } = true;
     public bool PlayerGestureSlideHorizontal { get; set; } = true;
     public bool PlayerGesturePressAndHold { get; set; } = true;
-    public string PersistentSongsSortBy { get; set; } = "title";
-    public string PersistentAlbumsSortBy { get; set; } = "title";
+    public SongSortOrder SongsSortOrder { get; set; } = SongSortOrder.Title;
+    public AlbumSortOrder AlbumsSortOrder { get; set; } = AlbumSortOrder.Title;
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -41,4 +41,22 @@ public class AlbumsPageViewModelTests
         await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.DateAdded);
         await Assert.That(settings.PersistentAlbumsSortOrder).IsEqualTo(AlbumSortOrder.DateAdded);
     }
+
+    [Test]
+    public async Task Receive_ShouldEnqueueFetchAlbumsViaDispatcherQueue()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        var message = new CommunityToolkit.Mvvm.Messaging.Messages.PropertyChangedMessage<Screenbox.Core.Models.MusicLibrary>(
+            libraryContext,
+            nameof(LibraryContext.Music),
+            libraryContext.Music,
+            libraryContext.Music);
+
+        vm.Receive(message);
+
+        await Assert.That(vm.GroupedAlbums).IsNotNull();
+    }
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -10,7 +10,7 @@ public class AlbumsPageViewModelTests
     [Test]
     public async Task Constructor_ShouldInitializeSortByFromSettings()
     {
-        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Year };
+        var settings = new TestSettingsService { PersistentAlbumsSortOrder = AlbumSortOrder.Year };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
@@ -20,25 +20,25 @@ public class AlbumsPageViewModelTests
     [Test]
     public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
     {
-        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Title };
+        var settings = new TestSettingsService { PersistentAlbumsSortOrder = AlbumSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
         vm.SortBy = AlbumSortOrder.Artist;
 
-        await Assert.That(settings.AlbumsSortOrder).IsEqualTo(AlbumSortOrder.Artist);
+        await Assert.That(settings.PersistentAlbumsSortOrder).IsEqualTo(AlbumSortOrder.Artist);
     }
 
     [Test]
     public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
     {
-        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Title };
+        var settings = new TestSettingsService { PersistentAlbumsSortOrder = AlbumSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
         vm.SetSortByCommand.Execute(AlbumSortOrder.DateAdded);
 
         await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.DateAdded);
-        await Assert.That(settings.AlbumsSortOrder).IsEqualTo(AlbumSortOrder.DateAdded);
+        await Assert.That(settings.PersistentAlbumsSortOrder).IsEqualTo(AlbumSortOrder.DateAdded);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Models;
@@ -44,7 +45,23 @@ public class AlbumsPageViewModelTests
     }
 
     [Test]
-    public async Task Receive_ShouldEnqueueAndExecuteFetchAlbumsViaDispatcherQueue()
+    public void Receive_ShouldNotThrow()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        var message = new PropertyChangedMessage<MusicLibrary>(
+            libraryContext,
+            nameof(LibraryContext.Music),
+            libraryContext.Music,
+            libraryContext.Music);
+
+        vm.Receive(message);
+    }
+
+    [Test]
+    public async Task FetchAlbums_ShouldUpdateGroupedAlbums()
     {
         var settings = new TestSettingsService();
         var libraryContext = new LibraryContext();
@@ -62,7 +79,7 @@ public class AlbumsPageViewModelTests
             new ArtistViewModel());
 
         libraryContext.Music = newLibrary;
-        DispatcherQueueTestHelper.PumpEvents();
+        vm.FetchAlbums();
 
         await Assert.That(vm.GroupedAlbums).IsNotEmpty();
         await Assert.That(vm.GroupedAlbums.SelectMany(g => g)).Contains(album);

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -1,5 +1,6 @@
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
+using Screenbox.Core.Models;
 using Screenbox.Core.Tests.Helpers;
 using Screenbox.Core.ViewModels;
 
@@ -43,20 +44,27 @@ public class AlbumsPageViewModelTests
     }
 
     [Test]
-    public async Task Receive_ShouldEnqueueFetchAlbumsViaDispatcherQueue()
+    public async Task Receive_ShouldEnqueueAndExecuteFetchAlbumsViaDispatcherQueue()
     {
         var settings = new TestSettingsService();
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
-        var message = new CommunityToolkit.Mvvm.Messaging.Messages.PropertyChangedMessage<Screenbox.Core.Models.MusicLibrary>(
-            libraryContext,
-            nameof(LibraryContext.Music),
-            libraryContext.Music,
-            libraryContext.Music);
+        await Assert.That(vm.GroupedAlbums).IsEmpty();
 
-        vm.Receive(message);
+        var album = new AlbumViewModel("Album A", "Artist A");
+        var albums = new Dictionary<string, AlbumViewModel> { ["Album A"] = album };
+        var newLibrary = new MusicLibrary(
+            Array.Empty<MediaViewModel>(),
+            albums,
+            new Dictionary<string, ArtistViewModel>(),
+            new AlbumViewModel(),
+            new ArtistViewModel());
 
-        await Assert.That(vm.GroupedAlbums).IsNotNull();
+        libraryContext.Music = newLibrary;
+        DispatcherQueueTestHelper.PumpEvents();
+
+        await Assert.That(vm.GroupedAlbums).IsNotEmpty();
+        await Assert.That(vm.GroupedAlbums.SelectMany(g => g)).Contains(album);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -1,4 +1,7 @@
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Models;
@@ -17,6 +20,7 @@ public class AlbumsPageViewModelTests
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
         await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.Year);
+        await Assert.That(vm.SelectedGenre).IsNull();
     }
 
     [Test]
@@ -42,6 +46,79 @@ public class AlbumsPageViewModelTests
 
         await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.DateAdded);
         await Assert.That(settings.PersistentAlbumsSortOrder).IsEqualTo(AlbumSortOrder.DateAdded);
+    }
+
+    [Test]
+    public async Task SetGenreCommand_WhenExecuted_ShouldUpdateSelectedGenre()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        vm.SetGenreCommand.Execute("Jazz");
+        await Assert.That(vm.SelectedGenre).IsEqualTo("Jazz");
+
+        vm.SetGenreCommand.Execute(string.Empty);
+        await Assert.That(vm.SelectedGenre).IsEqualTo(string.Empty);
+
+        vm.SetGenreCommand.Execute(null);
+        await Assert.That(vm.SelectedGenre).IsNull();
+    }
+
+    [Test]
+    public async Task FetchAlbums_WhenFilteredByGenre_ShouldFilterAlbumsAndSongs()
+    {
+        var song1 = CreateSong("Song 1", "Rock");
+        var album1 = new AlbumViewModel("Album Rock", "Artist 1");
+        album1.RelatedSongs.Add(song1);
+
+        var song2 = CreateSong("Song 2", "Jazz");
+        var album2 = new AlbumViewModel("Album Jazz", "Artist 2");
+        album2.RelatedSongs.Add(song2);
+
+        var song3 = CreateSong("Song 3", "");
+        var album3 = new AlbumViewModel("Album Unknown", "Artist 3");
+        album3.RelatedSongs.Add(song3);
+
+        var songs = new List<MediaViewModel> { song1, song2, song3 };
+        var albums = new Dictionary<string, AlbumViewModel>
+        {
+            ["Album Rock"] = album1,
+            ["Album Jazz"] = album2,
+            ["Album Unknown"] = album3
+        };
+
+        var musicLibrary = new MusicLibrary(
+            songs,
+            albums,
+            new Dictionary<string, ArtistViewModel>(),
+            new[] { "Jazz", "Rock" },
+            new AlbumViewModel(),
+            new ArtistViewModel());
+
+        var libraryContext = new LibraryContext { Music = musicLibrary };
+        var settings = new TestSettingsService();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        vm.FetchAlbums();
+        await Assert.That(vm.Songs.Count).IsEqualTo(3);
+        await Assert.That(vm.Genres).Contains("Jazz");
+        await Assert.That(vm.Genres).Contains("Rock");
+        await Assert.That(vm.GroupedAlbums.Sum(g => g.Count)).IsEqualTo(3);
+
+        vm.SelectedGenre = "Rock";
+        await Assert.That(vm.Songs.Count).IsEqualTo(1);
+        await Assert.That(vm.GroupedAlbums.Sum(g => g.Count)).IsEqualTo(1);
+        await Assert.That(vm.GroupedAlbums.SelectMany(g => g).First().Name).IsEqualTo("Album Rock");
+
+        vm.SelectedGenre = string.Empty;
+        await Assert.That(vm.Songs.Count).IsEqualTo(1);
+        await Assert.That(vm.GroupedAlbums.Sum(g => g.Count)).IsEqualTo(1);
+        await Assert.That(vm.GroupedAlbums.SelectMany(g => g).First().Name).IsEqualTo("Album Unknown");
+
+        vm.SelectedGenre = null;
+        await Assert.That(vm.Songs.Count).IsEqualTo(3);
+        await Assert.That(vm.GroupedAlbums.Sum(g => g.Count)).IsEqualTo(3);
     }
 
     [Test]
@@ -83,5 +160,16 @@ public class AlbumsPageViewModelTests
 
         await Assert.That(vm.GroupedAlbums).IsNotEmpty();
         await Assert.That(vm.GroupedAlbums.SelectMany(g => g)).Contains(album);
+    }
+
+    private static MediaViewModel CreateSong(string name, string genre)
+    {
+        var info = new MediaInfo(MediaPlaybackType.Music, name);
+        info.MusicProperties.Genre = genre;
+        return new MediaViewModel(new PlayerContext(), null!, new Uri($"file:///c:/music/{name}.mp3"))
+        {
+            Name = name,
+            MediaInfo = info
+        };
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -1,4 +1,5 @@
 using Screenbox.Core.Contexts;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Tests.Helpers;
 using Screenbox.Core.ViewModels;
 
@@ -9,35 +10,35 @@ public class AlbumsPageViewModelTests
     [Test]
     public async Task Constructor_ShouldInitializeSortByFromSettings()
     {
-        var settings = new TestSettingsService { PersistentAlbumsSortBy = "year" };
+        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Year };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
-        await Assert.That(vm.SortBy).IsEqualTo("year");
+        await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.Year);
     }
 
     [Test]
     public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
     {
-        var settings = new TestSettingsService { PersistentAlbumsSortBy = "title" };
+        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
-        vm.SortBy = "artist";
+        vm.SortBy = AlbumSortOrder.Artist;
 
-        await Assert.That(settings.PersistentAlbumsSortBy).IsEqualTo("artist");
+        await Assert.That(settings.AlbumsSortOrder).IsEqualTo(AlbumSortOrder.Artist);
     }
 
     [Test]
     public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
     {
-        var settings = new TestSettingsService { PersistentAlbumsSortBy = "title" };
+        var settings = new TestSettingsService { AlbumsSortOrder = AlbumSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new AlbumsPageViewModel(libraryContext, settings);
 
-        vm.SetSortByCommand.Execute("dateAdded");
+        vm.SetSortByCommand.Execute(AlbumSortOrder.DateAdded);
 
-        await Assert.That(vm.SortBy).IsEqualTo("dateAdded");
-        await Assert.That(settings.PersistentAlbumsSortBy).IsEqualTo("dateAdded");
+        await Assert.That(vm.SortBy).IsEqualTo(AlbumSortOrder.DateAdded);
+        await Assert.That(settings.AlbumsSortOrder).IsEqualTo(AlbumSortOrder.DateAdded);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/AlbumsPageViewModelTests.cs
@@ -1,0 +1,43 @@
+using Screenbox.Core.Contexts;
+using Screenbox.Core.Tests.Helpers;
+using Screenbox.Core.ViewModels;
+
+namespace Screenbox.Core.Tests.ViewModels;
+
+public class AlbumsPageViewModelTests
+{
+    [Test]
+    public async Task Constructor_ShouldInitializeSortByFromSettings()
+    {
+        var settings = new TestSettingsService { PersistentAlbumsSortBy = "year" };
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        await Assert.That(vm.SortBy).IsEqualTo("year");
+    }
+
+    [Test]
+    public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
+    {
+        var settings = new TestSettingsService { PersistentAlbumsSortBy = "title" };
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        vm.SortBy = "artist";
+
+        await Assert.That(settings.PersistentAlbumsSortBy).IsEqualTo("artist");
+    }
+
+    [Test]
+    public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
+    {
+        var settings = new TestSettingsService { PersistentAlbumsSortBy = "title" };
+        var libraryContext = new LibraryContext();
+        var vm = new AlbumsPageViewModel(libraryContext, settings);
+
+        vm.SetSortByCommand.Execute("dateAdded");
+
+        await Assert.That(vm.SortBy).IsEqualTo("dateAdded");
+        await Assert.That(settings.PersistentAlbumsSortBy).IsEqualTo("dateAdded");
+    }
+}

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -1,0 +1,43 @@
+using Screenbox.Core.Contexts;
+using Screenbox.Core.Tests.Helpers;
+using Screenbox.Core.ViewModels;
+
+namespace Screenbox.Core.Tests.ViewModels;
+
+public class SongsPageViewModelTests
+{
+    [Test]
+    public async Task Constructor_ShouldInitializeSortByFromSettings()
+    {
+        var settings = new TestSettingsService { PersistentSongsSortBy = "artist" };
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        await Assert.That(vm.SortBy).IsEqualTo("artist");
+    }
+
+    [Test]
+    public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
+    {
+        var settings = new TestSettingsService { PersistentSongsSortBy = "title" };
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        vm.SortBy = "album";
+
+        await Assert.That(settings.PersistentSongsSortBy).IsEqualTo("album");
+    }
+
+    [Test]
+    public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
+    {
+        var settings = new TestSettingsService { PersistentSongsSortBy = "title" };
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        vm.SetSortByCommand.Execute("dateAdded");
+
+        await Assert.That(vm.SortBy).IsEqualTo("dateAdded");
+        await Assert.That(settings.PersistentSongsSortBy).IsEqualTo("dateAdded");
+    }
+}

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -1,4 +1,5 @@
 using Screenbox.Core.Contexts;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Tests.Helpers;
 using Screenbox.Core.ViewModels;
 
@@ -9,35 +10,35 @@ public class SongsPageViewModelTests
     [Test]
     public async Task Constructor_ShouldInitializeSortByFromSettings()
     {
-        var settings = new TestSettingsService { PersistentSongsSortBy = "artist" };
+        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Artist };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
-        await Assert.That(vm.SortBy).IsEqualTo("artist");
+        await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.Artist);
     }
 
     [Test]
     public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
     {
-        var settings = new TestSettingsService { PersistentSongsSortBy = "title" };
+        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
-        vm.SortBy = "album";
+        vm.SortBy = SongSortOrder.Album;
 
-        await Assert.That(settings.PersistentSongsSortBy).IsEqualTo("album");
+        await Assert.That(settings.SongsSortOrder).IsEqualTo(SongSortOrder.Album);
     }
 
     [Test]
     public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
     {
-        var settings = new TestSettingsService { PersistentSongsSortBy = "title" };
+        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
-        vm.SetSortByCommand.Execute("dateAdded");
+        vm.SetSortByCommand.Execute(SongSortOrder.DateAdded);
 
-        await Assert.That(vm.SortBy).IsEqualTo("dateAdded");
-        await Assert.That(settings.PersistentSongsSortBy).IsEqualTo("dateAdded");
+        await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.DateAdded);
+        await Assert.That(settings.SongsSortOrder).IsEqualTo(SongSortOrder.DateAdded);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Models;
@@ -44,7 +45,23 @@ public class SongsPageViewModelTests
     }
 
     [Test]
-    public async Task Receive_ShouldEnqueueAndExecuteFetchSongsViaDispatcherQueue()
+    public void Receive_ShouldNotThrow()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        var message = new PropertyChangedMessage<MusicLibrary>(
+            libraryContext,
+            nameof(LibraryContext.Music),
+            libraryContext.Music,
+            libraryContext.Music);
+
+        vm.Receive(message);
+    }
+
+    [Test]
+    public async Task FetchSongs_ShouldUpdateSongsAndGroupedSongs()
     {
         var settings = new TestSettingsService();
         var libraryContext = new LibraryContext();
@@ -65,7 +82,7 @@ public class SongsPageViewModelTests
             new ArtistViewModel());
 
         libraryContext.Music = newLibrary;
-        DispatcherQueueTestHelper.PumpEvents();
+        vm.FetchSongs();
 
         await Assert.That(vm.Songs.Count).IsEqualTo(1);
         await Assert.That(vm.GroupedSongs).IsNotEmpty();

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -1,4 +1,7 @@
 using CommunityToolkit.Mvvm.Messaging.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
 using Screenbox.Core.Models;
@@ -17,6 +20,7 @@ public class SongsPageViewModelTests
         var vm = new SongsPageViewModel(libraryContext, settings);
 
         await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.Artist);
+        await Assert.That(vm.SelectedGenre).IsNull();
     }
 
     [Test]
@@ -42,6 +46,60 @@ public class SongsPageViewModelTests
 
         await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.DateAdded);
         await Assert.That(settings.PersistentSongsSortOrder).IsEqualTo(SongSortOrder.DateAdded);
+    }
+
+    [Test]
+    public async Task SetGenreCommand_WhenExecuted_ShouldUpdateSelectedGenre()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        vm.SetGenreCommand.Execute("Rock");
+        await Assert.That(vm.SelectedGenre).IsEqualTo("Rock");
+
+        vm.SetGenreCommand.Execute(string.Empty);
+        await Assert.That(vm.SelectedGenre).IsEqualTo(string.Empty);
+
+        vm.SetGenreCommand.Execute(null);
+        await Assert.That(vm.SelectedGenre).IsNull();
+    }
+
+    [Test]
+    public async Task FetchSongs_WhenFilteredByGenre_ShouldFilterSongsAndGroupedSongs()
+    {
+        var song1 = CreateSong("Song A", "Rock");
+        var song2 = CreateSong("Song B", "Pop");
+        var song3 = CreateSong("Song C", "");
+
+        var songs = new List<MediaViewModel> { song1, song2, song3 };
+        var musicLibrary = new MusicLibrary(
+            songs,
+            new Dictionary<string, AlbumViewModel>(),
+            new Dictionary<string, ArtistViewModel>(),
+            new[] { "Pop", "Rock" },
+            new AlbumViewModel(),
+            new ArtistViewModel());
+
+        var libraryContext = new LibraryContext { Music = musicLibrary };
+        var settings = new TestSettingsService();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        vm.FetchSongs();
+        await Assert.That(vm.Songs.Count).IsEqualTo(3);
+        await Assert.That(vm.Genres).Contains("Pop");
+        await Assert.That(vm.Genres).Contains("Rock");
+
+        vm.SelectedGenre = "Rock";
+        await Assert.That(vm.Songs.Count).IsEqualTo(1);
+        await Assert.That(vm.Songs[0].Name).IsEqualTo("Song A");
+
+        vm.SelectedGenre = string.Empty;
+        await Assert.That(vm.Songs.Count).IsEqualTo(1);
+        await Assert.That(vm.Songs[0].Name).IsEqualTo("Song C");
+
+        vm.SelectedGenre = null;
+        await Assert.That(vm.Songs.Count).IsEqualTo(3);
     }
 
     [Test]
@@ -87,5 +145,16 @@ public class SongsPageViewModelTests
         await Assert.That(vm.Songs.Count).IsEqualTo(1);
         await Assert.That(vm.GroupedSongs).IsNotEmpty();
         await Assert.That(vm.GroupedSongs.SelectMany(g => g)).Contains(song);
+    }
+
+    private static MediaViewModel CreateSong(string name, string genre)
+    {
+        var info = new MediaInfo(MediaPlaybackType.Music, name);
+        info.MusicProperties.Genre = genre;
+        return new MediaViewModel(new PlayerContext(), null!, new Uri($"file:///c:/music/{name}.mp3"))
+        {
+            Name = name,
+            MediaInfo = info
+        };
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -1,5 +1,6 @@
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Enums;
+using Screenbox.Core.Models;
 using Screenbox.Core.Tests.Helpers;
 using Screenbox.Core.ViewModels;
 
@@ -43,20 +44,31 @@ public class SongsPageViewModelTests
     }
 
     [Test]
-    public async Task Receive_ShouldEnqueueFetchSongsViaDispatcherQueue()
+    public async Task Receive_ShouldEnqueueAndExecuteFetchSongsViaDispatcherQueue()
     {
         var settings = new TestSettingsService();
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
-        var message = new CommunityToolkit.Mvvm.Messaging.Messages.PropertyChangedMessage<Screenbox.Core.Models.MusicLibrary>(
-            libraryContext,
-            nameof(LibraryContext.Music),
-            libraryContext.Music,
-            libraryContext.Music);
+        await Assert.That(vm.Songs).IsEmpty();
+        await Assert.That(vm.GroupedSongs).IsEmpty();
 
-        vm.Receive(message);
+        var song = new MediaViewModel(new PlayerContext(), new TestPlayerService(), new Uri("file:///c:/music/song.mp3"))
+        {
+            Name = "Song A"
+        };
+        var newLibrary = new MusicLibrary(
+            new[] { song },
+            new Dictionary<string, AlbumViewModel>(),
+            new Dictionary<string, ArtistViewModel>(),
+            new AlbumViewModel(),
+            new ArtistViewModel());
 
-        await Assert.That(vm.GroupedSongs).IsNotNull();
+        libraryContext.Music = newLibrary;
+        DispatcherQueueTestHelper.PumpEvents();
+
+        await Assert.That(vm.Songs.Count).IsEqualTo(1);
+        await Assert.That(vm.GroupedSongs).IsNotEmpty();
+        await Assert.That(vm.GroupedSongs.SelectMany(g => g)).Contains(song);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -10,7 +10,7 @@ public class SongsPageViewModelTests
     [Test]
     public async Task Constructor_ShouldInitializeSortByFromSettings()
     {
-        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Artist };
+        var settings = new TestSettingsService { PersistentSongsSortOrder = SongSortOrder.Artist };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
@@ -20,25 +20,25 @@ public class SongsPageViewModelTests
     [Test]
     public async Task SortBy_WhenChanged_ShouldUpdatePersistentSettings()
     {
-        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Title };
+        var settings = new TestSettingsService { PersistentSongsSortOrder = SongSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
         vm.SortBy = SongSortOrder.Album;
 
-        await Assert.That(settings.SongsSortOrder).IsEqualTo(SongSortOrder.Album);
+        await Assert.That(settings.PersistentSongsSortOrder).IsEqualTo(SongSortOrder.Album);
     }
 
     [Test]
     public async Task SetSortByCommand_WhenExecuted_ShouldUpdateSortByAndSettings()
     {
-        var settings = new TestSettingsService { SongsSortOrder = SongSortOrder.Title };
+        var settings = new TestSettingsService { PersistentSongsSortOrder = SongSortOrder.Title };
         var libraryContext = new LibraryContext();
         var vm = new SongsPageViewModel(libraryContext, settings);
 
         vm.SetSortByCommand.Execute(SongSortOrder.DateAdded);
 
         await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.DateAdded);
-        await Assert.That(settings.SongsSortOrder).IsEqualTo(SongSortOrder.DateAdded);
+        await Assert.That(settings.PersistentSongsSortOrder).IsEqualTo(SongSortOrder.DateAdded);
     }
 }

--- a/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
+++ b/Screenbox.Core.Tests/ViewModels/SongsPageViewModelTests.cs
@@ -41,4 +41,22 @@ public class SongsPageViewModelTests
         await Assert.That(vm.SortBy).IsEqualTo(SongSortOrder.DateAdded);
         await Assert.That(settings.PersistentSongsSortOrder).IsEqualTo(SongSortOrder.DateAdded);
     }
+
+    [Test]
+    public async Task Receive_ShouldEnqueueFetchSongsViaDispatcherQueue()
+    {
+        var settings = new TestSettingsService();
+        var libraryContext = new LibraryContext();
+        var vm = new SongsPageViewModel(libraryContext, settings);
+
+        var message = new CommunityToolkit.Mvvm.Messaging.Messages.PropertyChangedMessage<Screenbox.Core.Models.MusicLibrary>(
+            libraryContext,
+            nameof(LibraryContext.Music),
+            libraryContext.Music,
+            libraryContext.Music);
+
+        vm.Receive(message);
+
+        await Assert.That(vm.GroupedSongs).IsNotNull();
+    }
 }

--- a/Screenbox.Core/Enums/AlbumSortOrder.cs
+++ b/Screenbox.Core/Enums/AlbumSortOrder.cs
@@ -1,0 +1,9 @@
+namespace Screenbox.Core.Enums;
+
+public enum AlbumSortOrder
+{
+    Title,
+    Artist,
+    Year,
+    DateAdded
+}

--- a/Screenbox.Core/Enums/SongSortOrder.cs
+++ b/Screenbox.Core/Enums/SongSortOrder.cs
@@ -1,0 +1,10 @@
+namespace Screenbox.Core.Enums;
+
+public enum SongSortOrder
+{
+    Title,
+    Album,
+    Artist,
+    Year,
+    DateAdded
+}

--- a/Screenbox.Core/Helpers/MediaGroupingHelpers.cs
+++ b/Screenbox.Core/Helpers/MediaGroupingHelpers.cs
@@ -20,9 +20,19 @@ public static class MediaGroupingHelpers
 
     static MediaGroupingHelpers()
     {
-        _characterGroupings = string.IsNullOrWhiteSpace(ApplicationLanguages.PrimaryLanguageOverride)
+        string? overrideLanguage = null;
+        try
+        {
+            overrideLanguage = ApplicationLanguages.PrimaryLanguageOverride;
+        }
+        catch (Exception)
+        {
+            // Unpackaged environment (e.g. unit tests) lacks package identity
+        }
+
+        _characterGroupings = string.IsNullOrWhiteSpace(overrideLanguage)
             ? new CharacterGroupings()
-            : new CharacterGroupings(ApplicationLanguages.PrimaryLanguageOverride);
+            : new CharacterGroupings(overrideLanguage);
         CharacterGroupLabels = _characterGroupings
             .Select(x => string.IsNullOrEmpty(x.Label) ? OtherGroupSymbol : x.Label)
             .Distinct()

--- a/Screenbox.Core/Models/MusicLibrary.cs
+++ b/Screenbox.Core/Models/MusicLibrary.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using Screenbox.Core.ViewModels;
 
 namespace Screenbox.Core.Models;
 
 /// <summary>
-/// A snapshot of the user's music library containing all songs, albums, and artists.
+/// A snapshot of the user's music library containing all songs, albums, artists, and genres.
 /// Replace the entire instance when the library is updated rather than modifying individual collections.
 /// </summary>
 public sealed class MusicLibrary
@@ -13,6 +14,7 @@ public sealed class MusicLibrary
         new List<MediaViewModel>(),
         new Dictionary<string, AlbumViewModel>(),
         new Dictionary<string, ArtistViewModel>(),
+        Array.Empty<string>(),
         new AlbumViewModel(),
         new ArtistViewModel());
 
@@ -20,12 +22,14 @@ public sealed class MusicLibrary
         IReadOnlyList<MediaViewModel> songs,
         IReadOnlyDictionary<string, AlbumViewModel> albums,
         IReadOnlyDictionary<string, ArtistViewModel> artists,
+        IReadOnlyList<string> genres,
         AlbumViewModel unknownAlbum,
         ArtistViewModel unknownArtist)
     {
         Songs = songs;
         Albums = albums;
         Artists = artists;
+        Genres = genres;
         UnknownAlbum = unknownAlbum;
         UnknownArtist = unknownArtist;
     }
@@ -33,6 +37,7 @@ public sealed class MusicLibrary
     public IReadOnlyList<MediaViewModel> Songs { get; }
     public IReadOnlyDictionary<string, AlbumViewModel> Albums { get; }
     public IReadOnlyDictionary<string, ArtistViewModel> Artists { get; }
+    public IReadOnlyList<string> Genres { get; }
     public AlbumViewModel UnknownAlbum { get; }
     public ArtistViewModel UnknownArtist { get; }
 }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -142,10 +142,10 @@ public interface ISettingsService
     /// <summary>
     /// Gets or sets the preferred sort order for the songs page.
     /// </summary>
-    string PersistentSongsSortBy { get; set; }
+    SongSortOrder SongsSortOrder { get; set; }
 
     /// <summary>
     /// Gets or sets the preferred sort order for the albums page.
     /// </summary>
-    string PersistentAlbumsSortBy { get; set; }
+    AlbumSortOrder AlbumsSortOrder { get; set; }
 }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -138,4 +138,14 @@ public interface ISettingsService
     /// otherwise, <see langword="false"/>.
     /// </value>
     bool PlayerGesturePressAndHold { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preferred sort order for the songs page.
+    /// </summary>
+    string PersistentSongsSortBy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preferred sort order for the albums page.
+    /// </summary>
+    string PersistentAlbumsSortBy { get; set; }
 }

--- a/Screenbox.Core/Services/ISettingsService.cs
+++ b/Screenbox.Core/Services/ISettingsService.cs
@@ -142,10 +142,10 @@ public interface ISettingsService
     /// <summary>
     /// Gets or sets the preferred sort order for the songs page.
     /// </summary>
-    SongSortOrder SongsSortOrder { get; set; }
+    SongSortOrder PersistentSongsSortOrder { get; set; }
 
     /// <summary>
     /// Gets or sets the preferred sort order for the albums page.
     /// </summary>
-    AlbumSortOrder AlbumsSortOrder { get; set; }
+    AlbumSortOrder PersistentAlbumsSortOrder { get; set; }
 }

--- a/Screenbox.Core/Services/LibraryService.cs
+++ b/Screenbox.Core/Services/LibraryService.cs
@@ -176,6 +176,7 @@ public sealed class LibraryService : ILibraryService
             songs,
             albumFactory.Albums,
             artistFactory.Artists,
+            ExtractGenres(songs),
             albumFactory.UnknownAlbum,
             artistFactory.UnknownArtist);
 
@@ -564,8 +565,19 @@ public sealed class LibraryService : ILibraryService
             new List<MediaViewModel>(songs),
             new Dictionary<string, AlbumViewModel>(albumFactory.Albums),
             new Dictionary<string, ArtistViewModel>(artistFactory.Artists),
+            ExtractGenres(songs),
             albumFactory.UnknownAlbum,
             artistFactory.UnknownArtist);
+    }
+
+    private static IReadOnlyList<string> ExtractGenres(IEnumerable<MediaViewModel> songs)
+    {
+        return songs
+            .Select(s => s.MediaInfo.MusicProperties.Genre.Trim())
+            .Where(g => !string.IsNullOrEmpty(g))
+            .Distinct(StringComparer.CurrentCultureIgnoreCase)
+            .OrderBy(g => g, StringComparer.CurrentCulture)
+            .ToList();
     }
 
     private async Task<IReadOnlyList<StorageFile>> FetchFilesFromStorage(StorageFileQueryResult queryResult, uint fetchIndex, uint batchSize = 50)

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -32,6 +32,8 @@ public sealed class SettingsService : ISettingsService
     private const string PersistentRepeatModeKey = "Values/RepeatMode";
     private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
     private const string PersistentShowRemainingTimeKey = "Values/ShowRemainingTime";
+    private const string PersistentSongsSortByKey = "Values/Songs/SortBy";
+    private const string PersistentAlbumsSortByKey = "Values/Albums/SortBy";
     private const string PlayerShowChaptersKey = "Player/ShowChapters";
     private const string PrivacyPersistPlaybackPosition = "Privacy/PersistPlaybackPosition";
 
@@ -238,6 +240,18 @@ public sealed class SettingsService : ISettingsService
         set => SetValue(PlayerGesturePressAndHoldKey, value);
     }
 
+    public string PersistentSongsSortBy
+    {
+        get => GetValue<string>(PersistentSongsSortByKey) is { Length: > 0 } value ? value : "title";
+        set => SetValue(PersistentSongsSortByKey, value);
+    }
+
+    public string PersistentAlbumsSortBy
+    {
+        get => GetValue<string>(PersistentAlbumsSortByKey) is { Length: > 0 } value ? value : "title";
+        set => SetValue(PersistentAlbumsSortByKey, value);
+    }
+
     public SettingsService()
     {
         SetDefault(PlayerAutoResizeKey, (int)PlayerAutoResizeOption.Never);
@@ -255,6 +269,8 @@ public sealed class SettingsService : ISettingsService
         SetDefault(AdvancedMultipleInstancesKey, false);
         SetDefault(GlobalArgumentsKey, string.Empty);
         SetDefault(PersistentShowRemainingTimeKey, false);
+        SetDefault(PersistentSongsSortByKey, "title");
+        SetDefault(PersistentAlbumsSortByKey, "title");
         SetDefault(PlayerShowChaptersKey, true);
         SetDefault(PrivacyPersistPlaybackPosition, true);
         SetDefault(PlayerRewindStepKey, 5);

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -32,8 +32,8 @@ public sealed class SettingsService : ISettingsService
     private const string PersistentRepeatModeKey = "Values/RepeatMode";
     private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
     private const string PersistentShowRemainingTimeKey = "Values/ShowRemainingTime";
-    private const string PersistentSongsSortByKey = "Values/Songs/SortBy";
-    private const string PersistentAlbumsSortByKey = "Values/Albums/SortBy";
+    private const string SongsSortOrderKey = "Values/Songs/SortOrder";
+    private const string AlbumsSortOrderKey = "Values/Albums/SortOrder";
     private const string PlayerShowChaptersKey = "Player/ShowChapters";
     private const string PrivacyPersistPlaybackPosition = "Privacy/PersistPlaybackPosition";
 
@@ -240,16 +240,16 @@ public sealed class SettingsService : ISettingsService
         set => SetValue(PlayerGesturePressAndHoldKey, value);
     }
 
-    public string PersistentSongsSortBy
+    public SongSortOrder SongsSortOrder
     {
-        get => GetValue<string>(PersistentSongsSortByKey) is { Length: > 0 } value ? value : "title";
-        set => SetValue(PersistentSongsSortByKey, value);
+        get => (SongSortOrder)GetValue<int>(SongsSortOrderKey);
+        set => SetValue(SongsSortOrderKey, (int)value);
     }
 
-    public string PersistentAlbumsSortBy
+    public AlbumSortOrder AlbumsSortOrder
     {
-        get => GetValue<string>(PersistentAlbumsSortByKey) is { Length: > 0 } value ? value : "title";
-        set => SetValue(PersistentAlbumsSortByKey, value);
+        get => (AlbumSortOrder)GetValue<int>(AlbumsSortOrderKey);
+        set => SetValue(AlbumsSortOrderKey, (int)value);
     }
 
     public SettingsService()
@@ -269,8 +269,8 @@ public sealed class SettingsService : ISettingsService
         SetDefault(AdvancedMultipleInstancesKey, false);
         SetDefault(GlobalArgumentsKey, string.Empty);
         SetDefault(PersistentShowRemainingTimeKey, false);
-        SetDefault(PersistentSongsSortByKey, "title");
-        SetDefault(PersistentAlbumsSortByKey, "title");
+        SetDefault(SongsSortOrderKey, (int)SongSortOrder.Title);
+        SetDefault(AlbumsSortOrderKey, (int)AlbumSortOrder.Title);
         SetDefault(PlayerShowChaptersKey, true);
         SetDefault(PrivacyPersistPlaybackPosition, true);
         SetDefault(PlayerRewindStepKey, 5);

--- a/Screenbox.Core/Services/SettingsService.cs
+++ b/Screenbox.Core/Services/SettingsService.cs
@@ -32,8 +32,8 @@ public sealed class SettingsService : ISettingsService
     private const string PersistentRepeatModeKey = "Values/RepeatMode";
     private const string PersistentSubtitleLanguageKey = "Values/SubtitleLanguage";
     private const string PersistentShowRemainingTimeKey = "Values/ShowRemainingTime";
-    private const string SongsSortOrderKey = "Values/Songs/SortOrder";
-    private const string AlbumsSortOrderKey = "Values/Albums/SortOrder";
+    private const string PersistentSongsSortOrderKey = "Values/Songs/SortOrder";
+    private const string PersistentAlbumsSortOrderKey = "Values/Albums/SortOrder";
     private const string PlayerShowChaptersKey = "Player/ShowChapters";
     private const string PrivacyPersistPlaybackPosition = "Privacy/PersistPlaybackPosition";
 
@@ -240,16 +240,16 @@ public sealed class SettingsService : ISettingsService
         set => SetValue(PlayerGesturePressAndHoldKey, value);
     }
 
-    public SongSortOrder SongsSortOrder
+    public SongSortOrder PersistentSongsSortOrder
     {
-        get => (SongSortOrder)GetValue<int>(SongsSortOrderKey);
-        set => SetValue(SongsSortOrderKey, (int)value);
+        get => (SongSortOrder)GetValue<int>(PersistentSongsSortOrderKey);
+        set => SetValue(PersistentSongsSortOrderKey, (int)value);
     }
 
-    public AlbumSortOrder AlbumsSortOrder
+    public AlbumSortOrder PersistentAlbumsSortOrder
     {
-        get => (AlbumSortOrder)GetValue<int>(AlbumsSortOrderKey);
-        set => SetValue(AlbumsSortOrderKey, (int)value);
+        get => (AlbumSortOrder)GetValue<int>(PersistentAlbumsSortOrderKey);
+        set => SetValue(PersistentAlbumsSortOrderKey, (int)value);
     }
 
     public SettingsService()
@@ -269,8 +269,8 @@ public sealed class SettingsService : ISettingsService
         SetDefault(AdvancedMultipleInstancesKey, false);
         SetDefault(GlobalArgumentsKey, string.Empty);
         SetDefault(PersistentShowRemainingTimeKey, false);
-        SetDefault(SongsSortOrderKey, (int)SongSortOrder.Title);
-        SetDefault(AlbumsSortOrderKey, (int)AlbumSortOrder.Title);
+        SetDefault(PersistentSongsSortOrderKey, (int)SongSortOrder.Title);
+        SetDefault(PersistentAlbumsSortOrderKey, (int)AlbumSortOrder.Title);
         SetDefault(PlayerShowChaptersKey, true);
         SetDefault(PrivacyPersistPlaybackPosition, true);
         SetDefault(PlayerRewindStepKey, 5);

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -31,8 +31,8 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
 
     private readonly LibraryContext _libraryContext;
     private readonly ISettingsService _settingsService;
-    private readonly DispatcherQueue? _dispatcherQueue;
-    private readonly DispatcherQueueTimer? _refreshTimer;
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly DispatcherQueueTimer _refreshTimer;
 
     public AlbumsPageViewModel(LibraryContext libraryContext, ISettingsService settingsService)
     {
@@ -40,26 +40,19 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         _settingsService = settingsService;
         SortBy = _settingsService.PersistentAlbumsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-        _refreshTimer = _dispatcherQueue?.CreateTimer();
+        _refreshTimer = _dispatcherQueue.CreateTimer();
 
         Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)
     {
-        if (_dispatcherQueue is not null)
-        {
-            _dispatcherQueue.TryEnqueue(FetchAlbums);
-        }
-        else
-        {
-            FetchAlbums();
-        }
+        _dispatcherQueue.TryEnqueue(FetchAlbums);
     }
 
     public void OnNavigatedFrom()
     {
-        _refreshTimer?.Stop();
+        _refreshTimer.Stop();
     }
 
     public void FetchAlbums()
@@ -88,11 +81,11 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         // Progressively update when it's still loading
         if (_libraryContext.IsLoadingMusic)
         {
-            _refreshTimer?.Debounce(FetchAlbums, TimeSpan.FromSeconds(5));
+            _refreshTimer.Debounce(FetchAlbums, TimeSpan.FromSeconds(5));
         }
         else
         {
-            _refreshTimer?.Stop();
+            _refreshTimer.Stop();
         }
     }
 

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using CommunityToolkit.WinUI;
 using Screenbox.Core.Contexts;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
@@ -23,7 +24,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     public ObservableCollection<ObservableAlbumGroup> GroupedAlbums { get; } = [];
 
     [ObservableProperty]
-    public partial string SortBy { get; set; } = string.Empty;
+    public partial AlbumSortOrder SortBy { get; set; } = AlbumSortOrder.Title;
 
     [ObservableProperty]
     public partial AlbumViewModel? ContextAlbum { get; set; }
@@ -37,7 +38,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     {
         _libraryContext = libraryContext;
         _settingsService = settingsService;
-        SortBy = _settingsService.PersistentAlbumsSortBy;
+        SortBy = _settingsService.AlbumsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue?.CreateTimer();
 
@@ -160,13 +161,13 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         return groups;
     }
 
-    private List<IGrouping<string, AlbumViewModel>> GetCurrentGrouping(LibraryContext context, string sortBy)
+    private List<IGrouping<string, AlbumViewModel>> GetCurrentGrouping(LibraryContext context, AlbumSortOrder sortBy)
     {
         return sortBy switch
         {
-            "artist" => GetArtistGrouping(context),
-            "year" => GetYearGrouping(context),
-            "dateAdded" => GetDateAddedGrouping(context),
+            AlbumSortOrder.Artist => GetArtistGrouping(context),
+            AlbumSortOrder.Year => GetYearGrouping(context),
+            AlbumSortOrder.DateAdded => GetDateAddedGrouping(context),
             _ => GetDefaultGrouping(context)
         };
     }
@@ -180,9 +181,9 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         }
     }
 
-    partial void OnSortByChanged(string value)
+    partial void OnSortByChanged(AlbumSortOrder value)
     {
-        _settingsService.PersistentAlbumsSortBy = value;
+        _settingsService.AlbumsSortOrder = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedAlbums.Clear();
         foreach (IGrouping<string, AlbumViewModel> group in groups)
@@ -192,7 +193,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     }
 
     [RelayCommand]
-    private void SetSortBy(string tag)
+    private void SetSortBy(AlbumSortOrder tag)
     {
         SortBy = tag;
     }

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.WinUI;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Models;
+using Screenbox.Core.Services;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
 
@@ -28,26 +29,36 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     public partial AlbumViewModel? ContextAlbum { get; set; }
 
     private readonly LibraryContext _libraryContext;
-    private readonly DispatcherQueue _dispatcherQueue;
-    private readonly DispatcherQueueTimer _refreshTimer;
+    private readonly ISettingsService _settingsService;
+    private readonly DispatcherQueue? _dispatcherQueue;
+    private readonly DispatcherQueueTimer? _refreshTimer;
 
-    public AlbumsPageViewModel(LibraryContext libraryContext)
+    public AlbumsPageViewModel(LibraryContext libraryContext, ISettingsService settingsService)
     {
         _libraryContext = libraryContext;
+        _settingsService = settingsService;
+        SortBy = _settingsService.PersistentAlbumsSortBy;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-        _refreshTimer = _dispatcherQueue.CreateTimer();
+        _refreshTimer = _dispatcherQueue?.CreateTimer();
 
         Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)
     {
-        _dispatcherQueue.TryEnqueue(FetchAlbums);
+        if (_dispatcherQueue is not null)
+        {
+            _dispatcherQueue.TryEnqueue(FetchAlbums);
+        }
+        else
+        {
+            FetchAlbums();
+        }
     }
 
     public void OnNavigatedFrom()
     {
-        _refreshTimer.Stop();
+        _refreshTimer?.Stop();
     }
 
     public void FetchAlbums()
@@ -76,11 +87,11 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         // Progressively update when it's still loading
         if (_libraryContext.IsLoadingMusic)
         {
-            _refreshTimer.Debounce(FetchAlbums, TimeSpan.FromSeconds(5));
+            _refreshTimer?.Debounce(FetchAlbums, TimeSpan.FromSeconds(5));
         }
         else
         {
-            _refreshTimer.Stop();
+            _refreshTimer?.Stop();
         }
     }
 
@@ -171,6 +182,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
 
     partial void OnSortByChanged(string value)
     {
+        _settingsService.PersistentAlbumsSortBy = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedAlbums.Clear();
         foreach (IGrouping<string, AlbumViewModel> group in groups)

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -38,7 +38,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     {
         _libraryContext = libraryContext;
         _settingsService = settingsService;
-        SortBy = _settingsService.AlbumsSortOrder;
+        SortBy = _settingsService.PersistentAlbumsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue?.CreateTimer();
 
@@ -183,7 +183,7 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
 
     partial void OnSortByChanged(AlbumSortOrder value)
     {
-        _settingsService.AlbumsSortOrder = value;
+        _settingsService.PersistentAlbumsSortOrder = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedAlbums.Clear();
         foreach (IGrouping<string, AlbumViewModel> group in groups)

--- a/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/AlbumsPageViewModel.cs
@@ -27,6 +27,12 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     public partial AlbumSortOrder SortBy { get; set; } = AlbumSortOrder.Title;
 
     [ObservableProperty]
+    public partial string? SelectedGenre { get; set; }
+
+    [ObservableProperty]
+    public partial IReadOnlyList<string> Genres { get; set; } = Array.Empty<string>();
+
+    [ObservableProperty]
     public partial AlbumViewModel? ContextAlbum { get; set; }
 
     private readonly LibraryContext _libraryContext;
@@ -59,7 +65,8 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     {
         // No need to run fetch async. HomePageViewModel should already called the method.
         IsLoading = _libraryContext.IsLoadingMusic;
-        Songs = _libraryContext.Music.Songs;
+        Genres = _libraryContext.Music.Genres;
+        Songs = GetFilteredSongs().ToList();
 
         var groups = GetCurrentGrouping(_libraryContext, SortBy);
         if (Songs.Count < 5000)
@@ -89,9 +96,31 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         }
     }
 
-    private List<IGrouping<string, AlbumViewModel>> GetDefaultGrouping(LibraryContext context)
+    private IEnumerable<MediaViewModel> GetFilteredSongs()
     {
-        var groups = context.Music.Albums.Values
+        IReadOnlyList<MediaViewModel> allSongs = _libraryContext.Music.Songs;
+        return SelectedGenre switch
+        {
+            null => allSongs,
+            "" => allSongs.Where(s => string.IsNullOrWhiteSpace(s.MediaInfo.MusicProperties.Genre)),
+            _ => allSongs.Where(s => string.Equals(s.MediaInfo.MusicProperties.Genre.Trim(), SelectedGenre, StringComparison.CurrentCultureIgnoreCase))
+        };
+    }
+
+    private IEnumerable<AlbumViewModel> GetFilteredAlbums(LibraryContext context)
+    {
+        IEnumerable<AlbumViewModel> allAlbums = context.Music.Albums.Values;
+        return SelectedGenre switch
+        {
+            null => allAlbums,
+            "" => allAlbums.Where(a => a.RelatedSongs.Any(s => string.IsNullOrWhiteSpace(s.MediaInfo.MusicProperties.Genre))),
+            _ => allAlbums.Where(a => a.RelatedSongs.Any(s => string.Equals(s.MediaInfo.MusicProperties.Genre.Trim(), SelectedGenre, StringComparison.CurrentCultureIgnoreCase)))
+        };
+    }
+
+    private List<IGrouping<string, AlbumViewModel>> GetDefaultGrouping(LibraryContext context, IEnumerable<AlbumViewModel> albums)
+    {
+        var groups = albums
             .OrderBy(a => a.Name, StringComparer.CurrentCulture)
             .GroupBy(album => album == context.Music.UnknownAlbum
                 ? MediaGroupingHelpers.OtherGroupSymbol
@@ -114,9 +143,9 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         return sortedGroup;
     }
 
-    private List<IGrouping<string, AlbumViewModel>> GetArtistGrouping(LibraryContext context)
+    private List<IGrouping<string, AlbumViewModel>> GetArtistGrouping(LibraryContext context, IEnumerable<AlbumViewModel> albums)
     {
-        var groups = context.Music.Albums.Values.GroupBy(a => a.ArtistName)
+        var groups = albums.GroupBy(a => a.ArtistName)
             .OrderBy(g => g.Key, StringComparer.CurrentCulture)
             .ToList();
 
@@ -131,9 +160,9 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         return groups;
     }
 
-    private List<IGrouping<string, AlbumViewModel>> GetYearGrouping(LibraryContext context)
+    private List<IGrouping<string, AlbumViewModel>> GetYearGrouping(IEnumerable<AlbumViewModel> albums)
     {
-        var groups = context.Music.Albums.Values.GroupBy(a =>
+        var groups = albums.GroupBy(a =>
                 a.Year > 0
                     ? a.Year.ToString() ?? MediaGroupingHelpers.OtherGroupSymbol
                     : MediaGroupingHelpers.OtherGroupSymbol)
@@ -142,9 +171,9 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
         return groups;
     }
 
-    private List<IGrouping<string, AlbumViewModel>> GetDateAddedGrouping(LibraryContext context)
+    private List<IGrouping<string, AlbumViewModel>> GetDateAddedGrouping(IEnumerable<AlbumViewModel> albums)
     {
-        var groups = context.Music.Albums.Values.GroupBy(a => a.DateAdded.Date)
+        var groups = albums.GroupBy(a => a.DateAdded.Date)
             .OrderByDescending(g => g.Key)
             .Select(g =>
                 new ListGrouping<string, AlbumViewModel>(
@@ -156,12 +185,13 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
 
     private List<IGrouping<string, AlbumViewModel>> GetCurrentGrouping(LibraryContext context, AlbumSortOrder sortBy)
     {
+        var albums = GetFilteredAlbums(context);
         return sortBy switch
         {
-            AlbumSortOrder.Artist => GetArtistGrouping(context),
-            AlbumSortOrder.Year => GetYearGrouping(context),
-            AlbumSortOrder.DateAdded => GetDateAddedGrouping(context),
-            _ => GetDefaultGrouping(context)
+            AlbumSortOrder.Artist => GetArtistGrouping(context, albums),
+            AlbumSortOrder.Year => GetYearGrouping(albums),
+            AlbumSortOrder.DateAdded => GetDateAddedGrouping(albums),
+            _ => GetDefaultGrouping(context, albums)
         };
     }
 
@@ -177,7 +207,18 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     partial void OnSortByChanged(AlbumSortOrder value)
     {
         _settingsService.PersistentAlbumsSortOrder = value;
-        var groups = GetCurrentGrouping(_libraryContext, value);
+        UpdateGrouping();
+    }
+
+    partial void OnSelectedGenreChanged(string? value)
+    {
+        Songs = GetFilteredSongs().ToList();
+        UpdateGrouping();
+    }
+
+    private void UpdateGrouping()
+    {
+        var groups = GetCurrentGrouping(_libraryContext, SortBy);
         GroupedAlbums.Clear();
         foreach (IGrouping<string, AlbumViewModel> group in groups)
         {
@@ -189,5 +230,11 @@ public sealed partial class AlbumsPageViewModel : BaseMusicContentViewModel,
     private void SetSortBy(AlbumSortOrder tag)
     {
         SortBy = tag;
+    }
+
+    [RelayCommand]
+    private void SetGenre(string? genre)
+    {
+        SelectedGenre = genre;
     }
 }

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -27,8 +27,8 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
 
     private readonly LibraryContext _libraryContext;
     private readonly ISettingsService _settingsService;
-    private readonly DispatcherQueue? _dispatcherQueue;
-    private readonly DispatcherQueueTimer? _refreshTimer;
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly DispatcherQueueTimer _refreshTimer;
 
     public SongsPageViewModel(LibraryContext libraryContext, ISettingsService settingsService)
     {
@@ -36,26 +36,19 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         _settingsService = settingsService;
         SortBy = _settingsService.PersistentSongsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-        _refreshTimer = _dispatcherQueue?.CreateTimer();
+        _refreshTimer = _dispatcherQueue.CreateTimer();
 
         Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)
     {
-        if (_dispatcherQueue is not null)
-        {
-            _dispatcherQueue.TryEnqueue(FetchSongs);
-        }
-        else
-        {
-            FetchSongs();
-        }
+        _dispatcherQueue.TryEnqueue(FetchSongs);
     }
 
     public void OnNavigatedFrom()
     {
-        _refreshTimer?.Stop();
+        _refreshTimer.Stop();
     }
 
     public void FetchSongs()
@@ -85,11 +78,11 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         // Progressively update when it's still loading
         if (_libraryContext.IsLoadingMusic)
         {
-            _refreshTimer?.Debounce(FetchSongs, TimeSpan.FromSeconds(5));
+            _refreshTimer.Debounce(FetchSongs, TimeSpan.FromSeconds(5));
         }
         else
         {
-            _refreshTimer?.Stop();
+            _refreshTimer.Stop();
         }
     }
 

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using CommunityToolkit.WinUI;
 using Screenbox.Core.Contexts;
+using Screenbox.Core.Enums;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Models;
 using Screenbox.Core.Services;
@@ -22,7 +23,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     public ObservableCollection<ObservableMediaGroup> GroupedSongs { get; } = new();
 
     [ObservableProperty] public partial MediaViewModel? ContextMedia { get; set; }
-    [ObservableProperty] public partial string SortBy { get; set; } = string.Empty;
+    [ObservableProperty] public partial SongSortOrder SortBy { get; set; } = SongSortOrder.Title;
 
     private readonly LibraryContext _libraryContext;
     private readonly ISettingsService _settingsService;
@@ -33,7 +34,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     {
         _libraryContext = libraryContext;
         _settingsService = settingsService;
-        SortBy = _settingsService.PersistentSongsSortBy;
+        SortBy = _settingsService.SongsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue?.CreateTimer();
 
@@ -171,21 +172,21 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         return sortedGroup;
     }
 
-    private List<IGrouping<string, MediaViewModel>> GetCurrentGrouping(LibraryContext context, string sortBy)
+    private List<IGrouping<string, MediaViewModel>> GetCurrentGrouping(LibraryContext context, SongSortOrder sortBy)
     {
         return sortBy switch
         {
-            "album" => GetAlbumGrouping(context),
-            "artist" => GetArtistGrouping(context),
-            "year" => GetYearGrouping(),
-            "dateAdded" => GetDateAddedGrouping(),
+            SongSortOrder.Album => GetAlbumGrouping(context),
+            SongSortOrder.Artist => GetArtistGrouping(context),
+            SongSortOrder.Year => GetYearGrouping(),
+            SongSortOrder.DateAdded => GetDateAddedGrouping(),
             _ => GetDefaultGrouping()
         };
     }
 
-    partial void OnSortByChanged(string value)
+    partial void OnSortByChanged(SongSortOrder value)
     {
-        _settingsService.PersistentSongsSortBy = value;
+        _settingsService.SongsSortOrder = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedSongs.Clear();
         foreach (IGrouping<string, MediaViewModel> group in groups)
@@ -195,7 +196,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     }
 
     [RelayCommand]
-    private void SetSortBy(string tag)
+    private void SetSortBy(SongSortOrder tag)
     {
         SortBy = tag;
     }

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.WinUI;
 using Screenbox.Core.Contexts;
 using Screenbox.Core.Helpers;
 using Screenbox.Core.Models;
+using Screenbox.Core.Services;
 using Windows.System;
 
 namespace Screenbox.Core.ViewModels;
@@ -24,26 +25,36 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     [ObservableProperty] public partial string SortBy { get; set; } = string.Empty;
 
     private readonly LibraryContext _libraryContext;
-    private readonly DispatcherQueue _dispatcherQueue;
-    private readonly DispatcherQueueTimer _refreshTimer;
+    private readonly ISettingsService _settingsService;
+    private readonly DispatcherQueue? _dispatcherQueue;
+    private readonly DispatcherQueueTimer? _refreshTimer;
 
-    public SongsPageViewModel(LibraryContext libraryContext)
+    public SongsPageViewModel(LibraryContext libraryContext, ISettingsService settingsService)
     {
         _libraryContext = libraryContext;
+        _settingsService = settingsService;
+        SortBy = _settingsService.PersistentSongsSortBy;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-        _refreshTimer = _dispatcherQueue.CreateTimer();
+        _refreshTimer = _dispatcherQueue?.CreateTimer();
 
         Messenger.Register<PropertyChangedMessage<MusicLibrary>>(this);
     }
 
     public void Receive(PropertyChangedMessage<MusicLibrary> message)
     {
-        _dispatcherQueue.TryEnqueue(FetchSongs);
+        if (_dispatcherQueue is not null)
+        {
+            _dispatcherQueue.TryEnqueue(FetchSongs);
+        }
+        else
+        {
+            FetchSongs();
+        }
     }
 
     public void OnNavigatedFrom()
     {
-        _refreshTimer.Stop();
+        _refreshTimer?.Stop();
     }
 
     public void FetchSongs()
@@ -73,11 +84,11 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         // Progressively update when it's still loading
         if (_libraryContext.IsLoadingMusic)
         {
-            _refreshTimer.Debounce(FetchSongs, TimeSpan.FromSeconds(5));
+            _refreshTimer?.Debounce(FetchSongs, TimeSpan.FromSeconds(5));
         }
         else
         {
-            _refreshTimer.Stop();
+            _refreshTimer?.Stop();
         }
     }
 
@@ -174,6 +185,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
 
     partial void OnSortByChanged(string value)
     {
+        _settingsService.PersistentSongsSortBy = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedSongs.Clear();
         foreach (IGrouping<string, MediaViewModel> group in groups)

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -24,6 +24,8 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
 
     [ObservableProperty] public partial MediaViewModel? ContextMedia { get; set; }
     [ObservableProperty] public partial SongSortOrder SortBy { get; set; } = SongSortOrder.Title;
+    [ObservableProperty] public partial string? SelectedGenre { get; set; }
+    [ObservableProperty] public partial IReadOnlyList<string> Genres { get; set; } = Array.Empty<string>();
 
     private readonly LibraryContext _libraryContext;
     private readonly ISettingsService _settingsService;
@@ -55,7 +57,8 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     {
         // No need to run fetch async. HomePageViewModel should already called the method.
         IsLoading = _libraryContext.IsLoadingMusic;
-        Songs = _libraryContext.Music.Songs;
+        Genres = _libraryContext.Music.Genres;
+        Songs = GetFilteredSongs().ToList();
 
         // Populate song groups with fetched result
         var groups = GetCurrentGrouping(_libraryContext, SortBy);
@@ -84,6 +87,17 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
         {
             _refreshTimer.Stop();
         }
+    }
+
+    private IEnumerable<MediaViewModel> GetFilteredSongs()
+    {
+        IReadOnlyList<MediaViewModel> allSongs = _libraryContext.Music.Songs;
+        return SelectedGenre switch
+        {
+            null => allSongs,
+            "" => allSongs.Where(s => string.IsNullOrWhiteSpace(s.MediaInfo.MusicProperties.Genre)),
+            _ => allSongs.Where(s => string.Equals(s.MediaInfo.MusicProperties.Genre.Trim(), SelectedGenre, StringComparison.CurrentCultureIgnoreCase))
+        };
     }
 
     private List<IGrouping<string, MediaViewModel>> GetAlbumGrouping(LibraryContext context)
@@ -180,7 +194,18 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     partial void OnSortByChanged(SongSortOrder value)
     {
         _settingsService.PersistentSongsSortOrder = value;
-        var groups = GetCurrentGrouping(_libraryContext, value);
+        UpdateGrouping();
+    }
+
+    partial void OnSelectedGenreChanged(string? value)
+    {
+        Songs = GetFilteredSongs().ToList();
+        UpdateGrouping();
+    }
+
+    private void UpdateGrouping()
+    {
+        var groups = GetCurrentGrouping(_libraryContext, SortBy);
         GroupedSongs.Clear();
         foreach (IGrouping<string, MediaViewModel> group in groups)
         {
@@ -192,6 +217,12 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     private void SetSortBy(SongSortOrder tag)
     {
         SortBy = tag;
+    }
+
+    [RelayCommand]
+    private void SetGenre(string? genre)
+    {
+        SelectedGenre = genre;
     }
 
     [RelayCommand]

--- a/Screenbox.Core/ViewModels/SongsPageViewModel.cs
+++ b/Screenbox.Core/ViewModels/SongsPageViewModel.cs
@@ -34,7 +34,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
     {
         _libraryContext = libraryContext;
         _settingsService = settingsService;
-        SortBy = _settingsService.SongsSortOrder;
+        SortBy = _settingsService.PersistentSongsSortOrder;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         _refreshTimer = _dispatcherQueue?.CreateTimer();
 
@@ -186,7 +186,7 @@ public sealed partial class SongsPageViewModel : BaseMusicContentViewModel,
 
     partial void OnSortByChanged(SongSortOrder value)
     {
-        _settingsService.SongsSortOrder = value;
+        _settingsService.PersistentSongsSortOrder = value;
         var groups = GetCurrentGrouping(_libraryContext, value);
         GroupedSongs.Clear();
         foreach (IGrouping<string, MediaViewModel> group in groups)

--- a/Screenbox/Behaviors/GroupingOverviewBehavior.cs
+++ b/Screenbox/Behaviors/GroupingOverviewBehavior.cs
@@ -56,8 +56,8 @@ internal sealed partial class GroupingOverviewBehavior : Behavior<GridView>
             var element = (FrameworkElement)child;
             element.Width = GroupType switch
             {
-                "year" => 80,
-                null or "" when MediaGroupingHelpers.MaxGroupLabelLength > 1 => 100,
+                "year" or "Year" => 80,
+                null or "" or "title" or "Title" when MediaGroupingHelpers.MaxGroupLabelLength > 1 => 100,
                 _ when AssociatedObject.HorizontalAlignment != HorizontalAlignment.Stretch => double.NaN,
                 _ => itemWidth
             };

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -91,49 +91,69 @@
             </StackPanel>
         </Button>
 
-        <muxc:DropDownButton
-            x:Name="SortByButton"
+        <StackPanel
+            x:Name="HeaderActionsPanel"
             Grid.Row="0"
             Margin="{StaticResource ContentPagePadding}"
             HorizontalAlignment="Right"
-            AccessKey="{strings:KeyboardResources Key=CommandSortByKey}"
-            AutomationProperties.Name="{x:Bind GetSortByButtonAutomationName(ViewModel.SortBy), Mode=OneWay}"
-            Background="Transparent"
-            BorderBrush="Transparent">
-            <muxc:DropDownButton.Flyout>
-                <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:AlbumSortOrder.Title}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Title), Mode=OneWay}"
-                        Text="{strings:Resources Key=PropertyTitle}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:AlbumSortOrder.Artist}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Artist), Mode=OneWay}"
-                        Text="{strings:Resources Key=Artist}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:AlbumSortOrder.Year}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Year), Mode=OneWay}"
-                        Text="{strings:Resources Key=ReleasedYear}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:AlbumSortOrder.DateAdded}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.DateAdded), Mode=OneWay}"
-                        Text="{strings:Resources Key=DateAdded}" />
-                </MenuFlyout>
-            </muxc:DropDownButton.Flyout>
-            <StackPanel Orientation="Horizontal">
-                <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
-                <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
-                <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
-            </StackPanel>
-        </muxc:DropDownButton>
+            Orientation="Horizontal"
+            Spacing="8">
+            <muxc:DropDownButton
+                x:Name="SortByButton"
+                AccessKey="{strings:KeyboardResources Key=CommandSortByKey}"
+                AutomationProperties.Name="{x:Bind GetSortByButtonAutomationName(ViewModel.SortBy), Mode=OneWay}"
+                Background="Transparent"
+                BorderBrush="Transparent">
+                <muxc:DropDownButton.Flyout>
+                    <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:AlbumSortOrder.Title}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Title), Mode=OneWay}"
+                            Text="{strings:Resources Key=PropertyTitle}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:AlbumSortOrder.Artist}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Artist), Mode=OneWay}"
+                            Text="{strings:Resources Key=Artist}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:AlbumSortOrder.Year}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Year), Mode=OneWay}"
+                            Text="{strings:Resources Key=ReleasedYear}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:AlbumSortOrder.DateAdded}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.DateAdded), Mode=OneWay}"
+                            Text="{strings:Resources Key=DateAdded}" />
+                    </MenuFlyout>
+                </muxc:DropDownButton.Flyout>
+                <StackPanel Orientation="Horizontal">
+                    <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
+                    <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
+                    <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
+                </StackPanel>
+            </muxc:DropDownButton>
+
+            <muxc:DropDownButton
+                x:Name="GenreButton"
+                AccessKey="{strings:KeyboardResources Key=CommandFilterByGenreKey}"
+                AutomationProperties.Name="{x:Bind GetGenreButtonAutomationName(ViewModel.SelectedGenre), Mode=OneWay}"
+                Background="Transparent"
+                BorderBrush="Transparent">
+                <muxc:DropDownButton.Flyout>
+                    <MenuFlyout x:Name="GenreFlyout" Placement="BottomEdgeAlignedRight" />
+                </muxc:DropDownButton.Flyout>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock x:Name="GenreText"><Run Text="{strings:Resources Key=PropertyGenre}" /><Run Text=":&#160;" /></TextBlock>
+                    <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetGenreText(ViewModel.SelectedGenre), Mode=OneWay}" />
+                </StackPanel>
+            </muxc:DropDownButton>
+        </StackPanel>
 
         <muxc:ProgressBar
             Grid.Row="1"
@@ -210,8 +230,9 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="ShufflePlayButton.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
-                        <Setter Target="SortByButton.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
+                        <Setter Target="HeaderActionsPanel.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
                         <Setter Target="SortByText.Visibility" Value="Collapsed" />
+                        <Setter Target="GenreText.Visibility" Value="Collapsed" />
                         <Setter Target="AlbumGridView.Padding" Value="{StaticResource GridViewContentPageMinimalPadding}" />
                         <Setter Target="GroupOverview.Padding" Value="{StaticResource ContentPageMinimalPadding}" />
                     </VisualState.Setters>
@@ -235,6 +256,7 @@
                     <VisualState.Setters>
                         <Setter Target="AddToQueueMenuFlyoutItemIcon.Glyph" Value="{StaticResource PlaylistMusicAddMirroredGlyph}" />
                         <Setter Target="SortByFlyout.Placement" Value="BottomEdgeAlignedLeft" />
+                        <Setter Target="GenreFlyout.Placement" Value="BottomEdgeAlignedLeft" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -106,26 +106,25 @@
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:AlbumSortOrder.Title}"
                         GroupName="SortOrder"
-                        IsChecked="True"
-                        Tag="{x:Bind enums:AlbumSortOrder.Title}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Title), Mode=OneWay}"
                         Text="{strings:Resources Key=PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:AlbumSortOrder.Artist}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:AlbumSortOrder.Artist}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Artist), Mode=OneWay}"
                         Text="{strings:Resources Key=Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:AlbumSortOrder.Year}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:AlbumSortOrder.Year}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.Year), Mode=OneWay}"
                         Text="{strings:Resources Key=ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:AlbumSortOrder.DateAdded}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:AlbumSortOrder.DateAdded}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:AlbumSortOrder.DateAdded), Mode=OneWay}"
                         Text="{strings:Resources Key=DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>

--- a/Screenbox/Pages/AlbumsPage.xaml
+++ b/Screenbox/Pages/AlbumsPage.xaml
@@ -6,6 +6,7 @@
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:enums="using:Screenbox.Core.Enums"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -103,28 +104,28 @@
                 <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="title"
+                        CommandParameter="{x:Bind enums:AlbumSortOrder.Title}"
                         GroupName="SortOrder"
                         IsChecked="True"
-                        Tag="title"
+                        Tag="{x:Bind enums:AlbumSortOrder.Title}"
                         Text="{strings:Resources Key=PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="artist"
+                        CommandParameter="{x:Bind enums:AlbumSortOrder.Artist}"
                         GroupName="SortOrder"
-                        Tag="artist"
+                        Tag="{x:Bind enums:AlbumSortOrder.Artist}"
                         Text="{strings:Resources Key=Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="year"
+                        CommandParameter="{x:Bind enums:AlbumSortOrder.Year}"
                         GroupName="SortOrder"
-                        Tag="year"
+                        Tag="{x:Bind enums:AlbumSortOrder.Year}"
                         Text="{strings:Resources Key=ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="dateAdded"
+                        CommandParameter="{x:Bind enums:AlbumSortOrder.DateAdded}"
                         GroupName="SortOrder"
-                        Tag="dateAdded"
+                        Tag="{x:Bind enums:AlbumSortOrder.DateAdded}"
                         Text="{strings:Resources Key=DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>
@@ -194,7 +195,7 @@
                         </ItemsPanelTemplate>
                     </GridView.ItemsPanel>
                     <interactivity:Interaction.Behaviors>
-                        <behaviors:GroupingOverviewBehavior GroupType="{x:Bind ViewModel.SortBy, Mode=OneWay}" />
+                        <behaviors:GroupingOverviewBehavior GroupType="{x:Bind ViewModel.SortBy.ToString(), Mode=OneWay}" />
                     </interactivity:Interaction.Behaviors>
                 </GridView>
             </SemanticZoom.ZoomedOutView>

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -39,15 +39,20 @@ public sealed partial class AlbumsPage : Page
     {
         if (e.PropertyName == nameof(AlbumsPageViewModel.SortBy))
         {
-            var state = ViewModel.SortBy switch
-            {
-                "artist" => "SortByArtist",
-                _ => "SortByTitle"
-            };
-            VisualStateManager.GoToState(this, state, true);
+            UpdateSortVisualState(ViewModel.SortBy);
             UpdateSortByFlyout();
             SavePageState(0);
         }
+    }
+
+    private void UpdateSortVisualState(string sortBy)
+    {
+        var state = sortBy switch
+        {
+            "artist" => "SortByArtist",
+            _ => "SortByTitle"
+        };
+        VisualStateManager.GoToState(this, state, true);
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -60,6 +65,9 @@ public sealed partial class AlbumsPage : Page
             ViewModel.SortBy = pair.Key;
             _contentVerticalOffset = pair.Value;
         }
+
+        UpdateSortVisualState(ViewModel.SortBy);
+        UpdateSortByFlyout();
 
         if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchAlbums))
             ViewModel.FetchAlbums();

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -43,6 +43,15 @@ public sealed partial class AlbumsPage : Page
             UpdateSortVisualState(ViewModel.SortBy);
             SavePageState(0);
         }
+        else if (e.PropertyName == nameof(AlbumsPageViewModel.Genres))
+        {
+            UpdateGenreFlyoutItems();
+        }
+        else if (e.PropertyName == nameof(AlbumsPageViewModel.SelectedGenre))
+        {
+            UpdateGenreFlyoutSelection();
+            SavePageState(0);
+        }
     }
 
     private void UpdateSortVisualState(AlbumSortOrder sortBy)
@@ -59,11 +68,19 @@ public sealed partial class AlbumsPage : Page
     {
         base.OnNavigatedTo(e);
         if (e.NavigationMode == NavigationMode.Back
-            && Common.TryGetPageState(nameof(AlbumsPage), Frame.BackStackDepth, out var state)
-            && state is KeyValuePair<AlbumSortOrder, double> pair)
+            && Common.TryGetPageState(nameof(AlbumsPage), Frame.BackStackDepth, out var state))
         {
-            ViewModel.SortBy = pair.Key;
-            _contentVerticalOffset = pair.Value;
+            if (state is PageState pageState)
+            {
+                ViewModel.SortBy = pageState.SortBy;
+                ViewModel.SelectedGenre = pageState.SelectedGenre;
+                _contentVerticalOffset = pageState.VerticalOffset;
+            }
+            else if (state is KeyValuePair<AlbumSortOrder, double> pair)
+            {
+                ViewModel.SortBy = pair.Key;
+                _contentVerticalOffset = pair.Value;
+            }
         }
 
         UpdateSortVisualState(ViewModel.SortBy);
@@ -71,6 +88,7 @@ public sealed partial class AlbumsPage : Page
         if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchAlbums))
             ViewModel.FetchAlbums();
 
+        UpdateGenreFlyoutItems();
         ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
     }
 
@@ -79,6 +97,57 @@ public sealed partial class AlbumsPage : Page
         base.OnNavigatedFrom(e);
         ViewModel.OnNavigatedFrom();
         ViewModel.PropertyChanged -= ViewModelOnPropertyChanged;
+    }
+
+    private void UpdateGenreFlyoutItems()
+    {
+        GenreFlyout.Items.Clear();
+
+        var allGenresItem = new RadioMenuFlyoutItem
+        {
+            Text = Strings.Resources.AllGenres,
+            GroupName = "GenreFilter",
+            IsChecked = ViewModel.SelectedGenre is null,
+            Command = ViewModel.SetGenreCommand,
+            CommandParameter = null
+        };
+        GenreFlyout.Items.Add(allGenresItem);
+
+        var unknownGenreItem = new RadioMenuFlyoutItem
+        {
+            Text = Strings.Resources.UnknownGenre,
+            GroupName = "GenreFilter",
+            IsChecked = ViewModel.SelectedGenre == string.Empty,
+            Command = ViewModel.SetGenreCommand,
+            CommandParameter = string.Empty
+        };
+        GenreFlyout.Items.Add(unknownGenreItem);
+
+        foreach (string genre in ViewModel.Genres)
+        {
+            var genreItem = new RadioMenuFlyoutItem
+            {
+                Text = genre,
+                GroupName = "GenreFilter",
+                IsChecked = ViewModel.SelectedGenre == genre,
+                Command = ViewModel.SetGenreCommand,
+                CommandParameter = genre
+            };
+            GenreFlyout.Items.Add(genreItem);
+        }
+    }
+
+    private void UpdateGenreFlyoutSelection()
+    {
+        foreach (var item in GenreFlyout.Items.OfType<RadioMenuFlyoutItem>())
+        {
+            item.IsChecked = item.CommandParameter switch
+            {
+                null => ViewModel.SelectedGenre is null,
+                string param => param == ViewModel.SelectedGenre,
+                _ => false
+            };
+        }
     }
 
     private void AlbumGridView_OnLoaded(object sender, RoutedEventArgs e)
@@ -97,9 +166,11 @@ public sealed partial class AlbumsPage : Page
         SavePageState(e.NextView.VerticalOffset);
     }
 
+    private record PageState(AlbumSortOrder SortBy, string? SelectedGenre, double VerticalOffset);
+
     private void SavePageState(double verticalOffset)
     {
-        Common.SavePageState(new KeyValuePair<AlbumSortOrder, double>(ViewModel.SortBy, verticalOffset), nameof(AlbumsPage),
+        Common.SavePageState(new PageState(ViewModel.SortBy, ViewModel.SelectedGenre, verticalOffset), nameof(AlbumsPage),
             Frame.BackStackDepth);
     }
 
@@ -120,5 +191,21 @@ public sealed partial class AlbumsPage : Page
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
+    }
+
+    private string GetGenreText(string? genre)
+    {
+        return genre switch
+        {
+            null => Strings.Resources.AllGenres,
+            "" => Strings.Resources.UnknownGenre,
+            _ => genre
+        };
+    }
+
+    private string GetGenreButtonAutomationName(string? genre)
+    {
+        var optionText = GetGenreText(genre);
+        return Strings.Resources.FilterByGenreAutomationName(optionText);
     }
 }

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -41,7 +41,6 @@ public sealed partial class AlbumsPage : Page
         if (e.PropertyName == nameof(AlbumsPageViewModel.SortBy))
         {
             UpdateSortVisualState(ViewModel.SortBy);
-            UpdateSortByFlyout();
             SavePageState(0);
         }
     }
@@ -68,7 +67,6 @@ public sealed partial class AlbumsPage : Page
         }
 
         UpdateSortVisualState(ViewModel.SortBy);
-        UpdateSortByFlyout();
 
         if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchAlbums))
             ViewModel.FetchAlbums();
@@ -105,23 +103,22 @@ public sealed partial class AlbumsPage : Page
             Frame.BackStackDepth);
     }
 
-    private string GetSortByText(AlbumSortOrder tag)
+    private bool IsSortBy(AlbumSortOrder current, AlbumSortOrder target) => current == target;
+
+    private string GetSortByText(AlbumSortOrder sortBy)
     {
-        var item = SortByFlyout.Items?.FirstOrDefault(x => x.Tag is AlbumSortOrder order && order == tag) ?? SortByFlyout.Items?.FirstOrDefault();
-        return (item as MenuFlyoutItem)?.Text ?? string.Empty;
+        return sortBy switch
+        {
+            AlbumSortOrder.Artist => Strings.Resources.Artist,
+            AlbumSortOrder.Year => Strings.Resources.ReleasedYear,
+            AlbumSortOrder.DateAdded => Strings.Resources.DateAdded,
+            _ => Strings.Resources.PropertyTitle
+        };
     }
 
     private string GetSortByButtonAutomationName(AlbumSortOrder value)
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
-    }
-
-    private void UpdateSortByFlyout()
-    {
-        if (SortByFlyout.Items?.FirstOrDefault(x => x.Tag is AlbumSortOrder order && order == ViewModel.SortBy) is RadioMenuFlyoutItem radioItem)
-        {
-            radioItem.IsChecked = true;
-        }
     }
 }

--- a/Screenbox/Pages/AlbumsPage.xaml.cs
+++ b/Screenbox/Pages/AlbumsPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Controls;
+using Screenbox.Core.Enums;
 using Screenbox.Core.ViewModels;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -45,11 +46,11 @@ public sealed partial class AlbumsPage : Page
         }
     }
 
-    private void UpdateSortVisualState(string sortBy)
+    private void UpdateSortVisualState(AlbumSortOrder sortBy)
     {
         var state = sortBy switch
         {
-            "artist" => "SortByArtist",
+            AlbumSortOrder.Artist => "SortByArtist",
             _ => "SortByTitle"
         };
         VisualStateManager.GoToState(this, state, true);
@@ -60,7 +61,7 @@ public sealed partial class AlbumsPage : Page
         base.OnNavigatedTo(e);
         if (e.NavigationMode == NavigationMode.Back
             && Common.TryGetPageState(nameof(AlbumsPage), Frame.BackStackDepth, out var state)
-            && state is KeyValuePair<string, double> pair)
+            && state is KeyValuePair<AlbumSortOrder, double> pair)
         {
             ViewModel.SortBy = pair.Key;
             _contentVerticalOffset = pair.Value;
@@ -100,17 +101,17 @@ public sealed partial class AlbumsPage : Page
 
     private void SavePageState(double verticalOffset)
     {
-        Common.SavePageState(new KeyValuePair<string, double>(ViewModel.SortBy, verticalOffset), nameof(AlbumsPage),
+        Common.SavePageState(new KeyValuePair<AlbumSortOrder, double>(ViewModel.SortBy, verticalOffset), nameof(AlbumsPage),
             Frame.BackStackDepth);
     }
 
-    private string GetSortByText(string tag)
+    private string GetSortByText(AlbumSortOrder tag)
     {
-        var item = SortByFlyout.Items?.FirstOrDefault(x => (x.Tag as string) == tag) ?? SortByFlyout.Items?.FirstOrDefault();
+        var item = SortByFlyout.Items?.FirstOrDefault(x => x.Tag is AlbumSortOrder order && order == tag) ?? SortByFlyout.Items?.FirstOrDefault();
         return (item as MenuFlyoutItem)?.Text ?? string.Empty;
     }
 
-    private string GetSortByButtonAutomationName(string value)
+    private string GetSortByButtonAutomationName(AlbumSortOrder value)
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
@@ -118,8 +119,7 @@ public sealed partial class AlbumsPage : Page
 
     private void UpdateSortByFlyout()
     {
-        if ((SortByFlyout.Items?.FirstOrDefault(x => (x.Tag as string) == ViewModel.SortBy) ??
-             SortByFlyout.Items?.FirstOrDefault()) is RadioMenuFlyoutItem radioItem)
+        if (SortByFlyout.Items?.FirstOrDefault(x => x.Tag is AlbumSortOrder order && order == ViewModel.SortBy) is RadioMenuFlyoutItem radioItem)
         {
             radioItem.IsChecked = true;
         }

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -136,55 +136,75 @@
             </StackPanel>
         </Button>
 
-        <muxc:DropDownButton
-            x:Name="SortByButton"
+        <StackPanel
+            x:Name="HeaderActionsPanel"
             Grid.Row="0"
             Margin="{StaticResource ContentPagePadding}"
             HorizontalAlignment="Right"
-            AccessKey="{strings:KeyboardResources Key=CommandSortByKey}"
-            AutomationProperties.Name="{x:Bind GetSortByButtonAutomationName(ViewModel.SortBy), Mode=OneWay}"
-            Background="Transparent"
-            BorderBrush="Transparent">
-            <muxc:DropDownButton.Flyout>
-                <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:SongSortOrder.Title}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Title), Mode=OneWay}"
-                        Text="{strings:Resources Key=PropertyTitle}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:SongSortOrder.Album}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Album), Mode=OneWay}"
-                        Text="{strings:Resources Key=PropertyAlbum}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:SongSortOrder.Artist}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Artist), Mode=OneWay}"
-                        Text="{strings:Resources Key=Artist}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:SongSortOrder.Year}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Year), Mode=OneWay}"
-                        Text="{strings:Resources Key=ReleasedYear}" />
-                    <muxc:RadioMenuFlyoutItem
-                        Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="{x:Bind enums:SongSortOrder.DateAdded}"
-                        GroupName="SortOrder"
-                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.DateAdded), Mode=OneWay}"
-                        Text="{strings:Resources Key=DateAdded}" />
-                </MenuFlyout>
-            </muxc:DropDownButton.Flyout>
-            <StackPanel Orientation="Horizontal">
-                <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
-                <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
-                <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
-            </StackPanel>
-        </muxc:DropDownButton>
+            Orientation="Horizontal"
+            Spacing="8">
+            <muxc:DropDownButton
+                x:Name="SortByButton"
+                AccessKey="{strings:KeyboardResources Key=CommandSortByKey}"
+                AutomationProperties.Name="{x:Bind GetSortByButtonAutomationName(ViewModel.SortBy), Mode=OneWay}"
+                Background="Transparent"
+                BorderBrush="Transparent">
+                <muxc:DropDownButton.Flyout>
+                    <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:SongSortOrder.Title}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Title), Mode=OneWay}"
+                            Text="{strings:Resources Key=PropertyTitle}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:SongSortOrder.Album}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Album), Mode=OneWay}"
+                            Text="{strings:Resources Key=PropertyAlbum}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:SongSortOrder.Artist}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Artist), Mode=OneWay}"
+                            Text="{strings:Resources Key=Artist}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:SongSortOrder.Year}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Year), Mode=OneWay}"
+                            Text="{strings:Resources Key=ReleasedYear}" />
+                        <muxc:RadioMenuFlyoutItem
+                            Command="{x:Bind ViewModel.SetSortByCommand}"
+                            CommandParameter="{x:Bind enums:SongSortOrder.DateAdded}"
+                            GroupName="SortOrder"
+                            IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.DateAdded), Mode=OneWay}"
+                            Text="{strings:Resources Key=DateAdded}" />
+                    </MenuFlyout>
+                </muxc:DropDownButton.Flyout>
+                <StackPanel Orientation="Horizontal">
+                    <FontIcon Margin="0,0,8,0" Glyph="&#xE8CB;" />
+                    <TextBlock x:Name="SortByText"><Run Text="{strings:Resources Key=SortBy}" /><Run Text=":&#160;" /></TextBlock>
+                    <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetSortByText(ViewModel.SortBy), Mode=OneWay}" />
+                </StackPanel>
+            </muxc:DropDownButton>
+
+            <muxc:DropDownButton
+                x:Name="GenreButton"
+                AccessKey="{strings:KeyboardResources Key=CommandFilterByGenreKey}"
+                AutomationProperties.Name="{x:Bind GetGenreButtonAutomationName(ViewModel.SelectedGenre), Mode=OneWay}"
+                Background="Transparent"
+                BorderBrush="Transparent">
+                <muxc:DropDownButton.Flyout>
+                    <MenuFlyout x:Name="GenreFlyout" Placement="BottomEdgeAlignedRight" />
+                </muxc:DropDownButton.Flyout>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock x:Name="GenreText"><Run Text="{strings:Resources Key=PropertyGenre}" /><Run Text=":&#160;" /></TextBlock>
+                    <TextBlock Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind GetGenreText(ViewModel.SelectedGenre), Mode=OneWay}" />
+                </StackPanel>
+            </muxc:DropDownButton>
+        </StackPanel>
 
         <muxc:ProgressBar
             Grid.Row="1"
@@ -269,8 +289,9 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="ShufflePlayButton.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
-                        <Setter Target="SortByButton.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
+                        <Setter Target="HeaderActionsPanel.Margin" Value="{StaticResource ContentPageMinimalPadding}" />
                         <Setter Target="SortByText.Visibility" Value="Collapsed" />
+                        <Setter Target="GenreText.Visibility" Value="Collapsed" />
                         <Setter Target="SongListView.Padding" Value="{StaticResource ContentPageMinimalPadding}" />
                         <Setter Target="GroupOverview.Padding" Value="{StaticResource ContentPageMinimalPadding}" />
                     </VisualState.Setters>
@@ -301,6 +322,7 @@
                         <Setter Target="AddToQueueMenuFlyoutItemIcon.Glyph" Value="{StaticResource PlaylistMusicAddMirroredGlyph}" />
                         <contract13NotPresent:Setter Target="AddToPlaylistMenuFlyoutSubItemIcon.Glyph" Value="{StaticResource PlaylistAddMirroredGlyph}" />
                         <Setter Target="SortByFlyout.Placement" Value="BottomEdgeAlignedLeft" />
+                        <Setter Target="GenreFlyout.Placement" Value="BottomEdgeAlignedLeft" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -151,32 +151,31 @@
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:SongSortOrder.Title}"
                         GroupName="SortOrder"
-                        IsChecked="True"
-                        Tag="{x:Bind enums:SongSortOrder.Title}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Title), Mode=OneWay}"
                         Text="{strings:Resources Key=PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:SongSortOrder.Album}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:SongSortOrder.Album}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Album), Mode=OneWay}"
                         Text="{strings:Resources Key=PropertyAlbum}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:SongSortOrder.Artist}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:SongSortOrder.Artist}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Artist), Mode=OneWay}"
                         Text="{strings:Resources Key=Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:SongSortOrder.Year}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:SongSortOrder.Year}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.Year), Mode=OneWay}"
                         Text="{strings:Resources Key=ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
                         CommandParameter="{x:Bind enums:SongSortOrder.DateAdded}"
                         GroupName="SortOrder"
-                        Tag="{x:Bind enums:SongSortOrder.DateAdded}"
+                        IsChecked="{x:Bind IsSortBy(ViewModel.SortBy, enums:SongSortOrder.DateAdded), Mode=OneWay}"
                         Text="{strings:Resources Key=DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>

--- a/Screenbox/Pages/SongsPage.xaml
+++ b/Screenbox/Pages/SongsPage.xaml
@@ -8,6 +8,7 @@
     xmlns:controls="using:Screenbox.Controls"
     xmlns:converters="using:Screenbox.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:enums="using:Screenbox.Core.Enums"
     xmlns:helpers="using:Screenbox.Helpers"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -148,34 +149,34 @@
                 <MenuFlyout x:Name="SortByFlyout" Placement="BottomEdgeAlignedRight">
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="title"
+                        CommandParameter="{x:Bind enums:SongSortOrder.Title}"
                         GroupName="SortOrder"
                         IsChecked="True"
-                        Tag="title"
+                        Tag="{x:Bind enums:SongSortOrder.Title}"
                         Text="{strings:Resources Key=PropertyTitle}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="album"
+                        CommandParameter="{x:Bind enums:SongSortOrder.Album}"
                         GroupName="SortOrder"
-                        Tag="album"
+                        Tag="{x:Bind enums:SongSortOrder.Album}"
                         Text="{strings:Resources Key=PropertyAlbum}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="artist"
+                        CommandParameter="{x:Bind enums:SongSortOrder.Artist}"
                         GroupName="SortOrder"
-                        Tag="artist"
+                        Tag="{x:Bind enums:SongSortOrder.Artist}"
                         Text="{strings:Resources Key=Artist}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="year"
+                        CommandParameter="{x:Bind enums:SongSortOrder.Year}"
                         GroupName="SortOrder"
-                        Tag="year"
+                        Tag="{x:Bind enums:SongSortOrder.Year}"
                         Text="{strings:Resources Key=ReleasedYear}" />
                     <muxc:RadioMenuFlyoutItem
                         Command="{x:Bind ViewModel.SetSortByCommand}"
-                        CommandParameter="dateAdded"
+                        CommandParameter="{x:Bind enums:SongSortOrder.DateAdded}"
                         GroupName="SortOrder"
-                        Tag="dateAdded"
+                        Tag="{x:Bind enums:SongSortOrder.DateAdded}"
                         Text="{strings:Resources Key=DateAdded}" />
                 </MenuFlyout>
             </muxc:DropDownButton.Flyout>
@@ -253,7 +254,7 @@
                         </ItemsPanelTemplate>
                     </GridView.ItemsPanel>
                     <interactivity:Interaction.Behaviors>
-                        <behaviors:GroupingOverviewBehavior GroupType="{x:Bind ViewModel.SortBy, Mode=OneWay}" />
+                        <behaviors:GroupingOverviewBehavior GroupType="{x:Bind ViewModel.SortBy.ToString(), Mode=OneWay}" />
                     </interactivity:Interaction.Behaviors>
                 </GridView>
             </SemanticZoom.ZoomedOutView>

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -42,7 +42,6 @@ public sealed partial class SongsPage : Page
         }
 
         UpdateSortVisualState(ViewModel.SortBy);
-        UpdateSortByFlyout();
         SavePageState(0);
     }
 
@@ -71,7 +70,6 @@ public sealed partial class SongsPage : Page
         }
 
         UpdateSortVisualState(ViewModel.SortBy);
-        UpdateSortByFlyout();
 
         if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchSongs))
         {
@@ -117,23 +115,23 @@ public sealed partial class SongsPage : Page
         Common.SavePageState(new KeyValuePair<SongSortOrder, double>(ViewModel.SortBy, verticalOffset), nameof(SongsPage), Frame.BackStackDepth);
     }
 
-    private string GetSortByText(SongSortOrder tag)
+    private bool IsSortBy(SongSortOrder current, SongSortOrder target) => current == target;
+
+    private string GetSortByText(SongSortOrder sortBy)
     {
-        var item = SortByFlyout.Items?.FirstOrDefault(x => x.Tag is SongSortOrder order && order == tag) ?? SortByFlyout.Items?.FirstOrDefault();
-        return (item as MenuFlyoutItem)?.Text ?? string.Empty;
+        return sortBy switch
+        {
+            SongSortOrder.Album => Strings.Resources.PropertyAlbum,
+            SongSortOrder.Artist => Strings.Resources.Artist,
+            SongSortOrder.Year => Strings.Resources.ReleasedYear,
+            SongSortOrder.DateAdded => Strings.Resources.DateAdded,
+            _ => Strings.Resources.PropertyTitle
+        };
     }
 
     private string GetSortByButtonAutomationName(SongSortOrder value)
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
-    }
-
-    private void UpdateSortByFlyout()
-    {
-        if (SortByFlyout.Items?.FirstOrDefault(x => x.Tag is SongSortOrder order && order == ViewModel.SortBy) is RadioMenuFlyoutItem radioItem)
-        {
-            radioItem.IsChecked = true;
-        }
     }
 }

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Controls;
+using Screenbox.Core.Enums;
 using Screenbox.Core.ViewModels;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -45,12 +46,12 @@ public sealed partial class SongsPage : Page
         SavePageState(0);
     }
 
-    private void UpdateSortVisualState(string sortBy)
+    private void UpdateSortVisualState(SongSortOrder sortBy)
     {
         var state = sortBy switch
         {
-            "album" => "SortByAlbum",
-            "artist" => "SortByArtist",
+            SongSortOrder.Album => "SortByAlbum",
+            SongSortOrder.Artist => "SortByArtist",
             _ => "SortByTitle"
         };
 
@@ -63,7 +64,7 @@ public sealed partial class SongsPage : Page
 
         if (e.NavigationMode == NavigationMode.Back
             && Common.TryGetPageState(nameof(SongsPage), Frame.BackStackDepth, out var state)
-            && state is KeyValuePair<string, double> pair)
+            && state is KeyValuePair<SongSortOrder, double> pair)
         {
             ViewModel.SortBy = pair.Key;
             _contentVerticalOffset = pair.Value;
@@ -113,16 +114,16 @@ public sealed partial class SongsPage : Page
 
     private void SavePageState(double verticalOffset)
     {
-        Common.SavePageState(new KeyValuePair<string, double>(ViewModel.SortBy, verticalOffset), nameof(SongsPage), Frame.BackStackDepth);
+        Common.SavePageState(new KeyValuePair<SongSortOrder, double>(ViewModel.SortBy, verticalOffset), nameof(SongsPage), Frame.BackStackDepth);
     }
 
-    private string GetSortByText(string tag)
+    private string GetSortByText(SongSortOrder tag)
     {
-        var item = SortByFlyout.Items?.FirstOrDefault(x => (x.Tag as string) == tag) ?? SortByFlyout.Items?.FirstOrDefault();
+        var item = SortByFlyout.Items?.FirstOrDefault(x => x.Tag is SongSortOrder order && order == tag) ?? SortByFlyout.Items?.FirstOrDefault();
         return (item as MenuFlyoutItem)?.Text ?? string.Empty;
     }
 
-    private string GetSortByButtonAutomationName(string value)
+    private string GetSortByButtonAutomationName(SongSortOrder value)
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
@@ -130,11 +131,9 @@ public sealed partial class SongsPage : Page
 
     private void UpdateSortByFlyout()
     {
-        if ((SortByFlyout.Items?.FirstOrDefault(x => (x.Tag as string) == ViewModel.SortBy) ?? SortByFlyout.Items?.FirstOrDefault()) is not RadioMenuFlyoutItem radioItem)
+        if (SortByFlyout.Items?.FirstOrDefault(x => x.Tag is SongSortOrder order && order == ViewModel.SortBy) is RadioMenuFlyoutItem radioItem)
         {
-            return;
+            radioItem.IsChecked = true;
         }
-
-        radioItem.IsChecked = true;
     }
 }

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -36,13 +36,20 @@ public sealed partial class SongsPage : Page
 
     private void ViewModelOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName != nameof(SongsPageViewModel.SortBy))
+        if (e.PropertyName == nameof(SongsPageViewModel.SortBy))
         {
-            return;
+            UpdateSortVisualState(ViewModel.SortBy);
+            SavePageState(0);
         }
-
-        UpdateSortVisualState(ViewModel.SortBy);
-        SavePageState(0);
+        else if (e.PropertyName == nameof(SongsPageViewModel.Genres))
+        {
+            UpdateGenreFlyoutItems();
+        }
+        else if (e.PropertyName == nameof(SongsPageViewModel.SelectedGenre))
+        {
+            UpdateGenreFlyoutSelection();
+            SavePageState(0);
+        }
     }
 
     private void UpdateSortVisualState(SongSortOrder sortBy)
@@ -62,11 +69,19 @@ public sealed partial class SongsPage : Page
         base.OnNavigatedTo(e);
 
         if (e.NavigationMode == NavigationMode.Back
-            && Common.TryGetPageState(nameof(SongsPage), Frame.BackStackDepth, out var state)
-            && state is KeyValuePair<SongSortOrder, double> pair)
+            && Common.TryGetPageState(nameof(SongsPage), Frame.BackStackDepth, out var state))
         {
-            ViewModel.SortBy = pair.Key;
-            _contentVerticalOffset = pair.Value;
+            if (state is PageState pageState)
+            {
+                ViewModel.SortBy = pageState.SortBy;
+                ViewModel.SelectedGenre = pageState.SelectedGenre;
+                _contentVerticalOffset = pageState.VerticalOffset;
+            }
+            else if (state is KeyValuePair<SongSortOrder, double> pair)
+            {
+                ViewModel.SortBy = pair.Key;
+                _contentVerticalOffset = pair.Value;
+            }
         }
 
         UpdateSortVisualState(ViewModel.SortBy);
@@ -76,6 +91,7 @@ public sealed partial class SongsPage : Page
             ViewModel.FetchSongs();
         }
 
+        UpdateGenreFlyoutItems();
         ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
     }
 
@@ -85,6 +101,57 @@ public sealed partial class SongsPage : Page
 
         ViewModel.OnNavigatedFrom();
         ViewModel.PropertyChanged -= ViewModelOnPropertyChanged;
+    }
+
+    private void UpdateGenreFlyoutItems()
+    {
+        GenreFlyout.Items.Clear();
+
+        var allGenresItem = new RadioMenuFlyoutItem
+        {
+            Text = Strings.Resources.AllGenres,
+            GroupName = "GenreFilter",
+            IsChecked = ViewModel.SelectedGenre is null,
+            Command = ViewModel.SetGenreCommand,
+            CommandParameter = null
+        };
+        GenreFlyout.Items.Add(allGenresItem);
+
+        var unknownGenreItem = new RadioMenuFlyoutItem
+        {
+            Text = Strings.Resources.UnknownGenre,
+            GroupName = "GenreFilter",
+            IsChecked = ViewModel.SelectedGenre == string.Empty,
+            Command = ViewModel.SetGenreCommand,
+            CommandParameter = string.Empty
+        };
+        GenreFlyout.Items.Add(unknownGenreItem);
+
+        foreach (string genre in ViewModel.Genres)
+        {
+            var genreItem = new RadioMenuFlyoutItem
+            {
+                Text = genre,
+                GroupName = "GenreFilter",
+                IsChecked = ViewModel.SelectedGenre == genre,
+                Command = ViewModel.SetGenreCommand,
+                CommandParameter = genre
+            };
+            GenreFlyout.Items.Add(genreItem);
+        }
+    }
+
+    private void UpdateGenreFlyoutSelection()
+    {
+        foreach (var item in GenreFlyout.Items.OfType<RadioMenuFlyoutItem>())
+        {
+            item.IsChecked = item.CommandParameter switch
+            {
+                null => ViewModel.SelectedGenre is null,
+                string param => param == ViewModel.SelectedGenre,
+                _ => false
+            };
+        }
     }
 
     private void SongListView_OnLoaded(object sender, RoutedEventArgs e)
@@ -110,9 +177,11 @@ public sealed partial class SongsPage : Page
         SavePageState(e.NextView.VerticalOffset);
     }
 
+    private record PageState(SongSortOrder SortBy, string? SelectedGenre, double VerticalOffset);
+
     private void SavePageState(double verticalOffset)
     {
-        Common.SavePageState(new KeyValuePair<SongSortOrder, double>(ViewModel.SortBy, verticalOffset), nameof(SongsPage), Frame.BackStackDepth);
+        Common.SavePageState(new PageState(ViewModel.SortBy, ViewModel.SelectedGenre, verticalOffset), nameof(SongsPage), Frame.BackStackDepth);
     }
 
     private bool IsSortBy(SongSortOrder current, SongSortOrder target) => current == target;
@@ -133,5 +202,21 @@ public sealed partial class SongsPage : Page
     {
         var optionText = GetSortByText(value);
         return Strings.Resources.SortByAutomationName(optionText);
+    }
+
+    private string GetGenreText(string? genre)
+    {
+        return genre switch
+        {
+            null => Strings.Resources.AllGenres,
+            "" => Strings.Resources.UnknownGenre,
+            _ => genre
+        };
+    }
+
+    private string GetGenreButtonAutomationName(string? genre)
+    {
+        var optionText = GetGenreText(genre);
+        return Strings.Resources.FilterByGenreAutomationName(optionText);
     }
 }

--- a/Screenbox/Pages/SongsPage.xaml.cs
+++ b/Screenbox/Pages/SongsPage.xaml.cs
@@ -40,7 +40,14 @@ public sealed partial class SongsPage : Page
             return;
         }
 
-        var state = ViewModel.SortBy switch
+        UpdateSortVisualState(ViewModel.SortBy);
+        UpdateSortByFlyout();
+        SavePageState(0);
+    }
+
+    private void UpdateSortVisualState(string sortBy)
+    {
+        var state = sortBy switch
         {
             "album" => "SortByAlbum",
             "artist" => "SortByArtist",
@@ -48,8 +55,6 @@ public sealed partial class SongsPage : Page
         };
 
         VisualStateManager.GoToState(this, state, true);
-        UpdateSortByFlyout();
-        SavePageState(0);
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -63,6 +68,9 @@ public sealed partial class SongsPage : Page
             ViewModel.SortBy = pair.Key;
             _contentVerticalOffset = pair.Value;
         }
+
+        UpdateSortVisualState(ViewModel.SortBy);
+        UpdateSortByFlyout();
 
         if (!_dispatcherQueue.TryEnqueue(ViewModel.FetchSongs))
         {

--- a/Screenbox/Strings/en-US/KeyboardResources.resw
+++ b/Screenbox/Strings/en-US/KeyboardResources.resw
@@ -433,6 +433,10 @@
     <value>CS</value>
     <comment>{Range="A-Z"}{Limit=2}Access key for sorting options. For the initial key, avoid collision with any other Player or the first Navigation and TopNavigation key. The second key must be unique with respect to every other Command key in this file.</comment>
   </data>
+  <data name="CommandFilterByGenreKey" xml:space="preserve">
+    <value>CG</value>
+    <comment>{Range="A-Z"}{Limit=2}Access key for filtering by genre options. For the initial key, avoid collision with any other Player or the first Navigation and TopNavigation key. The second key must be unique with respect to every other Command key in this file.</comment>
+  </data>
   <data name="CommandPlayKey" xml:space="preserve">
     <value>CP</value>
     <comment>{Range="A-Z"}{Limit=2}Access key for playing. For the initial key, avoid collision with any other Player or the first Navigation and TopNavigation key. The second key must be unique with respect to every other Command key in this file.</comment>

--- a/Screenbox/Strings/en-US/Resources.resw
+++ b/Screenbox/Strings/en-US/Resources.resw
@@ -318,6 +318,9 @@
   <data name="UnknownGenre" xml:space="preserve">
     <value>Unknown genre</value>
   </data>
+  <data name="AllGenres" xml:space="preserve">
+    <value>All genres</value>
+  </data>
   <data name="AddFolder" xml:space="preserve">
     <value>Add folder</value>
   </data>
@@ -868,6 +871,10 @@
   <data name="SortByAutomationName" xml:space="preserve">
     <value>Sort by {0} option selected</value>
     <comment>#Format[String sortBy]</comment>
+  </data>
+  <data name="FilterByGenreAutomationName" xml:space="preserve">
+    <value>Filter by {0} option selected</value>
+    <comment>#Format[String genre]</comment>
   </data>
   <data name="Artist" xml:space="preserve">
     <value>Artist</value>


### PR DESCRIPTION
Resolves #698

### Context
Users with large music collections need a way to filter songs and albums by genre directly in the library views. Unlike static sorting options, genres vary depending on the files present in the user's library and must be dynamically extracted.

### Motivation
Providing a genre dropdown alongside the existing sort-by controls enables users to quickly narrow down their library views by specific music genres, view tracks with missing genre metadata ("Unknown genre"), or view all items ("All genres").

### Impact & Changes
- **Library Models & Services**:
  - `MusicLibrary`: Added read-only `Genres` property to the immutable music library snapshot.
  - `LibraryService`: Added `ExtractGenres` to automatically extract, deduplicate, and sort unique non-empty genre strings from library songs when building `MusicLibrary` snapshots.
- **ViewModels**:
  - `SongsPageViewModel` & `AlbumsPageViewModel`: Added `SelectedGenre`, `Genres`, and `SetGenreCommand`. Filter `Songs` and `GroupedSongs` / `GroupedAlbums` dynamically based on selected genre.
- **UI & Performance**:
  - Added `GenreButton` dropdown next to `SortByButton` in `SongsPage.xaml` and `AlbumsPage.xaml`.
  - Populated `RadioMenuFlyoutItem` elements as soon as the genre list is available (during page navigation and library updates) to ensure instantaneous flyout opening.
  - Preserved `SelectedGenre` state across backward navigation.
- **Localization & Accessibility**:
  - Added ReswPlus resources for `AllGenres`, `FilterByGenreAutomationName`, and access key `CommandFilterByGenreKey`.
- **Tests**:
  - Added unit test coverage for genre extraction, filtering, and commands in `SongsPageViewModelTests` and `AlbumsPageViewModelTests`.
