### PR TITLE
chore: update VS 2026 references in docs and enforce MSBuild for AI agents

### DIFF
--- a/.agents/skills/build-and-test/SKILL.md
+++ b/.agents/skills/build-and-test/SKILL.md
@@ -14,7 +14,17 @@ Follow these structured procedures when restoring, compiling, testing, or valida
 
 ## 1. Prerequisites & Package Restore
 
-Ensure local dotnet tools and NuGet packages are restored before building:
+Ensure local dotnet tools and NuGet packages are restored before building.
+
+> [!IMPORTANT]
+> **Always use MSBuild from Visual Studio 2026 (version 18)** for compiling and restoring projects in this repository. **NEVER use `dotnet build`**, as UWP and CsWinRT tooling require Visual Studio 2026 MSBuild.
+
+### Locate Visual Studio 2026 MSBuild
+You can locate MSBuild using `vswhere` or standard installation path:
+```pwsh
+$msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version "[18.0,19.0)" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+if (-not $msbuild) { $msbuild = "C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe" }
+```
 
 ### Restore Dotnet Tools (XAML Styler & LottieGen)
 ```pwsh
@@ -24,12 +34,12 @@ dotnet tool restore
 ### Restore NuGet Packages
 For the full solution:
 ```pwsh
-msbuild Screenbox.slnx -t:restore -p:Platform=x64 -p:Configuration=Debug
+& $msbuild Screenbox.slnx -t:restore -p:Platform=x64 -p:Configuration=Debug
 ```
 
 Or restore the main UWP app project individually:
 ```pwsh
-msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Restore /m
+& $msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Restore /m
 ```
 
 ---
@@ -38,7 +48,12 @@ msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Res
 
 Target the system platform for local development. For example, to build the main UWP app in Debug mode on the `x64` platform:
 ```pwsh
-msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+& $msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
+```
+
+Or build `Screenbox.Core`:
+```pwsh
+& $msbuild Screenbox.Core/Screenbox.Core.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
 ```
 
 ---
@@ -47,7 +62,7 @@ msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Bui
 
 ### Run Full Test Suite
 ```pwsh
