### PR TITLE
fix: shuffle button in playlist details page

### DIFF
--- a/Screenbox/Pages/PlaylistDetailsPage.xaml
+++ b/Screenbox/Pages/PlaylistDetailsPage.xaml
@@ -213,6 +213,7 @@
                             <AppBarButton
                                 AccessKey="{x:Bind strings:KeyboardResources.CommandShuffleAndPlayKey}"
                                 Command="{x:Bind ViewModel.ShuffleAndPlayCommand}"
+                                CommandParameter="{x:Bind ViewModel.Source, Mode=OneWay}"
                                 Icon="{ui:FontIcon FontFamily={StaticResource ScreenboxSymbolThemeFontFamily},
                                                    Glyph={StaticResource ShuffleGlyph},
                                                    MirroredWhenRightToLeft=True}"


### PR DESCRIPTION
The **ShuffleAndPlay** command expected a `PlaylistViewModel` parameter, but the XAML button didn't provide the required binding, leaving the command always disabled.