### PR TITLE
chore: remove unnecessary resource lookup enum

### DIFF
--- a/Screenbox.Core/Common/ResourceLookupType.cs
+++ b/Screenbox.Core/Common/ResourceLookupType.cs
@@ -1,9 +1,0 @@
-namespace Screenbox.Core;
-
-public enum StringLookupType
-{
-    None,
-    GoToPosition,
-    FrameSavedNotificationTitle,
-    ResumePositionNotificationTitle
-}


### PR DESCRIPTION
Not even sure it was ever used, which might explain why it managed to slip through multiple refactors when view models (that used localized resources) were being moved around.