-dotnet test Screenbox.Core.Tests/Screenbox.Core.Tests.csproj -v minimal
+dotnet run --project Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
 ```
 
 ### Testing Rules & Constraints

--- a/.agents/skills/generate-assets/SKILL.md
+++ b/.agents/skills/generate-assets/SKILL.md
@@ -57,7 +57,7 @@ When animation JSON files in `assets/animations/` are added or modified:
 2. **Generated Output Location**:
    - `Screenbox/Assets/Animations/*.cs` (e.g., `AnimatedPlayingVisualSource.cs`)
 3. **Verification**:
-   - Build `Screenbox` to ensure generated C# classes compile cleanly:
+   - Build `Screenbox` using MSBuild from Visual Studio 2026 to ensure generated C# classes compile cleanly:
      ```pwsh
      msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m
      ```

--- a/.agents/skills/github-workflow/SKILL.md
+++ b/.agents/skills/github-workflow/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: github-workflow
+description: >-
+  Procedures and guidelines for Git operations and GitHub CLI (`gh`) commands,
+  including branch management, commit messages, and creating pull requests or issues.
+---
+
+# GitHub CLI & Git Workflow Runbook
+
+Follow these structured procedures and guidelines when working with Git branches, commits, pull requests, and GitHub CLI (`gh`) commands.
+
+---
+
+## 1. GitHub CLI (`gh`) Guidelines for Windows
+
+> [!IMPORTANT]
+> **Always use `--body-file` (or `-F`) when passing markdown bodies to `gh` CLI commands on Windows.**
+> Never use inline strings (`--body` or `-b`) for multiline markdown, PR descriptions, issue bodies, or release notes. PowerShell and Windows CMD shell quoting frequently cause broken newlines, mangled quotes, and unwanted character escapes.
+
+### Creating a Pull Request with `gh pr create`
+
+1. **Write the PR description to a file** (e.g., in a temporary or scratch directory):
+   ```pwsh
+   # Example: write PR body to a temp markdown file
+   @'
+   ## Context & Motivation
+   Brief description of the problem, background, and why this change was made.
+
+   ## Key Changes & Impact
+   - Key change 1
+   - Key change 2
+
+   ## Testing & Verification
+   - Ran automated tests via `dotnet run`
+   - Verified build with Visual Studio 2026 MSBuild
+   '@ | Set-Content -Path ./pr_body.md -Encoding utf8
+   ```
+
+2. **Execute `gh pr create` using `--body-file`**:
+   ```pwsh
+   gh pr create --title "feat: descriptive title" --body-file ./pr_body.md --base main
+   ```
+
+3. **Clean up the temporary file**:
+   ```pwsh
+   Remove-Item -Path ./pr_body.md -ErrorAction SilentlyContinue
+   ```
+
+### Creating or Editing Issues with `gh`
+Similarly, always write issue bodies to a file and supply `--body-file`:
+```pwsh
+gh issue create --title "bug: descriptive title" --body-file ./issue_body.md
+```
+
+---
+
+## 2. Commit Message & PR Title Conventions
+
+- Use the [Conventional Commits](https://www.conventionalcommits.org/) standard.
+- Format: `<type>(<optional-scope>): <short summary>`
+  - `feat`: A new feature
+  - `fix`: A bug fix
+  - `docs`: Documentation changes only
+  - `refactor`: Code changes that neither fix a bug nor add a feature
+  - `perf`: Performance improvements
+  - `test`: Adding or correcting tests
+  - `chore`: Maintenance tasks, dependency updates, build tooling
+- PR titles must follow conventional commit naming.
+- PR descriptions must include **Context**, **Motivation**, and **Impact**, referencing any related issues (`Fixes #123`, `Resolves #456`).
+
+---
+
+## 3. Branching & Push Workflow
+
+1. Ensure changes are committed with conventional messages.
+2. Push branch to remote:
+   ```pwsh
+   git push -u origin <branch-name>
+   ```
+3. Open pull request using `gh pr create --body-file <path>`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 - Use conventional prefixes for pull request titles to summarize changes effectively.
 - Reference relevant issues or user stories in the pull requests.
 - When describing changes, include the context, motivation, and impact of the changes. Do not just list the changes made.
+- **GitHub CLI (`gh`) on Windows**: When creating or updating pull requests, issues, or releases via `gh` CLI, **always pass `--body-file` (or `-F`)** pointing to a markdown file instead of inline `--body` / `-b`. Inline markdown strings in Windows shells frequently suffer from broken quoting, mangled newlines, and character escape artifacts.
 
 ## Build and test
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,11 +7,13 @@
 
 ## Build and test
 
+- **Always use MSBuild from Visual Studio 2026 (version 18)** for restoring and compiling projects. **NEVER use `dotnet build`**, as UWP and WinRT tooling requires Visual Studio 2026 MSBuild.
+- MSBuild can be located via `vswhere` (`& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version "[18.0,19.0)" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) or standard path (`"C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe"`).
+- Restore the solution: `msbuild Screenbox.slnx -t:restore -p:Platform=x64 -p:Configuration=Debug`
 - Build `Screenbox.Core`: `msbuild Screenbox.Core/Screenbox.Core.csproj /t:Build /p:Configuration=Debug /p:Platform=x64 /m`
 - Restore the app project before building it if needed: `msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Restore /m`
 - Build the app project: `msbuild Screenbox/Screenbox.csproj /p:Configuration=Debug /p:Platform=x64 /t:Build /m`
-- Run the full automated test suite currently in the repo: `dotnet test Screenbox.Core.Tests/Screenbox.Core.Tests.csproj -v minimal`
-- Run DatabaseService-focused tests: `dotnet test Screenbox.Core.Tests/Screenbox.Core.Tests.csproj --filter "FullyQualifiedName~DatabaseServiceTests" -v n`
+- Run the full automated test suite: `dotnet run --project Screenbox.Core.Tests/Screenbox.Core.Tests.csproj`
 
 ## Persistence boundaries
 

--- a/.github/instructions/dotnet-uwp.instructions.md
+++ b/.github/instructions/dotnet-uwp.instructions.md
@@ -12,6 +12,7 @@ applyTo: '**/*.cs'
 
 ## General Instructions
 
