### PR TITLE
chore: add license headers to UI library project

### DIFF
--- a/Screenbox.UI/.editorconfig
+++ b/Screenbox.UI/.editorconfig
@@ -1,0 +1,15 @@
+# Not the root‑level .editorconfig file in the hierarchy
+root = false
+
+# C# files
+[*.cs]
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+file_header_template = Copyright (c) Tung Huynh and Contributors. All rights reserved.\nLicensed under the MIT License. See License.txt in the project root for license information.
+
+#### Diagnostic configuration ####
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = suggestion

--- a/Screenbox.UI/Automation/Peers/ContentUnavailableViewAutomationPeer.cs
+++ b/Screenbox.UI/Automation/Peers/ContentUnavailableViewAutomationPeer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Screenbox.UI.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;

--- a/Screenbox.UI/Automation/Peers/TitleBarAutomationPeer.cs
+++ b/Screenbox.UI/Automation/Peers/TitleBarAutomationPeer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Screenbox.UI.Controls;
 using Windows.ApplicationModel;
 using Windows.UI.Xaml.Automation.Peers;

--- a/Screenbox.UI/Controls/CommandBarEx/CommandBarEx.cs
+++ b/Screenbox.UI/Controls/CommandBarEx/CommandBarEx.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 

--- a/Screenbox.UI/Controls/CommonStyles/SplitButton_themeresources.xaml
+++ b/Screenbox.UI/Controls/CommonStyles/SplitButton_themeresources.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/CommonStyles/Thickness_themeresources.xaml
+++ b/Screenbox.UI/Controls/CommonStyles/Thickness_themeresources.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.Properties.cs
+++ b/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.Properties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Windows.UI.Xaml;
 
 namespace Screenbox.UI.Controls;

--- a/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.cs
+++ b/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Screenbox.UI.Automation.Peers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;

--- a/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.xaml
+++ b/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView_themeresources.xaml
+++ b/Screenbox.UI/Controls/ContentUnavailableView/ContentUnavailableView_themeresources.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/NavigationViewEx/NavigationViewEx.Properties.cs
+++ b/Screenbox.UI/Controls/NavigationViewEx/NavigationViewEx.Properties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/Screenbox.UI/Controls/NavigationViewEx/NavigationViewEx.cs
+++ b/Screenbox.UI/Controls/NavigationViewEx/NavigationViewEx.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Screenbox.UI/Controls/Primitives/ThicknessFilterKinds.cs
+++ b/Screenbox.UI/Controls/Primitives/ThicknessFilterKinds.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 
 namespace Screenbox.UI.Controls.Primitives;

--- a/Screenbox.UI/Controls/Primitives/ThicknessFiltersConverter.cs
+++ b/Screenbox.UI/Controls/Primitives/ThicknessFiltersConverter.cs
@@ -1,5 +1,7 @@
-// Inspired by:
-// https://github.com/microsoft/microsoft-ui-xaml/pull/6829
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// Inspired by https://github.com/microsoft/microsoft-ui-xaml/pull/6829
+// Original source is Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
 
 using System;
 using Windows.UI.Xaml;

--- a/Screenbox.UI/Controls/SplitButtonEx/SplitButtonEx.Properties.cs
+++ b/Screenbox.UI/Controls/SplitButtonEx/SplitButtonEx.Properties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Windows.UI.Xaml;
 
 namespace Screenbox.UI.Controls;

--- a/Screenbox.UI/Controls/SplitButtonEx/SplitButtonEx.cs
+++ b/Screenbox.UI/Controls/SplitButtonEx/SplitButtonEx.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;

--- a/Screenbox.UI/Controls/TitleBar/TitleBar.Properties.cs
+++ b/Screenbox.UI/Controls/TitleBar/TitleBar.Properties.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;

--- a/Screenbox.UI/Controls/TitleBar/TitleBar.cs
+++ b/Screenbox.UI/Controls/TitleBar/TitleBar.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using Screenbox.UI.Automation.Peers;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;

--- a/Screenbox.UI/Controls/TitleBar/TitleBar.xaml
+++ b/Screenbox.UI/Controls/TitleBar/TitleBar.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/TitleBar/TitleBarHeightMode.cs
+++ b/Screenbox.UI/Controls/TitleBar/TitleBarHeightMode.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 namespace Screenbox.UI.Controls;
 
 /// <summary>

--- a/Screenbox.UI/Controls/TitleBar/TitleBar_themeresources.xaml
+++ b/Screenbox.UI/Controls/TitleBar/TitleBar_themeresources.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Screenbox.UI/Controls/XamlControlsResources.xaml
+++ b/Screenbox.UI/Controls/XamlControlsResources.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     x:Class="Screenbox.UI.Controls.XamlControlsResources"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/Screenbox.UI/Controls/XamlControlsResources.xaml.cs
+++ b/Screenbox.UI/Controls/XamlControlsResources.xaml.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Tung Huynh and Contributors. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 namespace Screenbox.UI.Controls;
 
 public sealed partial class XamlControlsResources

--- a/Screenbox.UI/Themes/Generic.xaml
+++ b/Screenbox.UI/Themes/Generic.xaml
@@ -1,3 +1,4 @@
+<!--  Copyright (c) Tung Huynh and Contributors. All rights reserved. Licensed under the MIT License. See License.txt in the project root for license information.  -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"


### PR DESCRIPTION
Add project-level `.editorconfig` and standard MIT license headers across `Screenbox UI` C# and XAML files.