### PR TITLE
fix: add to playlist button in selection bar control

### DIFF
--- a/Screenbox/Behaviors/AddToPlaylistFlyoutBehavior.cs
+++ b/Screenbox/Behaviors/AddToPlaylistFlyoutBehavior.cs
@@ -101,6 +101,7 @@ internal sealed partial class AddToPlaylistFlyoutBehavior : Behavior<MenuFlyout>
         {
             StorageItemViewModel { Media: { } media } => [media],
             MediaViewModel vm => [vm],
+            SelectionViewModel selection => selection.GetSelectedItems<MediaViewModel>().ToArray(),
             IReadOnlyList<MediaViewModel> list => list.ToArray(),
             IEnumerable<MediaViewModel> collection => collection.ToArray(),
             IEnumerable<object> objects => objects.OfType<MediaViewModel>().ToArray(),

--- a/Screenbox/Controls/PlayQueueControl.xaml
+++ b/Screenbox/Controls/PlayQueueControl.xaml
@@ -231,6 +231,7 @@
                 CheckBoxIsChecked="{x:Bind ViewModel.Selection.IsAllSelected, Mode=OneWay}"
                 CheckBoxText="{x:Bind strings:Resources.ItemsSelected(ViewModel.Selection.SelectedCount), Mode=OneWay}"
                 CloseButtonCommand="{x:Bind ViewModel.Selection.DisableSelectionModeCommand}"
+                CommandParameter="{x:Bind ViewModel.Selection}"
                 IsAddToQueueButtonVisible="False"
                 IsPlayButtonVisible="False"
                 PlayNextButtonCommand="{x:Bind ViewModel.PlaySelectedNextCommand}"

--- a/Screenbox/Pages/HomePage.xaml
+++ b/Screenbox/Pages/HomePage.xaml
@@ -226,6 +226,7 @@
                 CheckBoxIsChecked="{x:Bind ViewModel.Selection.IsAllSelected, Mode=OneWay}"
                 CheckBoxText="{x:Bind strings:Resources.ItemsSelected(ViewModel.Selection.SelectedCount), Mode=OneWay}"
                 CloseButtonCommand="{x:Bind ViewModel.Selection.DisableSelectionModeCommand}"
+                CommandParameter="{x:Bind ViewModel.Selection}"
                 PlayButtonCommand="{x:Bind ViewModel.PlaySelectedCommand}"
                 PlayNextButtonCommand="{x:Bind ViewModel.PlaySelectedNextCommand}"
                 RemoveButtonCommand="{x:Bind ViewModel.RemoveSelectedCommand}"


### PR DESCRIPTION
Fixes a regression introduced in #1007, where removing the `CommandParameter` from the usages of `SelectionBarControl` caused the `AddToPlaylistButton` to stop passing its context to the `AddToPlaylistFlyoutBehavior`.

We should probably rename the `SelectionBarControl.CommandParameter` property, as it no longer serves as a command parameter in the places where the control is used.