### PR TITLE
fix: keep CultureInfo from falling out of sync with the app language

### DIFF
--- a/Screenbox/Extensions/AcceleratorService.cs
+++ b/Screenbox/Extensions/AcceleratorService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Screenbox.Helpers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -34,7 +33,7 @@ namespace Screenbox.Extensions;
 [Windows.Foundation.Metadata.ContractVersion(typeof(Windows.Foundation.UniversalApiContract), 327680u)]
 public sealed partial class AcceleratorService
 {
-    private static readonly bool _isHebrew = CultureInfo.CurrentCulture.TwoLetterISOLanguageName is "he";
+    private static readonly bool _isHebrew = GlobalizationHelper.CurrentAppCulture.TwoLetterISOLanguageName is "he";
 
     /// <summary>
     /// Identifies the AcceleratorService.ToolTip XAML attached property.

--- a/Screenbox/Helpers/GlobalizationHelper.cs
+++ b/Screenbox/Helpers/GlobalizationHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Windows.Globalization;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 
@@ -10,11 +11,17 @@ namespace Screenbox.Helpers;
 public static class GlobalizationHelper
 {
     /// <summary>
+    /// Gets the effective culture for the current application language.
+    /// </summary>
+    /// <value>The <see cref="CultureInfo"/> representing the current application culture.</value>
+    public static readonly CultureInfo CurrentAppCulture = GetCurrentAppCulture();
+
+    /// <summary>
     /// Gets a value that indicates whether the text direction for the current language
     /// is right-to-left.
     /// </summary>
     /// <value><see langword="true"/> if the text direction is right-to-left; otherwise, <see langword="false"/>.</value>
-    public static readonly bool IsRightToLeftLanguage = CultureInfo.CurrentCulture.TextInfo.IsRightToLeft;
+    public static readonly bool IsRightToLeftLanguage = CurrentAppCulture.TextInfo.IsRightToLeft;
 
     /// <summary>
     /// Gets the <see cref="FlowDirection"/> for the current application language.
@@ -56,5 +63,22 @@ public static class GlobalizationHelper
             FlyoutPlacementMode.RightEdgeAlignedBottom => FlyoutPlacementMode.LeftEdgeAlignedBottom,
             _ => placement,
         };
+    }
+
+    private static CultureInfo GetCurrentAppCulture()
+    {
+        string? primaryLanguage = ApplicationLanguages.PrimaryLanguageOverride;
+
+        if (string.IsNullOrEmpty(primaryLanguage))
+            return CultureInfo.CurrentCulture;
+
+        try
+        {
+            return new CultureInfo(primaryLanguage);
+        }
+        catch (CultureNotFoundException)
+        {
+            return CultureInfo.CurrentCulture;
+        }
     }
 }


### PR DESCRIPTION
In .NET Native, `CultureInfo` correctly reflected the application's language override, but in .NET 10 AOT it always returns the system culture instead. This can cause layout issues in certain conditions.