### PR TITLE
fix: CultureInfo.CurrentCulture doesn't respect language override

### DIFF
--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -47,7 +47,7 @@ sealed partial class App : Application
         _ = InitializeSentrySdk();
         UnhandledException += App_UnhandledException;
         CoreApplication.UnhandledErrorDetected += CoreApplication_UnhandledErrorDetected;
-        SyncCurrentCultureWithAppLanguage();
+        GlobalizationHelper.SyncCurrentCultureWithAppLanguage();
 
         InitializeComponent();
 
@@ -172,21 +172,6 @@ sealed partial class App : Application
         ));
 
         return services.BuildServiceProvider();
-    }
-
-    private static void SyncCurrentCultureWithAppLanguage()
-    {
-        string languageOverride = Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride;
-        if (!string.IsNullOrWhiteSpace(languageOverride))
-        {
-            var culture = new System.Globalization.CultureInfo(languageOverride);
-
-            // Sync all threads to the override language
-            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
-            System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
-            System.Globalization.CultureInfo.DefaultThreadCurrentCulture = culture;
-            System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = culture;
-        }
     }
 
     private static IDisposable InitializeSentrySdk()

--- a/Screenbox/App.xaml.cs
+++ b/Screenbox/App.xaml.cs
@@ -47,6 +47,7 @@ sealed partial class App : Application
         _ = InitializeSentrySdk();
         UnhandledException += App_UnhandledException;
         CoreApplication.UnhandledErrorDetected += CoreApplication_UnhandledErrorDetected;
+        SyncCurrentCultureWithAppLanguage();
 
         InitializeComponent();
 
@@ -171,6 +172,21 @@ sealed partial class App : Application
         ));
 
         return services.BuildServiceProvider();
+    }
+
+    private static void SyncCurrentCultureWithAppLanguage()
+    {
+        string languageOverride = Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride;
+        if (!string.IsNullOrWhiteSpace(languageOverride))
+        {
+            var culture = new System.Globalization.CultureInfo(languageOverride);
+
+            // Sync all threads to the override language
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
+            System.Globalization.CultureInfo.DefaultThreadCurrentCulture = culture;
+            System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = culture;
+        }
     }
 
     private static IDisposable InitializeSentrySdk()

--- a/Screenbox/Helpers/GlobalizationHelper.cs
+++ b/Screenbox/Helpers/GlobalizationHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Windows.Globalization;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 
@@ -14,7 +15,26 @@ public static class GlobalizationHelper
     /// is right-to-left.
     /// </summary>
     /// <value><see langword="true"/> if the text direction is right-to-left; otherwise, <see langword="false"/>.</value>
-    public static readonly bool IsRightToLeftLanguage = CultureInfo.CurrentCulture.TextInfo.IsRightToLeft;
+    public static bool IsRightToLeftLanguage { get; private set; } = CultureInfo.CurrentCulture.TextInfo.IsRightToLeft;
+
+    /// <summary>
+    /// Synchronizes the current culture with the application's language override.
+    /// </summary>
+    public static void SyncCurrentCultureWithAppLanguage()
+    {
+        string languageOverride = ApplicationLanguages.PrimaryLanguageOverride;
+        if (!string.IsNullOrWhiteSpace(languageOverride))
+        {
+            var culture = new CultureInfo(languageOverride);
+
+            // Sync all threads to the override language
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+            System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
+            IsRightToLeftLanguage = culture.TextInfo.IsRightToLeft;
+        }
+    }
 
     /// <summary>
     /// Gets the <see cref="FlowDirection"/> for the current application language.


### PR DESCRIPTION
NAOT no longer syncs the application language override `ApplicationLanguages.PrimaryLanguageOverride` with `CultureInfo.CurrentCulture` as .NET Native does. CurrentCulture now always return the system culture info. Thus, we need to set CurrentCulture at app launch to match the app language.