+- Always use MSBuild from Visual Studio 2026 (version 18) to restore and compile projects; never use `dotnet build`.
 - Make only high confidence suggestions when reviewing code changes.
 - Write code with good maintainability practices, including comments on why certain design decisions were made.
 - Handle edge cases and write clear exception handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository maintains its canonical AI agent instructions and coding guideli
 ## 📋 General Guidelines & Workflows
 
 Refer to [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for:
-- **Git & PR Workflows**: Conventional Commits standard, PR title conventions, issue linking, and descriptive change summaries (context, motivation, impact).
+- **Git & PR Workflows**: Conventional Commits standard, PR title conventions, issue linking, descriptive change summaries (context, motivation, impact), and mandatory `--body-file` usage for GitHub CLI (`gh`) commands on Windows.
 - **Build & Test Workflows**: MSBuild commands (Visual Studio 2026 / version 18) for `Screenbox` and `Screenbox.Core` (never `dotnet build`), and `dotnet run` for running `Screenbox.Core.Tests`.
 - **Persistence Boundaries**: Ephemeral SQLite cache data (`library_folders`, `media_records`, `playback_progress`) vs. durable user data (`playlists`, `playlist_items`), and per-table database recovery rules.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository maintains its canonical AI agent instructions and coding guideli
 
 Refer to [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for:
 - **Git & PR Workflows**: Conventional Commits standard, PR title conventions, issue linking, and descriptive change summaries (context, motivation, impact).
-- **Build & Test Workflows**: MSBuild commands for `Screenbox` and `Screenbox.Core`, and `dotnet test` commands with `DatabaseServiceTests` filtering.
+- **Build & Test Workflows**: MSBuild commands (Visual Studio 2026 / version 18) for `Screenbox` and `Screenbox.Core` (never `dotnet build`), and `dotnet run` for running `Screenbox.Core.Tests`.
 - **Persistence Boundaries**: Ephemeral SQLite cache data (`library_folders`, `media_records`, `playback_progress`) vs. durable user data (`playlists`, `playlist_items`), and per-table database recovery rules.
 
 ## 💻 C# and .NET 9+ Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to Screenbox! This guide will help y
 
 Before you begin, ensure you have the following installed:
 
-- **Visual Studio 2022** (Community, Professional, or Enterprise) or later
+- **Visual Studio 2026** (Community, Professional, or Enterprise) or later
   - Required workloads:
     - **WinUI application development**
   - Required optional components:
@@ -55,7 +55,7 @@ Before you begin, ensure you have the following installed:
 
 ### 2. Open and Build the Solution
 
-1. **Open the solution** in Visual Studio: `Screenbox.sln`
+1. **Open the solution** in Visual Studio: `Screenbox.slnx`
 2. **Set the platform** to match your machine's architecture (typically x64)
 3. **Build the solution** to restore NuGet packages: `F6`
 4. **Start debugging**: `F5`
@@ -67,7 +67,7 @@ Visual Studio's built-in Git integration should be sufficient for most developme
 The solution contains two main projects:
 
 ```
-Screenbox.sln
+Screenbox.slnx
 ├── Screenbox/           # Main UWP application (UI layer)
 └── Screenbox.Core/      # Core business logic library
 ```

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Feel free to open an issue if you want to report a bug, give feedback, or ask a 
 
 ### Quick Start for Developers
 
-1. **Prerequisites**: Visual Studio 2022 with UWP development workload
+1. **Prerequisites**: Visual Studio 2026 with UWP development workload
 2. **Clone**: `git clone https://github.com/huynhsontung/Screenbox.git`
-3. **Build**: Open `Screenbox.sln` and build the solution (Ctrl+Shift+B)
+3. **Build**: Open `Screenbox.slnx` and build the solution (Ctrl+Shift+B)
 4. **Run**: Set platform to x64 and start debugging (F5)
 
 See the [Contributing Guide](CONTRIBUTING.md) for detailed setup instructions.

--- a/Screenbox.Core.Tests/README.md
+++ b/Screenbox.Core.Tests/README.md
@@ -40,18 +40,19 @@ This test project contains unit tests for `Screenbox.Core` focusing on SQL datab
 
 The test project relies strictly on the `x64`, `ARM64`, or `x86` build architectures to align with the Screenbox UWP environments. Standard `AnyCPU` configuration is intentionally overridden.
 
-### Using MSBuild / Visual Studio:
+### Using MSBuild / Visual Studio 2026 (18):
 ```cmd
 "C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe" Screenbox.Core.Tests\Screenbox.Core.Tests.csproj /p:Configuration=Release /p:Platform=x64 /restore
 ```
 
 ### Running Tests:
-```cmd
-vstest.console.exe Screenbox.Core.Tests\bin\x64\Release\*\Screenbox.Core.Tests.dll
+Using `dotnet run`:
+```pwsh
+dotnet run --project Screenbox.Core.Tests/Screenbox.Core.Tests.csproj
 ```
-Or via `.NET CLI` targeting the pre-built DLL (which is how GitHub Actions CI executes it):
+Or by running the built test executable directly:
 ```cmd
-dotnet test Screenbox.Core.Tests\bin\x64\Release\*\Screenbox.Core.Tests.dll
+Screenbox.Core.Tests\bin\x64\Release\net10.0-windows10.0.26100.0\Screenbox.Core.Tests.exe
 ```
 
 ---

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -36,7 +36,7 @@ The architecture is built around clean separation of concerns:
 The solution contains two main projects organized for clear separation of concerns:
 
 ```
-Screenbox.sln
+Screenbox.slnx
 ├── Screenbox/           # Main UWP application (UI layer)
 └── Screenbox.Core/      # Core business logic library
 ```
@@ -330,7 +330,7 @@ The following table summarizes the allowed dependency directions between layers:
 - **CommunityToolkit.Mvvm**: Modern MVVM framework with source generators and messaging
 
 ### Development and Build Tools  
-- **Visual Studio 2022**: Primary integrated development environment
+- **Visual Studio 2026**: Primary integrated development environment
 - **MSBuild**: Build system and project management
 - **XAML Styler**: XAML formatting and style enforcement
 


### PR DESCRIPTION
## Context & Motivation

Visual Studio has upgraded to version 2026 (18.x). In this codebase, UWP, CsWinRT, and WinUI project builds require MSBuild from Visual Studio 2026 rather than `dotnet build`. Additionally, unit testing with TUnit on .NET 10 is executed directly via `dotnet run`.

This PR updates all remaining references to Visual Studio 2022 across the repository to Visual Studio 2026, establishes strict build guidelines for AI agents, and adds a dedicated GitHub CLI workflow skill that enforces `--body-file` usage on Windows.

## Key Changes & Impact

- **Agent Instructions & Skills**:
  - Enforced Visual Studio 2026 MSBuild usage (forbidding `dotnet build`) across `.github/copilot-instructions.md`, `AGENTS.md`, and `.agents/skills/build-and-test/SKILL.md`.
  - Added MSBuild resolution logic via `vswhere` (`-version "[18.0,19.0)"`).
  - Switched automated test instructions to `dotnet run --project Screenbox.Core.Tests/Screenbox.Core.Tests.csproj`.
  - Added new `.agents/skills/github-workflow/SKILL.md` runbook establishing `--body-file` / `-F` requirement for Windows `gh` CLI operations.
- **Documentation & Solution References**:
  - Updated `README.md`, `CONTRIBUTING.md`, and `docs/PROJECT_STRUCTURE.md` prerequisites from Visual Studio 2022 to Visual Studio 2026.
  - Updated solution file references from `Screenbox.sln` to `Screenbox.slnx`.

## Testing & Verification

- ✅ Full solution restore (`Screenbox.slnx`) with Visual Studio 2026 MSBuild.
- ✅ Successful compilation of `Screenbox`, `Screenbox.Core`, and `Screenbox.Core.Tests` with Visual Studio 2026 MSBuild.
- ✅ Ran all 26 automated unit tests via `dotnet run --project Screenbox.Core.Tests/Screenbox.Core.Tests.csproj` (26 passed, 0 failed).
- ✅ Verified XAML formatting with `pwsh ./scripts/lint-xaml.ps1`.
- ✅ Confirmed zero remaining references to Visual Studio 2022 in the repository.
