### PR TITLE
feat: add current media to playlists via player context menu

### DIFF
--- a/Screenbox/Controls/PlayerControls.xaml
+++ b/Screenbox/Controls/PlayerControls.xaml
@@ -120,6 +120,11 @@
             </Flyout>
 
             <MenuFlyout x:Key="NormalPlayerContextMenu">
+                <interactivity:Interaction.Behaviors>
+                    <behaviors:AddToPlaylistFlyoutBehavior
+                        DataContext="{x:Bind ViewModel.PlayQueue.CurrentItem, Mode=OneWay}"
+                        TargetSubItem="{x:Bind AddToPlaylistSubMenu}" />
+                </interactivity:Interaction.Behaviors>
                 <MenuFlyoutItem
                     AccessKey="{x:Bind strings:KeyboardResources.MenuItemFileKey}"
                     Command="{x:Bind Common.OpenFilesCommand}"
@@ -139,6 +144,16 @@
                     IsEnabled="{x:Bind ViewModel.HasActiveItem, Mode=OneWay}"
                     Text="{x:Bind strings:Resources.OpenWith}" />
                 <MenuFlyoutSeparator />
+                <MenuFlyoutSubItem
+                    x:Name="AddToPlaylistSubMenu"
+                    IsEnabled="{x:Bind ViewModel.HasActiveItem, Mode=OneWay}"
+                    Text="{x:Bind strings:Resources.AddToPlaylist}">
+                    <MenuFlyoutSubItem.Icon>
+                        <FontIcon
+                            FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
+                            Glyph="{StaticResource PlaylistAddGlyph}" />
+                    </MenuFlyoutSubItem.Icon>
+                </MenuFlyoutSubItem>
                 <MenuFlyoutItem
                     Command="{StaticResource OpenInFileExplorerCommand}"
                     CommandParameter="{x:Bind ViewModel.PlayQueue.CurrentItem, Mode=OneWay}"


### PR DESCRIPTION
## Summary

This PR adds an **"Add to playlist"** option to the media player's existing `...` menu and right-click context menu.

This addresses #1036 by making it possible to add the currently playing media directly to an existing playlist, or create a new playlist, without navigating away from the player.

Closes #1036

## What changed

The change is intentionally small and reuses Screenbox's existing playlist infrastructure.

The following was added to the player's existing `NormalPlayerContextMenu`:

* An **Add to playlist** submenu
* The existing `PlaylistAddGlyph` icon
* The existing localized `AddToPlaylist` resource
* The existing `AddToPlaylistFlyoutBehavior`
* The currently playing item, `ViewModel.PlayQueue.CurrentItem`, as the media item to add

Because the player `...` button and the video surface right-click action already share the same `NormalPlayerContextMenu`, this single change makes the feature available from both entry points.

## Implementation details

Screenbox already has an `AddToPlaylistFlyoutBehavior` that is used in several other parts of the application.

That behavior already handles:

* Loading the current list of playlists
* Adding one or more media items to an existing playlist
* Creating a new playlist
* Adding the selected media to the newly created playlist
* Calling the existing playlist commands
* Showing the existing playlist-added notification
* Persisting playlist changes through the existing playlist implementation

Instead of introducing another command or duplicating playlist logic in `PlayerControls`, this PR attaches the existing behavior to the player's context menu.

The behavior receives:

```xml
DataContext="{x:Bind ViewModel.PlayQueue.CurrentItem, Mode=OneWay}"
```

This means the playlist submenu operates on the currently active media item.

The menu entry follows the same pattern already used elsewhere in Screenbox:

```xml
<MenuFlyoutSubItem
    x:Name="AddToPlaylistSubMenu"
    IsEnabled="{x:Bind ViewModel.HasActiveItem, Mode=OneWay}"
    Text="{x:Bind strings:Resources.AddToPlaylist}">
    <MenuFlyoutSubItem.Icon>
        <FontIcon
            FontFamily="{StaticResource ScreenboxSymbolThemeFontFamily}"
            Glyph="{StaticResource PlaylistAddGlyph}" />
    </MenuFlyoutSubItem.Icon>
</MenuFlyoutSubItem>
```

and the existing behavior populates the submenu when the flyout is opened.

## Why this approach

I chose this implementation to keep the change consistent with the existing Screenbox architecture.

It does **not** introduce:

* A new ViewModel
* A new command
* A new service
* New playlist persistence logic
* A new dialog
* New localization strings
* A new icon
* A new dependency

The existing playlist behavior already provides all of the required functionality, so reusing it keeps the implementation small and avoids maintaining duplicate playlist logic.

## User experience

When media is currently playing, the user can now:

1. Open the player's `...` menu, or right-click the video/player area.
2. Select **Add to playlist**.
3. Choose an existing playlist.

The submenu also retains the existing **Create new playlist** option provided by `AddToPlaylistFlyoutBehavior`.

If there is no active media item, the **Add to playlist** entry is disabled.

## Scope

This PR implements the primary request from #1036:

* [x] Add **Add to playlist** to the player's `...` menu
* [x] Make the same option available through the player right-click menu
* [x] Support adding to an existing playlist
* [x] Support creating a new playlist using the existing flow
* [x] Reuse existing Screenbox playlist behavior and UI resources

The optional dedicated player-button and keyboard-shortcut suggestions from the issue are not included in this PR in order to keep the implementation focused and minimal.

## Files changed

Only one file is modified:

```text
Screenbox/Controls/PlayerControls.xaml
```

## Testing

Verified the following at the code/XAML level:

* The implementation uses the existing `AddToPlaylistFlyoutBehavior`
* The currently playing media is passed to the behavior
* Existing playlist commands are reused
* Existing localization resources are reused
* Existing `PlaylistAddGlyph` is reused
* The menu item is disabled when there is no active media
* The same `NormalPlayerContextMenu` is used by both the player `...` menu and the video context menu
* No new dependencies or persistence logic were introduced
* The modified XAML is structurally valid

### Manual test cases

The following scenarios should be verified in the application:

* Play a local media file and add it to an existing playlist from the `...` menu
* Right-click the player and add the current media to an existing playlist
* Create a new playlist from the **Add to playlist** submenu
* Verify the newly created playlist contains the current media
* Verify the playlist-added notification appears
* Verify the playlist remains updated after restarting the application
* Verify the menu correctly reflects newly created playlists when reopened
* Verify **Add to playlist** is disabled when no media item is active

## Screenshots

### Player `...` menu

*Add screenshot here showing the new "Add to playlist" option.*

### Add to playlist submenu

*Add screenshot here showing existing playlists and "Create new playlist".*

## Related issue

Closes #1036
