### PR TITLE
refactor(videoview): migrate from Silk.NET to Vortice.Windows

### DIFF
--- a/Screenbox.VideoView/Screenbox.VideoView.csproj
+++ b/Screenbox.VideoView/Screenbox.VideoView.csproj
@@ -15,6 +15,6 @@
   <ItemGroup>
     <PackageReference Include="LibVLCSharp.UWP" Version="3.10.1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
-    <PackageReference Include="Silk.NET.Direct3D11" Version="2.23.0" />
+    <PackageReference Include="Vortice.Direct3D11" Version="3.8.3" />
   </ItemGroup>
 </Project>

--- a/Screenbox.VideoView/SwapChainPanelExtensions.cs
+++ b/Screenbox.VideoView/SwapChainPanelExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using Silk.NET.Core.Native;
 using Windows.UI.Xaml.Controls;
 
 namespace Screenbox.Controls;
@@ -10,22 +9,26 @@ namespace Screenbox.Controls;
 [Guid("f92f19d2-3ade-45a6-a20c-f6f1ea90554b")]
 internal partial interface ISwapChainPanelNative
 {
-    unsafe void SetSwapChain(IUnknown* swapChain);
+    void SetSwapChain(IntPtr swapChain);
 }
 
 internal static class SwapChainPanelExtensions
 {
-    internal static unsafe void SetSwapChain(this SwapChainPanel panel, IUnknown* swapChain)
+    internal static void SetSwapChain(this SwapChainPanel panel, IntPtr swapChain)
     {
-        if (panel == null) throw new ArgumentNullException(nameof(panel));
+        ArgumentNullException.ThrowIfNull(panel);
 
         var winrtObj = panel as WinRT.IWinRTObject;
-        if (winrtObj?.NativeObject == null)
+        if (winrtObj?.NativeObject is null)
+        {
             throw new ObjectDisposedException(nameof(panel), "The underlying WinRT native object has been disposed.");
+        }
 
         IntPtr nativePtr = winrtObj.NativeObject.ThisPtr;
         if (nativePtr == IntPtr.Zero)
+        {
             throw new ObjectDisposedException(nameof(panel), "The underlying WinRT native pointer is null.");
+        }
 
         ComWrappers cw = new StrategyBasedComWrappers();
         var panelNative = (ISwapChainPanelNative)cw.GetOrCreateObjectForComInstance(nativePtr, CreateObjectFlags.None);

--- a/Screenbox.VideoView/VideoView.cs
+++ b/Screenbox.VideoView/VideoView.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Numerics;
 using LibVLCSharp.Shared;
-using Silk.NET.Core.Contexts;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using Silk.NET.DXGI;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -12,17 +12,15 @@ namespace Screenbox.Controls;
 public sealed class VideoViewInitializedEventArgs : EventArgs
 {
     public string[] SwapChainOptions { get; }
+
     public VideoViewInitializedEventArgs(string[] swapChainOptions) => SwapChainOptions = swapChainOptions;
 }
 
-public unsafe partial class VideoView : SwapChainPanel
+public partial class VideoView : SwapChainPanel
 {
-    private D3D11 _d3d11;
-    private DXGI _dxgi;
-
-    private ComPtr<ID3D11Device> _d3d11Device;
-    private ComPtr<ID3D11DeviceContext> _d3d11Context;
-    private ComPtr<IDXGISwapChain1> _swapChain;
+    private ID3D11Device? _d3d11Device;
+    private ID3D11DeviceContext? _d3d11Context;
+    private IDXGISwapChain1? _swapChain;
 
     private bool _loaded;
     private static readonly Guid SWAPCHAIN_WIDTH = new("f1b59347-1643-411a-ad6b-c780177a06b6");
@@ -41,85 +39,81 @@ public unsafe partial class VideoView : SwapChainPanel
 
     public VideoView()
     {
-        _d3d11 = new D3D11(new DefaultNativeContext("d3d11"));
-        _dxgi = new DXGI(new DefaultNativeContext("dxgi"));
-
         SizeChanged += (s, e) =>
         {
-            if (_loaded) UpdateSize();
-            else CreateSwapChain();
+            if (_loaded)
+            {
+                UpdateSize();
+            }
+            else
+            {
+                CreateSwapChain();
+            }
         };
         CompositionScaleChanged += (s, e) =>
         {
-            if (_loaded) UpdateScale();
+            if (_loaded)
+            {
+                UpdateScale();
+            }
         };
         Unloaded += (s, e) => DestroySwapChain();
     }
 
     private void CreateSwapChain()
     {
-        if (ActualHeight == 0 || ActualWidth == 0) return;
+        if (ActualHeight == 0 || ActualWidth == 0)
+        {
+            return;
+        }
 
         DestroySwapChain();
 
-        // 1. Create D3D11 Device and Context (pass null to use default feature levels)
-        _d3d11.CreateDevice(
-            default(ComPtr<IDXGIAdapter>),
-            D3DDriverType.Hardware,
-            IntPtr.Zero,
-            (uint)CreateDeviceFlag.BgraSupport,
+        // 1. Create D3D11 Device and Context
+        D3D11.D3D11CreateDevice(
             null,
-            0,
-            D3D11.SdkVersion,
-            ref _d3d11Device,
-            null,
-            ref _d3d11Context
-        );
+            DriverType.Hardware,
+            DeviceCreationFlags.BgraSupport,
+            null!,
+            out _d3d11Device,
+            out _d3d11Context
+        ).CheckError();
+
+        if (_d3d11Device is null || _d3d11Context is null)
+        {
+            return;
+        }
 
         // 2. Query DXGI Factory from D3D11 Device
         using var dxgiDevice = _d3d11Device.QueryInterface<IDXGIDevice1>();
-        ComPtr<IDXGIAdapter> dxgiAdapter = default;
-        try
+        dxgiDevice.GetAdapter(out IDXGIAdapter adapter);
+        using (adapter)
         {
-            dxgiDevice.GetAdapter(ref dxgiAdapter);
-            using var dxgiAdapter1 = dxgiAdapter.QueryInterface<IDXGIAdapter1>();
-            using var dxgiFactory = dxgiAdapter1.GetParent<IDXGIFactory2>();
+            using var dxgiFactory = adapter.GetParent<IDXGIFactory2>();
 
             // 3. Define Swap Chain Description
-            SwapChainDesc1 scd = new()
+            SwapChainDescription1 scd = new()
             {
                 Width = (uint)(ActualWidth * CompositionScaleX),
                 Height = (uint)(ActualHeight * CompositionScaleY),
-                Format = Format.FormatB8G8R8A8Unorm,
+                Format = Format.B8G8R8A8_UNorm,
                 Stereo = false,
-                SampleDesc = new SampleDesc(1, 0),
-                BufferUsage = DXGI.UsageRenderTargetOutput,
+                SampleDescription = new SampleDescription(1, 0),
+                BufferUsage = Usage.RenderTargetOutput,
                 BufferCount = 2,
                 SwapEffect = SwapEffect.FlipSequential,
                 Scaling = Scaling.Stretch,
                 AlphaMode = AlphaMode.Unspecified
             };
 
-            // 4. Create Swap Chain for Composition (using Handle to bypass extension method ambiguities)
-            IDXGISwapChain1* swapChainPtr = null;
-            int hr = dxgiFactory.Handle->CreateSwapChainForComposition(
-                (IUnknown*)_d3d11Device.Handle,
-                &scd,
-                null,
-                &swapChainPtr
-            );
-            SilkMarshal.ThrowHResult(hr);
-            _swapChain = new ComPtr<IDXGISwapChain1>(swapChainPtr);
-        }
-        finally
-        {
-            dxgiAdapter.Dispose();
+            // 4. Create Swap Chain for Composition
+            _swapChain = dxgiFactory.CreateSwapChainForComposition(_d3d11Device, scd);
         }
 
-        dxgiDevice.SetMaximumFrameLatency(1);
+        dxgiDevice.MaximumFrameLatency = 1;
 
         // 5. Set Swap Chain on SwapChainPanel
-        this.SetSwapChain((IUnknown*)_swapChain.Handle);
+        this.SetSwapChain(_swapChain.NativePointer);
 
         _loaded = true;
         UpdateScale();
@@ -128,40 +122,43 @@ public unsafe partial class VideoView : SwapChainPanel
         // Expose SwapChain options for LibVLC
         var options = new[]
         {
-            $"--winrt-d3dcontext=0x{(IntPtr)_d3d11Context.Handle:x}",
-            $"--winrt-swapchain=0x{(IntPtr)_swapChain.Handle:x}"
+            $"--winrt-d3dcontext=0x{_d3d11Context.NativePointer:x}",
+            $"--winrt-swapchain=0x{_swapChain.NativePointer:x}"
         };
 
         Initialized?.Invoke(this, new VideoViewInitializedEventArgs(options));
     }
 
-    private void UpdateSize()
+    private unsafe void UpdateSize()
     {
-        if (!_loaded || _swapChain.Handle == null) return;
+        if (!_loaded || _swapChain is null)
+        {
+            return;
+        }
 
         int w = (int)(ActualWidth * CompositionScaleX);
         int h = (int)(ActualHeight * CompositionScaleY);
 
-        Guid widthGuid = SWAPCHAIN_WIDTH;
-        Guid heightGuid = SWAPCHAIN_HEIGHT;
-
-        _swapChain.SetPrivateData(&widthGuid, sizeof(int), &w);
-        _swapChain.SetPrivateData(&heightGuid, sizeof(int), &h);
+        _swapChain.SetPrivateData(SWAPCHAIN_WIDTH, sizeof(int), new IntPtr(&w));
+        _swapChain.SetPrivateData(SWAPCHAIN_HEIGHT, sizeof(int), new IntPtr(&h));
     }
 
     private void UpdateScale()
     {
-        if (!_loaded || _swapChain.Handle == null) return;
+        if (!_loaded || _swapChain is null)
+        {
+            return;
+        }
 
         using var swapChain2 = _swapChain.QueryInterface<IDXGISwapChain2>();
-        if (swapChain2.Handle != null)
+        if (swapChain2 is not null)
         {
-            var matrix = new Matrix3X2F(
-                1.0f / CompositionScaleX, 0.0f,
-                0.0f, 1.0f / CompositionScaleY,
+            var matrix = new Matrix3x2(
+                1.0f / (float)CompositionScaleX, 0.0f,
+                0.0f, 1.0f / (float)CompositionScaleY,
                 0.0f, 0.0f
             );
-            swapChain2.Handle->SetMatrixTransform(&matrix);
+            swapChain2.MatrixTransform = matrix;
         }
     }
 
@@ -171,7 +168,7 @@ public unsafe partial class VideoView : SwapChainPanel
         {
             try
             {
-                this.SetSwapChain(null);
+                this.SetSwapChain(IntPtr.Zero);
             }
             catch (ObjectDisposedException)
             {
@@ -179,9 +176,13 @@ public unsafe partial class VideoView : SwapChainPanel
             }
         }
 
-        _swapChain.Dispose();
-        _d3d11Context.Dispose();
-        _d3d11Device.Dispose();
+        _swapChain?.Dispose();
+        _d3d11Context?.Dispose();
+        _d3d11Device?.Dispose();
+
+        _swapChain = null;
+        _d3d11Context = null;
+        _d3d11Device = null;
         _loaded = false;
     }
 }


### PR DESCRIPTION
## Context & Motivation
The `Screenbox.VideoView` library previously utilized `Silk.NET.Direct3D11` for Direct3D 11 and DXGI swap chain initialization. In Native AOT compilation scenarios, Silk.NET's large auto-generated bindings and reflection-heavy abstractions introduce significant binary size overhead and require manual `ComPtr<T>` lifetime management and unsafe pointer manipulation.

To eliminate this binary bloat while improving code maintainability, this PR migrates `Screenbox.VideoView` to `Vortice.Windows` (`Vortice.Direct3D11` v3.8.3).

## Changes & Impact
- **Dependency Migration**: Replaced `Silk.NET.Direct3D11` package reference with `Vortice.Direct3D11` (v3.8.3) in `Screenbox.VideoView.csproj`.
- **Managed COM Interop**: Replaced manual `ComPtr<ID3D11Device>`, `ComPtr<ID3D11DeviceContext>`, and `ComPtr<IDXGISwapChain1>` handling with Vortice's strongly-typed managed COM wrappers implementing standard `IDisposable`.
- **Safe Interop Pipeline**: Updated `SwapChainPanelExtensions` to accept native `IntPtr` values instead of raw unmanaged `IUnknown*` pointers, removing unsafe blocks from the COM interface declaration.
- **Modern .NET Integration**: Switched matrix transformations to standard `System.Numerics.Matrix3x2`.

## Verification
- Successfully built `Screenbox.VideoView` with zero warnings and zero errors.
- Built main `Screenbox` UWP app with MSBuild.
- Executed unit tests in `Screenbox.Core.Tests` (17/17 passed).